### PR TITLE
fix/parsec: enable minimal_network

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -46,7 +46,6 @@ use self::utils::{Environment, PeerCount, TransactionCount};
 use rand::Rng;
 use std::collections::BTreeSet;
 
-#[ignore]
 #[test]
 fn minimal_network() {
     // 4 is the minimal network size for which the super majority is less than it.


### PR DESCRIPTION
In its current state, our code passes this test. Enable it so we can
catch any regression while investigating the other tests.