### PR TITLE
feat/parsec: try to generate SVG files from dot files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,7 @@ There is a basic example available in the examples folder.  This allows you to s
 cargo run --example=basic --features=dump-graphs -- --peers=5 --events=10
 ```
 
-To generate SVG graphs from the resulting dot files:
-
-```
-dot -Tsvg *.dot -O
-```
+If you have `dot` from [graphviz](https://graphviz.gitlab.io/download) available in your path, then SVG graphs will also have been generated from each of these dot files.  If not, you can copy the contents of a generated dot file into an online converter (e.g. http://viz-js.com) to view the gossip graph.
 
 ## Detailed tutorial
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -143,7 +143,10 @@ fn get_params() -> Params {
             "This example creates a mock network of peers, each running the Parsec protocol to \
              reach consensus on a number of random network events.  To dump each node's gossip \
              graph in dot format to a file in your system temp dir, build the example with \
-             `--features=dump-graphs`.",
+             `--features=dump-graphs`.  If you have `dot` (from graphviz) available in your path, \
+             each dot file will have a corresponding SVG file created for it.  Otherwise you can \
+             copy the contents of a generated dot file into an online converter (e.g. \
+             http://viz-js.com) to view the gossip graph.",
         )
         .set_term_width(100)
         .arg(

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,7 +1,7 @@
 # Prerequisites
 To clone the repo, `git` must be installed.
 To compile the code and run the tests, `cargo` is required.
-To generate graphs from generated dot files, `graphviz` is necessary.
+To optionally generate graphs from generated dot files, `graphviz` is necessary. If you prefer, you can use an online converter (e.g. http://viz-js.com) to view the gossip graphs rather than installing graphviz.
 
 To install [graphviz](https://graphviz.gitlab.io/download/) on Ubuntu,
 ```
@@ -29,21 +29,20 @@ From the parsec repository, run the tests. Be sure to use the feature: `dump-gra
 ```
 cd parsec
 cargo test --release --features=dump-graphs -- --nocapture
-
 ```
 
-# Generate images from the generated dot files
+# View the graphs
 
 The output must contain lines analogous to these:
 
 ```
-Writing dot files in "/tmp/parsec_graphs/53srr3/test_minimal_network"
-Writing dot files in "/tmp/parsec_graphs/53srr3/test_multiple_votes_before_gossip"
-Writing dot files in "/tmp/parsec_graphs/53srr3/test_faulty_third_terminate_concurrently"
-Writing dot files in "/tmp/parsec_graphs/53srr3/test_duplicate_votes_before_gossip"
-Writing dot files in "/tmp/parsec_graphs/53srr3/test_faulty_third_never_gossip"
-Writing dot files in "/tmp/parsec_graphs/53srr3/test_faulty_third_terminate_at_random_points"
-Writing dot files in "/tmp/parsec_graphs/53srr3/test_multiple_votes_during_gossip"
+Writing dot files in /tmp/parsec_graphs/53srr3/test_minimal_network
+Writing dot files in /tmp/parsec_graphs/53srr3/test_multiple_votes_before_gossip
+Writing dot files in /tmp/parsec_graphs/53srr3/test_faulty_third_terminate_concurrently
+Writing dot files in /tmp/parsec_graphs/53srr3/test_duplicate_votes_before_gossip
+Writing dot files in /tmp/parsec_graphs/53srr3/test_faulty_third_never_gossip
+Writing dot files in /tmp/parsec_graphs/53srr3/test_faulty_third_terminate_at_random_points
+Writing dot files in /tmp/parsec_graphs/53srr3/test_multiple_votes_during_gossip
 ```
 
 Go to one of the directories listed above:
@@ -51,7 +50,7 @@ Go to one of the directories listed above:
 cd /tmp/parsec_graphs/53srr3/test_minimal_network
 ```
 
-This particular example consists of 4 nodes reaching consensus on the order of one single event. It is quite trivial. This is why the directory contains only 4 files:
+This particular example consists of four nodes reaching consensus on the order of one single event. It is quite trivial. This is why the directory contains only four dot files:
 ```
 .
 ├── Alice-001.dot
@@ -60,20 +59,25 @@ This particular example consists of 4 nodes reaching consensus on the order of o
 └── Dave-001.dot
 ```
 
-These are `dot` representations of the files. You may read them with a text editor to get a feel for the syntax.
+These are `dot` representations of the gossip graphs. You may read them with a text editor to get a feel for the syntax.
 
-From these dot representations, images may be generated using graphviz.
-Let's generate some vector graphic images.
+From these dot representations, images may be generated using graphviz. If you already had `dot` from graphviz available on your path, the test will have generated one SVG image of the gossip graph per dot file:
 ```
-dot -T svg ./*.dot -O
+.
+├── Alice-001.dot.svg
+├── Bob-001.dot.svg
+├── Carol-001.dot.svg
+└── Dave-001.dot.svg
+```
+
+You can open these SVG files in your favourite web browser to view them.
+
+If these SVG files don't already exist, you can either copy a dot file's contents into an online converter (e.g. http://viz-js.com) to view the gossip graph, or you can install graphviz (as detailed above) and then run:
+```
+dot -Tsvg Alice-001.dot -O
 ```
 
 # Explore
-
-Now, let's open all these images with your favourite web browser:
-```
-firefox *.svg
-```
 
 These graphs demonstrate how each node reaches a conclusion, based on each node casting a single vote (highlighted in cyan blue). The gossip events that make that vote valid are highlighted in crimson red. The gossip events that contain special values for estimates, bin values, auxiliary values and decisions are labelled with the information needed to understand the decision process.
 
@@ -81,8 +85,7 @@ Now, `test_minimal_network` is a silly example as reaching consensus on a single
 
 # Play around
 
-For more control over the scenario, please run the example.
-To see which options you may use, run
+For more control over the scenario, please run the example. To see which options you may use, run
 ```
 cargo run --release --example basic --features=dump-graphs -- --help
 ```
@@ -91,4 +94,3 @@ For instance, for an example with 10 peers agreeing on the order of 5 events, ru
 ```
 cargo run --release --example basic --features=dump-graphs -- -p10 -e5
 ```
-


### PR DESCRIPTION
As well as automatically creating SVGs, this also makes the instructions somewhat more Windows-friendly:
  * Paths are printed in a way that is more useful for copy-pasting in a Windows console.
  * Instructions now avoid use of `*.dot` which fails on Windows.
  * Instructions now avoid expectation that Firefox is in the path as this is unusual on Windows.