### PR TITLE
MAID-2919: fix/parsec: allow more iterations for one test

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -103,7 +103,7 @@ fn multiple_votes_during_gossip() {
     let mut env = Environment::new(&PeerCount(4), &TransactionCount(num_transactions), None);
 
     // Every peer gossips while occasionally casting a vote for a randomly-chosen transaction.
-    utils::loop_with_max_iterations(100, || {
+    utils::loop_with_max_iterations(200, || {
         env.network
             .interleave_syncs_and_votes(&mut env.rng, &mut env.transactions);
         for peer in &mut env.network.peers {


### PR DESCRIPTION
During soak testing, we found that this test exceeded 100 iterations
every few thousand runs.
Relax the max number of iterations slightly to make that failure much
more unlikely and improve tests reliability.