### PR TITLE
MAID-2864: fix/parsec: fix receeding consensus

### DIFF
--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -29,9 +29,8 @@ pub(crate) struct Event<T: NetworkEvent, P: PublicId> {
     pub last_ancestors: BTreeMap<P, u64>,
     // Index of each peer's earliest event that is a descendant of this event.
     pub first_descendants: BTreeMap<P, u64>,
-    // The hashes of the oldest events by each peer which comprise not-yet-stable blocks this event can see,
-    // along with the largest payload of all blocks made valid by that event.
-    pub valid_blocks_carried: BTreeMap<P, (Hash, T)>,
+    // Payloads of all the blocks made valid by this event
+    pub valid_blocks_carried: BTreeSet<T>,
     // The set of peers for which this event can strongly-see an event by that peer which carries a
     // valid block.  If there are a supermajority of peers here, this event is an "observer".
     pub observations: BTreeSet<P>,
@@ -93,7 +92,7 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
             index: None,
             last_ancestors: BTreeMap::default(),
             first_descendants: BTreeMap::default(),
-            valid_blocks_carried: BTreeMap::default(),
+            valid_blocks_carried: BTreeSet::default(),
             observations: BTreeSet::default(),
         })
     }
@@ -167,7 +166,7 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
             index: None,
             last_ancestors: BTreeMap::default(),
             first_descendants: BTreeMap::default(),
-            valid_blocks_carried: BTreeMap::default(),
+            valid_blocks_carried: BTreeSet::default(),
             observations: BTreeSet::default(),
         })
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -166,7 +166,7 @@ fn faulty_third_never_gossip() {
     }
 
     // Gossip to let all remaining peers reach consensus on all the blocks.
-    utils::loop_with_max_iterations(200, || {
+    utils::loop_with_max_iterations(100, || {
         env.network.send_random_syncs(&mut env.rng);
         for peer in &mut env.network.peers {
             peer.poll();
@@ -200,7 +200,7 @@ fn faulty_third_terminate_concurrently() {
     }
 
     // While gossiping, at a single random point remove all faulty peers in one go.
-    utils::loop_with_max_iterations(200, || {
+    utils::loop_with_max_iterations(100, || {
         env.network.send_random_syncs(&mut env.rng);
         for peer in &mut env.network.peers {
             peer.poll();
@@ -248,7 +248,7 @@ fn faulty_third_terminate_at_random_points() {
 
     // While gossiping, at random points remove a single faulty peer, up to a maximum of
     // `num_faulty` peers removed in total.
-    utils::loop_with_max_iterations(200, || {
+    utils::loop_with_max_iterations(100, || {
         env.network.send_random_syncs(&mut env.rng);
         for peer in &mut env.network.peers {
             peer.poll();

--- a/tests/utils/network.rs
+++ b/tests/utils/network.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use parsec::mock::{self, PeerId};
+use parsec::mock::{self, PeerId, Transaction};
 use rand::Rng;
 use std::collections::BTreeSet;
 use utils::Peer;
@@ -42,7 +42,38 @@ impl Network {
                     .filter(|&id| id != sender_id)
                     .nth(rng.gen_range(0, peer_ids.len() - 1))
             );
-            self.exchange_messages(sender_id, receiver_id);
+            self.exchange_messages(sender_id, receiver_id, None);
+        }
+    }
+
+    pub fn interleave_syncs_and_votes<R: Rng>(
+        &mut self,
+        rng: &mut R,
+        transactions: &mut [Transaction],
+    ) {
+        let peer_ids = self
+            .peers
+            .iter()
+            .map(|peer| peer.id.clone())
+            .collect::<Vec<_>>();
+        for sender_id in &peer_ids {
+            let receiver_id = unwrap!(
+                peer_ids
+                    .iter()
+                    .filter(|&id| id != sender_id)
+                    .nth(rng.gen_range(0, peer_ids.len() - 1))
+            );
+            rng.shuffle(transactions);
+            if rng.gen_weighted_bool(10) {
+                self.peer_mut(sender_id)
+                    .vote_for_first_not_already_voted_for(&transactions);
+            }
+            let opt_transactions = if rng.gen_weighted_bool(10) {
+                Some(&*transactions)
+            } else {
+                None
+            };
+            self.exchange_messages(sender_id, receiver_id, opt_transactions);
         }
     }
 
@@ -62,7 +93,12 @@ impl Network {
         unwrap!(self.peers.iter_mut().find(|peer| peer.id == *id))
     }
 
-    fn exchange_messages(&mut self, sender_id: &PeerId, receiver_id: &PeerId) {
+    fn exchange_messages(
+        &mut self,
+        sender_id: &PeerId,
+        receiver_id: &PeerId,
+        transactions: Option<&[Transaction]>,
+    ) {
         let request = unwrap!(
             self.peer(sender_id)
                 .parsec
@@ -74,6 +110,11 @@ impl Network {
                 .parsec
                 .handle_request(sender_id, request)
         );
+
+        if let Some(transactns) = transactions {
+            self.peer_mut(sender_id)
+                .vote_for_first_not_already_voted_for(transactns);
+        }
 
         unwrap!(
             self.peer_mut(sender_id)

--- a/tests/utils/peer.rs
+++ b/tests/utils/peer.rs
@@ -27,6 +27,15 @@ impl Peer {
         }
     }
 
+    pub fn vote_for_first_not_already_voted_for(&mut self, transactions: &[Transaction]) {
+        for transaction in transactions {
+            if !self.parsec.have_voted_for(transaction) {
+                unwrap!(self.parsec.vote_for(transaction.clone()));
+                break;
+            }
+        }
+    }
+
     pub fn poll(&mut self) {
         while let Some(block) = self.parsec.poll() {
             self.blocks.push(block)
@@ -34,12 +43,8 @@ impl Peer {
     }
 
     // Returns the payloads of `self.blocks` in the order in which they were returned by `poll()`.
-    pub fn blocks_payloads(&self) -> Vec<Transaction> {
-        self.blocks
-            .iter()
-            .map(Block::payload)
-            .cloned()
-            .collect::<Vec<_>>()
+    pub fn blocks_payloads(&self) -> Vec<&Transaction> {
+        self.blocks.iter().map(Block::payload).collect()
     }
 }
 


### PR DESCRIPTION
The valid blocks carried don't get recalculated on old gossip events
when clearing the consensus data, which causes consensus to occur later
and later as old events aren't ever again considered as interesting
events.