### PR TITLE
fix/parsec.git: update all meta_votes

### DIFF
--- a/src/meta_vote.rs
+++ b/src/meta_vote.rs
@@ -114,13 +114,17 @@ impl MetaVote {
         coin_tosses: &BTreeMap<usize, bool>,
         total_peers: usize,
     ) -> Vec<Self> {
-        let mut next = parent
-            .iter()
-            .map(|meta_vote| {
-                let counts = MetaVoteCounts::new(meta_vote, others, total_peers);
-                Self::update_meta_vote(meta_vote, counts, &coin_tosses)
-            })
-            .collect::<Vec<_>>();
+        let mut next = Vec::new();
+        for vote in parent {
+            let counts = MetaVoteCounts::new(vote, others, total_peers);
+            let updated = Self::update_meta_vote(vote, counts, &coin_tosses);
+            let decided = updated.decision.is_some();
+            next.push(updated);
+            if decided {
+                break;
+            }
+        }
+
         while let Some(next_meta_vote) =
             Self::next_meta_vote(next.last(), others, &coin_tosses, total_peers)
         {

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -644,7 +644,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
     }
 
     // Returns the set of meta votes held by all peers other than the creator of `event` which are
-    // votes by `peer_id` since the given `round` and `step`.
+    // votes by `peer_id`.
     fn collect_other_meta_votes(
         &self,
         peer_id: &S::PublicId,


### PR DESCRIPTION
When update meta_votes of a peer due to received new events, the
new updated meta_votes shall be taken into account as well.