### PR TITLE
fix/parsec: don't expect meta-votes to be set

### DIFF
--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -459,13 +459,14 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
     }
 
     fn update_round_hashes(&mut self, event_hash: &Hash) -> Result<(), Error> {
-        let meta_votes = self.meta_votes.get(event_hash).ok_or(Error::Logic)?;
-        for (peer_id, event_votes) in meta_votes.iter() {
-            for meta_vote in event_votes {
-                if let Some(hashes) = self.round_hashes.get_mut(&peer_id) {
-                    while hashes.len() < meta_vote.round + 1 {
-                        let next_round_hash = hashes[hashes.len() - 1].increment_round()?;
-                        hashes.push(next_round_hash);
+        if let Some(meta_votes) = self.meta_votes.get(event_hash) {
+            for (peer_id, event_votes) in meta_votes.iter() {
+                for meta_vote in event_votes {
+                    if let Some(hashes) = self.round_hashes.get_mut(&peer_id) {
+                        while hashes.len() < meta_vote.round + 1 {
+                            let next_round_hash = hashes[hashes.len() - 1].increment_round()?;
+                            hashes.push(next_round_hash);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
In update_round_hashes, we can't expect for the meta-votes to always be
set as the function: set_meta_votes can sometimes fail to set them (for
instance before any observation happen)