### PR TITLE
Add foreign function interface for PARSEC [MAID-2942, MAID-2955]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,20 +10,27 @@ repository = "https://github.com/maidsafe/parsec"
 version = "0.5.0"
 
 [dependencies]
-lazy_static = { version = "~1.0.1", optional = true }
-log = "~0.3.8"
+ffi_utils = "~0.8.0"
+lazy_static = "~1.0.1"
+log = "~0.4.1"
 maidsafe_utilities = "~0.17.0"
 quick-error = "~1.2.2"
 rand = "~0.4.2"
 serde = "~1.0.66"
 serde_derive = "~1.0.66"
 tiny-keccak = "~1.4.2"
+unwrap = "~1.2.0"
+
+[target.'cfg(target_os="linux")'.dependencies]
+procinfo = "~0.4.2"
 
 [dev-dependencies]
 clap = "~2.31.2"
 proptest = "~0.8.6"
-unwrap = "~1.2.0"
 
 [features]
-dump-graphs = ["lazy_static"]
+dump-graphs = []
 testing = ["maidsafe_utilities/testing"]
+
+[lib]
+crate_type = ["staticlib", "rlib", "cdylib"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use ffi_utils::ErrorCode;
+
 quick_error! {
     /// Parsec error variants.
     #[derive(Debug)]
@@ -24,6 +26,12 @@ quick_error! {
         Serialisation(error: ::maidsafe_utilities::serialisation::SerialisationError) {
             description(error.description())
             display("Serialisation error: {}", error)
+            from()
+        }
+        /// String Error.
+        String(error: ::ffi_utils::StringError) {
+            description("Error occurred while performing a String conversion.")
+            display("String error: {:?}", error)
             from()
         }
         /// Peer is not known to this node.
@@ -46,10 +54,64 @@ quick_error! {
             description("Duplicate vote")
             display("This node has already voted for this network event.")
         }
+        /// Utf8 Error.
+        Utf8(error: ::std::str::Utf8Error) {
+            description(error.description())
+            display("Utf8 error: {:?}", error)
+            from()
+        }
         /// Logic error.
         Logic {
             description("Logic error")
             display("This a logic error and represents a flaw in the code.")
         }
+        /// Unexpected error. Contains custom error message.
+        Unexpected(error: String) {
+            description("An unexpected error has occurred.")
+            display("Unexpected error: {}", error)
+        }
+    }
+}
+
+#[allow(missing_docs)]
+pub mod codes {
+    pub const ERR_MISMATCHED_PAYLOAD: i32 = -1;
+    pub const ERR_SIGNATURE_FAILURE: i32 = -2;
+    pub const ERR_SERIALISATION: i32 = -3;
+    pub const ERR_STRING: i32 = -4;
+    pub const ERR_UNKNOWN_PEER: i32 = -5;
+    pub const ERR_INVALID_EVENT: i32 = -6;
+    pub const ERR_UNKNOWN_PARENT: i32 = -7;
+    pub const ERR_DUPLICATE_VOTE: i32 = -8;
+    pub const ERR_UTF8: i32 = -9;
+
+    pub const ERR_LOGIC: i32 = -100;
+    pub const ERR_UNEXPECTED: i32 = -101;
+}
+
+impl ErrorCode for Error {
+    fn error_code(&self) -> i32 {
+        use error::codes::*;
+
+        match *self {
+            Error::MismatchedPayload => ERR_MISMATCHED_PAYLOAD,
+            Error::SignatureFailure => ERR_SIGNATURE_FAILURE,
+            Error::Serialisation(_) => ERR_SERIALISATION,
+            Error::String(_) => ERR_STRING,
+            Error::UnknownPeer => ERR_UNKNOWN_PEER,
+            Error::InvalidEvent => ERR_INVALID_EVENT,
+            Error::UnknownParent => ERR_UNKNOWN_PARENT,
+            Error::DuplicateVote => ERR_DUPLICATE_VOTE,
+            Error::Utf8(_) => ERR_UTF8,
+
+            Error::Logic => ERR_LOGIC,
+            Error::Unexpected(_) => ERR_UNEXPECTED,
+        }
+    }
+}
+
+impl<'a> From<&'a str> for Error {
+    fn from(s: &'a str) -> Self {
+        Error::Unexpected(s.to_string())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,7 +84,6 @@ pub mod codes {
     pub const ERR_UNKNOWN_PARENT: i32 = -7;
     pub const ERR_DUPLICATE_VOTE: i32 = -8;
     pub const ERR_UTF8: i32 = -9;
-
     pub const ERR_LOGIC: i32 = -100;
     pub const ERR_UNEXPECTED: i32 = -101;
 }
@@ -103,7 +102,6 @@ impl ErrorCode for Error {
             Error::UnknownParent => ERR_UNKNOWN_PARENT,
             Error::DuplicateVote => ERR_DUPLICATE_VOTE,
             Error::Utf8(_) => ERR_UTF8,
-
             Error::Logic => ERR_LOGIC,
             Error::Unexpected(_) => ERR_UNEXPECTED,
         }

--- a/src/ffi/block.rs
+++ b/src/ffi/block.rs
@@ -1,0 +1,270 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! Block FFI.
+
+use block::Block as NativeBlock;
+use error::Error;
+use ffi::utils;
+use ffi::{NetworkEvent, PeerId, Proof, ProofList, PublicId, Vote};
+use ffi_utils;
+use std::collections::BTreeMap;
+use std::slice;
+
+/// Serves as an opaque pointer to `Block` struct.
+///
+/// Should be deallocated with `block_free`.
+pub struct Block(pub(crate) NativeBlock<NetworkEvent, PeerId>);
+
+/// Create a new block from `payload` and the `public_ids` with their corresponding `votes`.
+/// `items_len` corresponds to a number of `votes` and `public_ids` which must be the same.
+///
+/// `o_block` must be freed using `block_free`.
+#[no_mangle]
+pub unsafe extern "C" fn block_new(
+    payload: *const u8,
+    payload_len: usize,
+    public_ids: *const *const PublicId,
+    votes: *const *const Vote,
+    items_len: usize,
+    o_block: *mut *const Block,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let payload = slice::from_raw_parts(payload, payload_len).to_vec();
+        let public_ids = slice::from_raw_parts(public_ids, items_len);
+        let votes = slice::from_raw_parts(votes, items_len);
+
+        let mut votes_map = BTreeMap::new();
+
+        public_ids.iter().zip(votes.iter()).for_each(|(id, vote)| {
+            let _ = votes_map.insert((**id).0.clone(), (**vote).0.clone());
+        });
+
+        let block = Block(NativeBlock::new(payload, &votes_map)?);
+        *o_block = Box::into_raw(Box::new(block));
+
+        Ok(())
+    })
+}
+
+/// Returns the Payload of this block.
+#[no_mangle]
+pub unsafe extern "C" fn block_payload(
+    block: *const Block,
+    o_payload: *mut *const u8,
+    o_payload_len: *mut usize,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let payload = (*block).0.payload();
+
+        *o_payload = payload.as_ptr();
+        *o_payload_len = payload.len();
+
+        Ok(())
+    })
+}
+
+/// Returns the Proofs of this block.
+///
+/// `o_proofs` must be freed using `proof_list_free`.
+#[no_mangle]
+pub unsafe extern "C" fn block_proofs(block: *const Block, o_proofs: *mut *const ProofList) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let proofs: Vec<_> = (*block)
+            .0
+            .proofs()
+            .iter()
+            .map(|proof| Box::into_raw(Box::new(Proof(proof.clone()))))
+            .collect();
+
+        let (ptr, len, cap) = ffi_utils::vec_into_raw_parts(proofs);
+        let proof_list = ProofList {
+            proofs: ptr as *const _,
+            proofs_len: len,
+            proofs_cap: cap,
+        };
+        *o_proofs = Box::into_raw(Box::new(proof_list));
+
+        Ok(())
+    })
+}
+
+/// Converts `vote` to a `Proof` and attempts to add it to the block. Returns an error if `vote` is
+/// invalid (i.e. signature check fails or the `vote` is for a different network event). Sets
+/// `o_new_proof` to 1 (true) if the `Proof` wasn't previously held in this `Block`, or 0 (false) if
+/// it was previously held.
+#[no_mangle]
+pub unsafe extern "C" fn block_add_vote(
+    block: *mut Block,
+    peer_id: *const PublicId,
+    vote: *const Vote,
+    o_new_proof: *mut u8,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        *o_new_proof = (*block).0.add_vote(&(*peer_id).0, &(*vote).0)? as u8;
+        Ok(())
+    })
+}
+
+/// Frees this block and its associated data.
+#[no_mangle]
+pub unsafe extern "C" fn block_free(block: *mut Block) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let _ = Box::from_raw(block);
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use ffi::*;
+    use mock;
+    use std::{mem, ptr, slice};
+
+    #[test]
+    fn ffi_block_new() {
+        utils::memory_check("ffi_block_new", 1000, || {
+            let payload = b"hello world";
+
+            unsafe {
+                let mut block = mem::zeroed();
+
+                assert_ffi!(block_new(
+                    payload.as_ptr(),
+                    payload.len(),
+                    ptr::null(),
+                    ptr::null(),
+                    0,
+                    &mut block,
+                ));
+
+                let payload_output = unwrap!(utils::get_vec_u8(|output, len| block_payload(
+                    block, output, len
+                )));
+
+                assert_eq!(payload_output.len(), payload.len());
+                assert_eq!(payload_output.as_slice(), &payload[..]);
+
+                assert_ffi!(block_free(block as *mut _));
+            }
+        })
+    }
+
+    #[test]
+    fn ffi_block_add_vote() {
+        utils::memory_check("ffi_block_add_vote", 100, || {
+            let ids_count = 4;
+            let ids = mock::create_ids(ids_count);
+
+            let payload = b"hello world";
+
+            unsafe {
+                let mut public_ids = Vec::with_capacity(ids_count);
+                let mut votes = Vec::with_capacity(ids_count);
+
+                // Set up public ids
+                for id in &ids {
+                    let id_bytes = id.as_bytes();
+                    public_ids.push(unwrap!(utils::get_1(|id| public_id_from_bytes(
+                        id_bytes.as_ptr(),
+                        id_bytes.len(),
+                        id
+                    ))));
+                }
+
+                // Set up secret ids
+                for id in &ids {
+                    let id_bytes = id.as_bytes();
+                    let secret_id = unwrap!(utils::get_1(|id| secret_id_from_bytes(
+                        id_bytes.as_ptr(),
+                        id_bytes.len(),
+                        id
+                    )));
+
+                    votes.push(unwrap!(utils::get_1(|vote| vote_new(
+                        secret_id,
+                        payload.as_ptr(),
+                        payload.len(),
+                        vote
+                    ))));
+
+                    assert_ffi!(secret_id_free(secret_id));
+                }
+
+                // Create a new block
+                let mut block = mem::zeroed();
+                assert_ffi!(block_new(
+                    payload.as_ptr(),
+                    payload.len(),
+                    public_ids.as_ptr(),
+                    votes.as_ptr(),
+                    ids_count - 1,
+                    &mut block,
+                ));
+
+                // Try to add new votes
+                let proof_not_held = unwrap!(utils::get_1(|proof| block_add_vote(
+                    block as *mut _,
+                    public_ids[ids_count - 2],
+                    votes[ids_count - 2],
+                    proof
+                )));
+                assert_eq!(proof_not_held, 0);
+
+                let proof_not_held = unwrap!(utils::get_1(|proof| block_add_vote(
+                    block as *mut _,
+                    public_ids[ids_count - 1],
+                    votes[ids_count - 1],
+                    proof
+                )));
+                assert_eq!(proof_not_held, 1);
+
+                // Get list of proofs
+                let proof_list = unwrap!(utils::get_1(|out| block_proofs(block, out)));
+                assert_eq!((*proof_list).proofs_len, ids_count);
+
+                let proofs = slice::from_raw_parts((*proof_list).proofs, (*proof_list).proofs_len);
+
+                // Check proofs
+                for (i, proof) in proofs.iter().enumerate() {
+                    let is_valid = unwrap!(utils::get_1(|out| proof_is_valid(
+                        *proof,
+                        payload.as_ptr(),
+                        payload.len(),
+                        out
+                    )));
+                    assert_eq!(is_valid, 1);
+
+                    let public_id = unwrap!(utils::get_1(|out| proof_public_id(*proof, out)));
+                    assert_eq!(
+                        unwrap!(utils::get_vec_u8(|out, len| public_id_as_bytes(
+                            public_id, out, len
+                        ))),
+                        unwrap!(utils::get_vec_u8(|out, len| public_id_as_bytes(
+                            public_ids[i],
+                            out,
+                            len
+                        ))),
+                    );
+
+                    unwrap!(utils::get_0(|| public_id_free(public_id)));
+                }
+
+                // Free memory
+                assert_ffi!(proof_list_free(proof_list));
+                for id in public_ids {
+                    assert_ffi!(public_id_free(id));
+                }
+                for vote in votes {
+                    assert_ffi!(vote_free(vote));
+                }
+                assert_ffi!(block_free(block as *mut _));
+            }
+        })
+    }
+}

--- a/src/ffi/error.rs
+++ b/src/ffi/error.rs
@@ -1,0 +1,115 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use ffi_utils::FfiResult;
+use std::cell::RefCell;
+use std::ffi::CString;
+use std::ptr;
+
+thread_local!{
+    static LAST_ERROR: RefCell<Option<FfiResult>> = RefCell::new(None);
+}
+
+/// Returns a pointer to the last error that occurred. This pointer will become invalid the next
+/// time an error occurs, so make sure to copy any needed data. This may return NULL if no error has
+/// occurred.
+#[no_mangle]
+pub unsafe extern "C" fn err_last() -> *const FfiResult {
+    LAST_ERROR.with(|last| match *last.borrow() {
+        Some(err) => &err,
+        None => ptr::null(),
+    })
+}
+
+/// Clears the last error.
+#[no_mangle]
+pub unsafe extern "C" fn err_clear() {
+    LAST_ERROR.with(|last| {
+        if let Some(err) = *last.borrow() {
+            // Drop the description string
+            let _ = CString::from_raw(err.description as *mut _);
+        }
+        *last.borrow_mut() = None;
+    });
+}
+
+/// Sets the error. For internal use.
+pub(crate) fn err_set(error_code: i32, description: CString) {
+    // Clear the last error.
+    if let Some(err) = err_take() {
+        // Drop the allocated data.
+        let _ = unsafe { CString::from_raw(err.description as *mut _) };
+    }
+
+    // Set the new error.
+    LAST_ERROR.with(|last| {
+        *last.borrow_mut() = Some(FfiResult {
+            error_code,
+            description: description.into_raw(),
+        });
+    });
+}
+
+// Retrieves the most recent error, clearing it in the process.
+fn err_take() -> Option<FfiResult> {
+    LAST_ERROR.with(|prev| prev.borrow_mut().take())
+}
+
+#[cfg(test)]
+mod tests {
+    use error;
+    use ffi::*;
+    use std::ffi::CStr;
+
+    #[test]
+    fn ffi_error_api() {
+        let bytes = &[192];
+
+        utils::memory_check("ffi_error", 100, || {
+            unsafe {
+                // No error has occurred yet, should be null.
+                assert!(err_last().is_null());
+
+                // Generate and get the last error code.
+                let err_code = match utils::get_1(|out| {
+                    public_id_from_bytes(bytes.as_ptr(), bytes.len(), out)
+                }) {
+                    Ok(_) => panic!("Expected error code."),
+                    Err(e) => e,
+                };
+                assert_eq!(err_code, error::codes::ERR_UTF8);
+
+                // Get the last full error.
+                let err = err_last();
+                assert_eq!((*err).error_code, err_code);
+                assert_eq!(
+                    unwrap!(CStr::from_ptr((*err).description).to_str()),
+                    "Utf8 error: Utf8Error { valid_up_to: 0, error_len: Some(1) }"
+                );
+
+                // Ensure the last error did not get cleared.
+                assert!(!err_last().is_null());
+
+                // Generate and get another error code.
+                let err_code = match utils::get_1(|out| {
+                    public_id_from_bytes(bytes.as_ptr(), bytes.len(), out)
+                }) {
+                    Ok(_) => panic!("Expected error code."),
+                    Err(e) => e,
+                };
+                assert_eq!(err_code, error::codes::ERR_UTF8);
+
+                // Clear the error.
+                err_clear();
+
+                // Ensure the last error got cleared.
+                assert!(err_last().is_null());
+            }
+        })
+    }
+}

--- a/src/ffi/id.rs
+++ b/src/ffi/id.rs
@@ -1,0 +1,212 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use error::Error;
+use ffi::utils;
+use id::Proof as NativeProof;
+use mock::PeerId;
+use std::{slice, str};
+
+/// Secret peer signing key.
+///
+/// Should be deallocated with `secret_id_free`.
+pub struct SecretId(pub(crate) PeerId);
+/// Public peer signing key.
+///
+/// Should be deallocated with `public_id_free`.
+pub struct PublicId(pub(crate) PeerId);
+
+/// Creates a public ID from raw bytes pointed by `id` with a size `id_len`.
+/// Returns the opaque pointer to `o_public_id`.
+///
+/// `o_public_id` must be freed using `public_id_free`.
+#[no_mangle]
+pub unsafe extern "C" fn public_id_from_bytes(
+    bytes: *const u8,
+    bytes_len: usize,
+    o_public_id: *mut *const PublicId,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let public_id = slice::from_raw_parts(bytes, bytes_len);
+        let peer_id = PeerId::new(str::from_utf8(public_id)?);
+
+        *o_public_id = Box::into_raw(Box::new(PublicId(peer_id)));
+        Ok(())
+    })
+}
+
+/// Returns the bytes contained in `public_id`.
+#[no_mangle]
+pub unsafe extern "C" fn public_id_as_bytes(
+    public_id: *const PublicId,
+    o_bytes: *mut *const u8,
+    o_bytes_len: *mut usize,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let bytes = (*public_id).0.as_bytes();
+
+        *o_bytes = bytes.as_ptr();
+        *o_bytes_len = bytes.len();
+        Ok(())
+    })
+}
+
+/// Deallocates a public id.
+#[no_mangle]
+pub unsafe extern "C" fn public_id_free(public_id: *const PublicId) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let _ = Box::from_raw(public_id as *mut PublicId);
+        Ok(())
+    })
+}
+
+/// Creates a secret ID from raw bytes pointed by `id` with a size `id_len`.
+/// Returns the opaque pointer to the `o_secret_id`.
+///
+/// `o_secret_id` must be freed using `secret_id_free`.
+#[no_mangle]
+pub unsafe extern "C" fn secret_id_from_bytes(
+    bytes: *const u8,
+    bytes_len: usize,
+    o_secret_id: *mut *const SecretId,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<(), Error> {
+        let public_id = slice::from_raw_parts(bytes, bytes_len);
+        let peer_id = PeerId::new(str::from_utf8(public_id)?);
+
+        *o_secret_id = Box::into_raw(Box::new(SecretId(peer_id)));
+        Ok(())
+    })
+}
+
+/// Returns the bytes contained in `secret_id`.
+#[no_mangle]
+pub unsafe extern "C" fn secret_id_as_bytes(
+    secret_id: *const SecretId,
+    o_bytes: *mut *const u8,
+    o_bytes_len: *mut usize,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let bytes = (*secret_id).0.as_bytes();
+
+        *o_bytes = bytes.as_ptr();
+        *o_bytes_len = bytes.len();
+        Ok(())
+    })
+}
+
+/// Deallocates a secret id.
+#[no_mangle]
+pub unsafe extern "C" fn secret_id_free(secret_id: *const SecretId) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<(), Error> {
+        let _ = Box::from_raw(secret_id as *mut SecretId);
+        Ok(())
+    })
+}
+
+/// Serves as an opaque pointer to `Proof` struct.
+///
+/// Should be deallocated with `proof_free`.
+#[derive(Debug)]
+pub struct Proof(pub(crate) NativeProof<PeerId>);
+
+/// Returns a public ID to `o_public_id` associated with a `proof`.
+///
+/// `o_public_id` must be freed using `public_id_free`.
+#[no_mangle]
+pub unsafe extern "C" fn proof_public_id(
+    proof: *const Proof,
+    o_public_id: *mut *const PublicId,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let native_public_id = (*proof).0.public_id().clone();
+
+        let public_id = PublicId(native_public_id);
+        *o_public_id = Box::into_raw(Box::new(public_id));
+        Ok(())
+    })
+}
+
+/// Returns a signature associated with a `proof`.
+#[no_mangle]
+pub unsafe extern "C" fn proof_signature(
+    proof: *const Proof,
+    o_signature: *mut *const u8,
+    o_signature_len: *mut usize,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let native_signature = (*proof).0.signature().as_bytes();
+
+        *o_signature = native_signature.as_ptr();
+        *o_signature_len = native_signature.len();
+        Ok(())
+    })
+}
+
+/// Verifies the `proof` against data. Writes `1` to `o_is_valid` if valid.
+#[no_mangle]
+pub unsafe extern "C" fn proof_is_valid(
+    proof: *const Proof,
+    data: *const u8,
+    data_len: usize,
+    o_is_valid: *mut u8,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let data_slice = slice::from_raw_parts(data, data_len);
+
+        if (*proof).0.is_valid(data_slice) {
+            *o_is_valid = 1;
+        } else {
+            *o_is_valid = 0;
+        }
+
+        Ok(())
+    })
+}
+
+/// Deallocates proof.
+#[no_mangle]
+pub unsafe extern "C" fn proof_free(proof: *const Proof) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let _ = Box::from_raw(proof as *mut Proof);
+        Ok(())
+    })
+}
+
+/// Container for a list of proofs.
+///
+/// Should be deallocated with `proof_list_free`.
+#[repr(C)]
+#[derive(Debug)]
+pub struct ProofList {
+    /// Pointer to a sequential list of proofs.
+    pub proofs: *const *const Proof,
+    /// Size of the proofs list.
+    pub proofs_len: usize,
+    /// Internal implementation detail (Rust vector capacity).
+    pub proofs_cap: usize,
+}
+
+/// Deallocates proof list.
+#[no_mangle]
+pub unsafe extern "C" fn proof_list_free(proof_list: *const ProofList) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let vec = Vec::from_raw_parts(
+            (*proof_list).proofs as *mut _,
+            (*proof_list).proofs_len,
+            (*proof_list).proofs_cap,
+        );
+
+        for proof in vec {
+            let _ = proof_free(proof);
+        }
+
+        let _ = Box::from_raw(proof_list as *mut ProofList);
+        Ok(())
+    })
+}

--- a/src/ffi/id.rs
+++ b/src/ffi/id.rs
@@ -16,12 +16,13 @@ use std::{slice, str};
 ///
 /// Should be deallocated with `secret_id_free`.
 pub struct SecretId(pub(crate) PeerId);
+
 /// Public peer signing key.
 ///
 /// Should be deallocated with `public_id_free`.
 pub struct PublicId(pub(crate) PeerId);
 
-/// Creates a public ID from raw bytes pointed by `id` with a size `id_len`.
+/// Creates a public ID from raw bytes pointed by `bytes` with a size `bytes_len`.
 /// Returns the opaque pointer to `o_public_id`.
 ///
 /// `o_public_id` must be freed using `public_id_free`.
@@ -40,7 +41,10 @@ pub unsafe extern "C" fn public_id_from_bytes(
     })
 }
 
-/// Returns the bytes contained in `public_id`.
+/// Passes back the bytes contained in `public_id` through the output variables
+/// `o_bytes` and `o_bytes_len`.
+///
+/// The returned pointers must be freed using `public_id_free`.
 #[no_mangle]
 pub unsafe extern "C" fn public_id_as_bytes(
     public_id: *const PublicId,
@@ -65,7 +69,7 @@ pub unsafe extern "C" fn public_id_free(public_id: *const PublicId) -> i32 {
     })
 }
 
-/// Creates a secret ID from raw bytes pointed by `id` with a size `id_len`.
+/// Creates a secret ID from raw bytes pointed by `bytes` with a size `bytes_len`.
 /// Returns the opaque pointer to the `o_secret_id`.
 ///
 /// `o_secret_id` must be freed using `secret_id_free`.
@@ -84,7 +88,10 @@ pub unsafe extern "C" fn secret_id_from_bytes(
     })
 }
 
-/// Returns the bytes contained in `secret_id`.
+/// Passes back the bytes contained in `secret_id` through the output variables
+/// `o_bytes` and `o_bytes_len`.
+///
+/// The returned pointers must be freed using `secret_id_free`.
 #[no_mangle]
 pub unsafe extern "C" fn secret_id_as_bytes(
     secret_id: *const SecretId,

--- a/src/ffi/message.rs
+++ b/src/ffi/message.rs
@@ -1,0 +1,38 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use error::Error;
+use ffi::{utils, NetworkEvent, PeerId};
+use gossip::{Request as ParsecReq, Response as ParsecResp};
+
+/// Opaque structure holding a request from a peer.
+///
+/// Should be deallocated with `request_free`.
+pub struct Request(pub(crate) ParsecReq<NetworkEvent, PeerId>);
+/// Opaque structure holding a response from a peer.
+///
+/// Should be deallocated with `response_free`.
+pub struct Response(pub(crate) ParsecResp<NetworkEvent, PeerId>);
+
+/// Deallocates a request.
+#[no_mangle]
+pub unsafe extern "C" fn request_free(request: *const Request) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<(), Error> {
+        let _ = Box::from_raw(request as *mut Request);
+        Ok(())
+    })
+}
+
+/// Deallocates a response.
+#[no_mangle]
+pub unsafe extern "C" fn response_free(response: *const Response) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<(), Error> {
+        let _ = Box::from_raw(response as *mut Response);
+        Ok(())
+    })
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,0 +1,101 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! FFI.
+//!
+//! # Memory checking
+//!
+//! Below we have documented some of the ways in which the FFI module is checked for memory leaks or
+//! other memory errors:
+//!
+//! ## Procinfo (Linux only)
+//!
+//! Our smoke tests measure memory both before and after each test and will print a warning if
+//! memory grew, which could indicate a memory leak. The tests must be run with `--nocapture` to
+//! print output and `--test-threads=1` for accurate results. As Procinfo is a Linux-only crate, we
+//! only measure memory when testing on Linux.
+//!
+//! ## Running sanitizers (requires nightly)
+//!
+//! You can run several different sanitizers using variations of the following command:
+//!
+//! ```text
+//! RUSTFLAGS="-Z sanitizer=address" cargo test ffi --target x86_64-apple-darwin -- --nocapture
+//! ```
+//!
+//! Possible targets are limited to:
+//!
+//! * x86_64-unknown-linux-gnu: supports the `address`, `leak`, `memory`, and `thread` sanitizers.
+//! * x86_64-apple-darwin: supports the `address` and `thread` sanitizers.
+//!
+//! More information can be found at https://github.com/japaric/rust-san.
+//!
+//! ## Checking for memory leaks (requires nightly)
+//!
+//! You can check for memory leaks using Valgrind. Make sure you have it installed on your system.
+//!
+//! First, you will need to set the global allocator:
+//!
+//! ```ignore
+//! #![feature(global_allocator)]
+//! #![feature(allocator_api)]
+//!
+//! use std::alloc::System;
+//!
+//! #[global_allocator]
+//! static GLOBAL: System = System;
+//! ```
+//!
+//! Build the example:
+//!
+//! ```text
+//! cargo test ffi --no-run
+//! ```
+//!
+//! Then run valgrind:
+//!
+//! ```text
+//! valgrind --leak-check=full target/debug/<executable>
+//! ```
+//!
+//! You should see a leak summary. The fields that concern us are "definitely lost" and "indirectly
+//! lost": these should be 0. The other fields can likely be ignored -- "possibly lost" seems to
+//! always report some bytes.
+
+#![allow(unsafe_code)]
+
+#[macro_use]
+pub mod utils;
+
+/// Functions defining blocks API.
+pub mod block;
+/// Functions for getting and clearing FFI errors.
+pub mod error;
+/// Functions defining public and private identity traits and objects.
+pub mod id;
+/// Message objects.
+pub mod message;
+/// Functions defining public interface for core Parsec functions.
+pub mod parsec;
+/// Functions defining votes API.
+pub mod vote;
+
+use mock;
+use network_event::NetworkEvent as NetEvent;
+
+pub(crate) type NetworkEvent = Vec<u8>;
+pub(crate) type PeerId = mock::PeerId;
+
+impl NetEvent for Vec<u8> {}
+
+pub use ffi::block::*;
+pub use ffi::error::*;
+pub use ffi::id::*;
+pub use ffi::message::*;
+pub use ffi::parsec::*;
+pub use ffi::vote::*;

--- a/src/ffi/parsec.rs
+++ b/src/ffi/parsec.rs
@@ -1,0 +1,224 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use error::Error;
+use ffi::message::{Request, Response};
+use ffi::utils;
+use ffi::{Block, NetworkEvent, PeerId, PublicId, SecretId};
+use parsec::Parsec as NativeParsec;
+use std::collections::BTreeSet;
+use std::{ptr, slice};
+
+/// Serves as an opaque pointer to `Parsec` struct.
+///
+/// Should be deallocated with `parsec_free`.
+pub struct Parsec(NativeParsec<NetworkEvent, PeerId>);
+
+/// Creates a new `Parsec` for a peer with the given ID and genesis peer IDs (ours included).
+/// You should initialise these IDs through functions like `public_id_from_bytes`.
+/// Returns an opaque pointer to the `Parsec` structure.
+///
+/// `o_parsec` must be freed using `parsec_free`.
+#[no_mangle]
+pub unsafe extern "C" fn parsec_new(
+    our_id: *const SecretId,
+    genesis_group: *const *const PublicId,
+    genesis_group_len: usize,
+    o_parsec: *mut *mut Parsec,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let genesis_vec = slice::from_raw_parts(genesis_group, genesis_group_len);
+        let genesis_group_set: BTreeSet<_> =
+            genesis_vec.iter().map(|id| (**id).0.clone()).collect();
+
+        let native_parsec = NativeParsec::new((*our_id).0.clone(), &genesis_group_set);
+        let parsec = Box::new(Parsec(native_parsec));
+
+        *o_parsec = Box::into_raw(parsec);
+        Ok(())
+    })
+}
+
+/// Adds a vote for `network_event`. Returns an error if we have already voted for this.
+#[no_mangle]
+pub unsafe extern "C" fn parsec_vote_for(
+    parsec: *mut Parsec,
+    network_event: *const u8,
+    network_event_len: usize,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let network_event = slice::from_raw_parts(network_event, network_event_len).to_vec();
+        (*parsec).0.vote_for(network_event)?;
+        Ok(())
+    })
+}
+
+/// Creates a new message to be gossiped to a peer containing all gossip events this node thinks
+/// that peer needs.  If `peer_id` is `NULL`, a message containing all known gossip events is
+/// returned.  If `peer_id` is an id and the given peer is unknown to this node, an error is
+/// returned.
+/// Returns an opaque `request`.
+///
+/// `o_request` must be freed using `request_free`.
+#[no_mangle]
+pub unsafe extern "C" fn parsec_create_gossip(
+    parsec: *const Parsec,
+    peer_id: *const PublicId,
+    o_request: *mut *const Request,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let peer = if peer_id.is_null() {
+            None
+        } else {
+            Some((*peer_id).0.clone())
+        };
+
+        let req = (*parsec).0.create_gossip(peer)?;
+        *o_request = Box::into_raw(Box::new(Request(req)));
+        Ok(())
+    })
+}
+
+/// Handles a received request (`req`) from `src` peer.
+/// Returns an opaque `response` to be sent back to `src`
+/// or an error if the request was not valid.
+///
+/// `o_response` must be freed using `response_free`.
+#[no_mangle]
+pub unsafe extern "C" fn parsec_handle_request(
+    parsec: *mut Parsec,
+    src: *const PublicId,
+    req: *const Request,
+    o_response: *mut *const Response,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let resp = (*parsec).0.handle_request(&(*src).0, (*req).0.clone())?;
+        *o_response = Box::into_raw(Box::new(Response(resp)));
+        Ok(())
+    })
+}
+
+/// Handles a received response (`resp`) from `src` peer.
+/// Returns an error if the response was not valid.
+#[no_mangle]
+pub unsafe extern "C" fn parsec_handle_response(
+    parsec: *mut Parsec,
+    src: *const PublicId,
+    resp: *const Response,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        (*parsec).0.handle_response(&(*src).0, (*resp).0.clone())?;
+        Ok(())
+    })
+}
+
+/// Steps the algorithm and returns the next stable block, if any.
+/// Returns an opaque block (`o_block`) if there's a block or a null pointer instead.
+///
+/// If non-null pointer is returned, it's a user's responsibility to free it after use
+/// by calling `block_free`.
+#[no_mangle]
+pub unsafe extern "C" fn parsec_poll(parsec: *mut Parsec, o_block: *mut *const Block) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let res = (*parsec).0.poll();
+        *o_block = if let Some(block) = res {
+            let block = Block(block);
+            Box::into_raw(Box::new(block))
+        } else {
+            ptr::null()
+        };
+        Ok(())
+    })
+}
+
+/// Checks if the given `network_event` has already been voted for by us.
+/// Returns 0 (false) or 1 (true) in `o_result`.
+#[no_mangle]
+pub unsafe extern "C" fn parsec_have_voted_for(
+    parsec: *const Parsec,
+    network_event: *const u8,
+    network_event_len: usize,
+    o_result: *mut u8,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let network_event = slice::from_raw_parts(network_event, network_event_len).to_vec();
+        *o_result = (*parsec).0.have_voted_for(&network_event) as u8;
+        Ok(())
+    })
+}
+
+/// Frees this `Parsec` instance and its associated data.
+#[no_mangle]
+pub unsafe extern "C" fn parsec_free(parsec: *mut Parsec) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let _ = Box::from_raw(parsec);
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use ffi::*;
+
+    #[test]
+    fn ffi_parsec_new() {
+        utils::memory_check("ffi_error", 100, || {
+            let bytes = b"test";
+            let net_event = b"event";
+
+            unsafe {
+                let secret_id = unwrap!(utils::get_1(|out| secret_id_from_bytes(
+                    bytes.as_ptr(),
+                    bytes.len(),
+                    out
+                )));
+                let public_id = unwrap!(utils::get_1(|out| public_id_from_bytes(
+                    bytes.as_ptr(),
+                    bytes.len(),
+                    out
+                )));
+                let group = &[public_id];
+
+                let parsec = unwrap!(utils::get_1(|out| parsec_new(
+                    secret_id,
+                    group.as_ptr(),
+                    group.len(),
+                    out
+                )));
+
+                let voted_for = unwrap!(utils::get_1(|out| parsec_have_voted_for(
+                    parsec,
+                    net_event.as_ptr(),
+                    net_event.len(),
+                    out
+                )));
+                assert_eq!(voted_for, 0);
+
+                // FIXME: Memory leak in this function call.
+                unwrap!(utils::get_0(|| parsec_vote_for(
+                    parsec,
+                    net_event.as_ptr(),
+                    net_event.len(),
+                )));
+
+                let voted_for = unwrap!(utils::get_1(|out| parsec_have_voted_for(
+                    parsec,
+                    net_event.as_ptr(),
+                    net_event.len(),
+                    out
+                )));
+                assert_eq!(voted_for, 1);
+
+                // Free everything.
+                unwrap!(utils::get_0(|| secret_id_free(secret_id)));
+                unwrap!(utils::get_0(|| public_id_free(public_id)));
+                unwrap!(utils::get_0(|| parsec_free(parsec)));
+            }
+        })
+    }
+}

--- a/src/ffi/utils.rs
+++ b/src/ffi/utils.rs
@@ -1,0 +1,140 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! Utils.
+
+use error::Error;
+use ffi::error;
+use ffi_utils;
+use std::slice;
+
+#[macro_export]
+macro_rules! assert_ffi {
+    ($e:expr) => {{
+        let err_code: i32 = $e;
+        if err_code != 0 {
+            use std::ffi::CStr;
+            use $crate::ffi::err_last;
+            let err = err_last();
+            let err_desc = unwrap!(CStr::from_ptr((*err).description).to_str());
+            panic!("Error with code {}: {}", err_code, err_desc)
+        }
+    }};
+}
+
+/// Catches panics. On error sets the thread-local error message and returns the `i32` error code.
+pub fn catch_unwind_err_set<F>(f: F) -> i32
+where
+    F: FnOnce() -> Result<(), Error>,
+{
+    match ffi_utils::catch_unwind_result(f) {
+        Err(err) => {
+            let (error_code, description) = ffi_result!(Err::<(), Error>(err));
+            error::err_set(error_code, description);
+            error_code
+        }
+        Ok(()) => 0,
+    }
+}
+
+/// Runs an FFI function that contains zero output parameters and returns an `i32` error code on
+/// failure.
+pub unsafe fn get_0<F>(f: F) -> Result<(), i32>
+where
+    F: FnOnce() -> i32,
+{
+    let res = f();
+
+    if res == 0 {
+        Ok(())
+    } else {
+        Err(res)
+    }
+}
+
+/// Runs an FFI function that contains one output parameter and returns either the output parameter
+/// on success or an `i32` error code on failure.
+pub unsafe fn get_1<F, T>(f: F) -> Result<T, i32>
+where
+    F: FnOnce(*mut T) -> i32,
+{
+    use std::mem;
+
+    let mut output: T = mem::zeroed();
+    let res = f(&mut output);
+
+    if res == 0 {
+        Ok(output)
+    } else {
+        Err(res)
+    }
+}
+
+/// Runs an FFI function that contains a u8 array and length output parameters and returns either
+/// the array and length output parameters on success or an `i32` error code on failure.
+pub unsafe fn get_vec_u8<F>(f: F) -> Result<Vec<u8>, i32>
+where
+    F: FnOnce(*mut *const u8, *mut usize) -> i32,
+{
+    use std::mem;
+
+    let mut ptr: *const u8 = mem::zeroed();
+    let mut len: usize = mem::zeroed();
+    let res = f(&mut ptr, &mut len);
+
+    if res == 0 {
+        Ok(slice::from_raw_parts(ptr, len).to_vec())
+    } else {
+        Err(res)
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn memory_check<F>(test: &str, num_iterations: usize, f: F)
+where
+    F: FnOnce() + Copy,
+{
+    #[cfg(target_os = "linux")]
+    use procinfo;
+
+    // Measure the amount of baseline memory.
+    #[cfg(target_os = "linux")]
+    let memory_before = {
+        let memory_before = unwrap!(procinfo::pid::statm_self()).resident;
+        memory_before
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    println!("[{}] Skipping memory check, Linux required.\n", test);
+
+    for _ in 1..num_iterations {
+        f();
+    }
+
+    // Measure the amount of memory in use at the end.
+    #[cfg(target_os = "linux")]
+    {
+        let memory_after = unwrap!(procinfo::pid::statm_self()).resident;
+        println!(
+            "\n[{}] Memory before: {} pages, memory after: {} pages",
+            test, memory_before, memory_after
+        );
+        if memory_before < memory_after {
+            println!(
+                "[{}] Warning: memory grew during the execution of this test. This is expected \
+                 if running sanitizers, otherwise there is probably a leak.",
+                test
+            );
+            println!(
+                "[{}] Average memory leaked per iteration: {} pages",
+                test,
+                (memory_after - memory_before) as f64 / num_iterations as f64
+            );
+        }
+    }
+}

--- a/src/ffi/vote.rs
+++ b/src/ffi/vote.rs
@@ -1,0 +1,159 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use error::Error;
+use ffi::id::Proof;
+use ffi::{utils, NetworkEvent, PeerId, PublicId, SecretId};
+use std::slice;
+use vote::Vote as NativeVote;
+
+/// Serves as an opaque pointer to `Vote` struct.
+///
+/// Should be deallocated with `vote_free`.
+pub struct Vote(pub(crate) NativeVote<NetworkEvent, PeerId>);
+
+/// Creates a vote for the given `payload` and writes it to `o_vote`.
+///
+/// Should be deallocated with `vote_free`.
+#[no_mangle]
+pub unsafe extern "C" fn vote_new(
+    secret_id: *const SecretId,
+    payload: *const u8,
+    payload_len: usize,
+    o_vote: *mut *const Vote,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<(), Error> {
+        let payload_vec = slice::from_raw_parts(payload, payload_len).to_vec();
+
+        let native_vote = NativeVote::new(&(*secret_id).0, payload_vec);
+
+        *o_vote = Box::into_raw(Box::new(Vote(native_vote)));
+        Ok(())
+    })
+}
+
+/// Returns the payload being voted for.
+#[no_mangle]
+pub unsafe extern "C" fn vote_payload(
+    vote: *const Vote,
+    o_payload: *mut *const u8,
+    o_payload_len: *mut usize,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let payload = (*vote).0.payload();
+
+        *o_payload = payload.as_ptr();
+        *o_payload_len = payload.len();
+        Ok(())
+    })
+}
+
+/// Returns the signature of this vote's payload.
+#[no_mangle]
+pub unsafe extern "C" fn vote_signature(
+    vote: *const Vote,
+    o_signature: *mut *const u8,
+    o_signature_len: *mut usize,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let signature = (*vote).0.signature().as_bytes();
+
+        *o_signature = signature.as_ptr();
+        *o_signature_len = signature.len();
+        Ok(())
+    })
+}
+
+/// Validates this vote's signature and payload against the given public ID.
+/// Returns 0 (false) or 1 (true) in `o_is_valid`.
+#[no_mangle]
+pub unsafe extern "C" fn vote_is_valid(
+    vote: *const Vote,
+    public_id: *const PublicId,
+    o_is_valid: *mut u8,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        if (*vote).0.is_valid(&(*public_id).0) {
+            *o_is_valid = 1
+        } else {
+            *o_is_valid = 0
+        }
+
+        Ok(())
+    })
+}
+
+/// Creates a proof from this vote and writes it to `o_proof`.
+/// Returns error if this vote is not valid (i.e. if !vote_is_valid()).
+///
+/// Should be deallocated with `proof_free`.
+#[no_mangle]
+pub unsafe extern "C" fn vote_create_proof(
+    vote: *const Vote,
+    public_id: *const PublicId,
+    o_proof: *mut *const Proof,
+) -> i32 {
+    utils::catch_unwind_err_set(|| -> Result<_, Error> {
+        let native_proof = (*vote).0.create_proof(&(*public_id).0)?;
+
+        *o_proof = Box::into_raw(Box::new(Proof(native_proof)));
+        Ok(())
+    })
+}
+
+/// Deallocates vote.
+#[no_mangle]
+pub unsafe extern "C" fn vote_free(vote: *const Vote) -> i32 {
+    let _ = Box::from_raw(vote as *mut Vote);
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use ffi::*;
+
+    #[test]
+    fn ffi_vote_new() {
+        utils::memory_check("ffi_vote_new", 1000, || {
+            let secret_id_bytes = b"hello";
+            let public_id_bytes = b"howdy";
+            let payload = b"testing";
+
+            unsafe {
+                let secret_id = unwrap!(utils::get_1(|out| secret_id_from_bytes(
+                    secret_id_bytes.as_ptr(),
+                    secret_id_bytes.len(),
+                    out
+                )));
+
+                let vote = unwrap!(utils::get_1(|out| vote_new(
+                    secret_id,
+                    payload.as_ptr(),
+                    payload.len(),
+                    out
+                )));
+
+                let result = unwrap!(utils::get_vec_u8(|out, len| vote_payload(vote, out, len)));
+                assert_eq!(result, payload);
+
+                let public_id = unwrap!(utils::get_1(|out| public_id_from_bytes(
+                    public_id_bytes.as_ptr(),
+                    public_id_bytes.len(),
+                    out
+                )));
+
+                let is_valid = unwrap!(utils::get_1(|out| vote_is_valid(vote, public_id, out)));
+                assert_eq!(is_valid, 1);
+
+                unwrap!(utils::get_0(|| secret_id_free(secret_id)));
+                unwrap!(utils::get_0(|| public_id_free(public_id)));
+                unwrap!(utils::get_0(|| vote_free(vote)));
+            }
+        })
+    }
+}

--- a/src/id.rs
+++ b/src/id.rs
@@ -16,6 +16,7 @@ use std::hash::Hash;
 pub trait PublicId: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned + Debug {
     /// The signature type associated with the chosen asymmetric key scheme.
     type Signature: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned + Debug;
+
     /// Verifies `signature` against `data` using this `PublicId`.  Returns `true` if valid.
     fn verify_signature(&self, signature: &Self::Signature, data: &[u8]) -> bool;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@
     variant_size_differences
 )]
 
+#[macro_use]
+extern crate ffi_utils;
 #[cfg(feature = "dump-graphs")]
 #[macro_use]
 extern crate lazy_static;
@@ -67,6 +69,8 @@ extern crate lazy_static;
 extern crate log;
 #[macro_use]
 extern crate maidsafe_utilities;
+#[cfg(all(test, target_os = "linux"))]
+extern crate procinfo;
 #[macro_use]
 extern crate quick_error;
 extern crate rand;
@@ -74,6 +78,8 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate tiny_keccak;
+#[macro_use]
+extern crate unwrap;
 
 mod block;
 mod dump_graph;
@@ -87,6 +93,8 @@ mod parsec;
 mod peer_list;
 mod round_hash;
 mod vote;
+
+pub mod ffi;
 
 #[doc(hidden)]
 /// **NOT FOR PRODUCTION USE**: Mock types which trivially implement the required Parsec traits.

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -18,7 +18,17 @@ const NAMES: &[&str] = &[
 
 /// **NOT FOR PRODUCTION USE**: Mock signature type.
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug)]
-pub struct Signature(String);
+pub struct Signature(Vec<u8>);
+
+impl Signature {
+    pub fn from_bytes(sig: &[u8]) -> Self {
+        Signature(Vec::from(sig))
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
 
 /// **NOT FOR PRODUCTION USE**: Mock type implementing `PublicId` and `SecretId` traits.  For
 /// non-mocks, these two traits must be implemented by two separate types; a public key and secret
@@ -32,6 +42,10 @@ impl PeerId {
     pub fn new(id: &str) -> Self {
         Self { id: id.to_string() }
     }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.id.as_bytes()
+    }
 }
 
 impl Debug for PeerId {
@@ -42,6 +56,7 @@ impl Debug for PeerId {
 
 impl PublicId for PeerId {
     type Signature = Signature;
+
     fn verify_signature(&self, _signature: &Self::Signature, _data: &[u8]) -> bool {
         true
     }
@@ -49,11 +64,12 @@ impl PublicId for PeerId {
 
 impl SecretId for PeerId {
     type PublicId = PeerId;
+
     fn public_id(&self) -> &Self::PublicId {
         &self
     }
     fn sign_detached(&self, _data: &[u8]) -> Signature {
-        Signature(format!("of {:?}", self))
+        Signature(Vec::from(format!("of {:?}", self)))
     }
 }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -33,7 +33,7 @@ pub struct Parsec<T: NetworkEvent, S: SecretId> {
     events_with_valid_blocks: BTreeMap<S::PublicId, VecDeque<Hash>>,
     // Consensused network events that have not been returned via `poll()` yet.
     consensused_blocks: VecDeque<Block<T, S::PublicId>>,
-    // Hash of all payloads that were consensused ever
+    // Hash of all payloads that were consensused ever.
     consensus_history: Vec<Hash>,
     // The meta votes of the events.
     meta_votes: BTreeMap<Hash, BTreeMap<S::PublicId, Vec<MetaVote>>>,

--- a/tests/Xargo.toml
+++ b/tests/Xargo.toml
@@ -1,0 +1,6 @@
+[dependencies.std]
+features = ["panic-unwind", "asan", "lsan", "msan", "tsan"]
+
+# if using `cargo test`
+[dependencies.test]
+stage = 1

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -55,6 +55,7 @@
 )]
 
 extern crate maidsafe_utilities;
+#[macro_use]
 extern crate parsec;
 extern crate rand;
 #[macro_use]
@@ -66,8 +67,8 @@ mod utils;
 
 use self::utils::proptest::{arbitrary_delay, ScheduleOptionsStrategy, ScheduleStrategy};
 use self::utils::{
-    DelayDistribution, Environment, GossipStrategy, PeerCount, RngChoice, Schedule,
-    ScheduleOptions, TransactionCount,
+    DelayDistribution, Environment, GossipStrategy, ParsecFfiImpl, ParsecRustImpl, PeerCount,
+    RngChoice, Schedule, ScheduleOptions, TransactionCount,
 };
 use proptest::prelude::ProptestConfig;
 use proptest::test_runner::FileFailurePersistence;
@@ -81,7 +82,28 @@ static SEED: RngChoice = RngChoice::SeededRandom;
 fn minimal_network() {
     // 4 is the minimal network size for which the super majority is less than it.
     let num_peers = 4;
-    let mut env = Environment::new(&PeerCount(num_peers), &TransactionCount(1), SEED);
+    let mut env =
+        Environment::<ParsecRustImpl>::new(&PeerCount(num_peers), &TransactionCount(1), SEED);
+
+    let schedule = Schedule::new(
+        &mut env,
+        &ScheduleOptions {
+            votes_before_gossip: true,
+            ..Default::default()
+        },
+    );
+    env.network.execute_schedule(schedule);
+
+    let result = env.network.blocks_all_in_sequence();
+    assert!(result.is_ok(), "{:?}", result);
+}
+
+#[test]
+fn ffi_minimal_network() {
+    // 4 is the minimal network size for which the super majority is less than it.
+    let num_peers = 4;
+    let mut env =
+        Environment::<ParsecFfiImpl>::new(&PeerCount(num_peers), &TransactionCount(1), SEED);
 
     let schedule = Schedule::new(
         &mut env,
@@ -99,7 +121,30 @@ fn minimal_network() {
 #[test]
 fn multiple_votes_before_gossip() {
     let num_transactions = 10;
-    let mut env = Environment::new(&PeerCount(4), &TransactionCount(num_transactions), SEED);
+    let mut env = Environment::<ParsecRustImpl>::new(
+        &PeerCount(4),
+        &TransactionCount(num_transactions),
+        SEED,
+    );
+
+    let schedule = Schedule::new(
+        &mut env,
+        &ScheduleOptions {
+            votes_before_gossip: true,
+            ..Default::default()
+        },
+    );
+    env.network.execute_schedule(schedule);
+
+    let result = env.network.blocks_all_in_sequence();
+    assert!(result.is_ok(), "{:?}", result);
+}
+
+#[test]
+fn ffi_multiple_votes_before_gossip() {
+    let num_transactions = 10;
+    let mut env =
+        Environment::<ParsecFfiImpl>::new(&PeerCount(4), &TransactionCount(num_transactions), SEED);
 
     let schedule = Schedule::new(
         &mut env,
@@ -117,7 +162,24 @@ fn multiple_votes_before_gossip() {
 #[test]
 fn multiple_votes_during_gossip() {
     let num_transactions = 10;
-    let mut env = Environment::new(&PeerCount(4), &TransactionCount(num_transactions), SEED);
+    let mut env = Environment::<ParsecRustImpl>::new(
+        &PeerCount(4),
+        &TransactionCount(num_transactions),
+        SEED,
+    );
+
+    let schedule = Schedule::new(&mut env, &Default::default());
+    env.network.execute_schedule(schedule);
+
+    let result = env.network.blocks_all_in_sequence();
+    assert!(result.is_ok(), "{:?}", result);
+}
+
+#[test]
+fn ffi_multiple_votes_during_gossip() {
+    let num_transactions = 10;
+    let mut env =
+        Environment::<ParsecFfiImpl>::new(&PeerCount(4), &TransactionCount(num_transactions), SEED);
 
     let schedule = Schedule::new(&mut env, &Default::default());
     env.network.execute_schedule(schedule);
@@ -128,7 +190,25 @@ fn multiple_votes_during_gossip() {
 
 #[test]
 fn duplicate_votes_before_gossip() {
-    let mut env = Environment::new(&PeerCount(4), &TransactionCount(1), SEED);
+    let mut env = Environment::<ParsecRustImpl>::new(&PeerCount(4), &TransactionCount(1), SEED);
+
+    let schedule = Schedule::new(
+        &mut env,
+        &ScheduleOptions {
+            votes_before_gossip: true,
+            prob_vote_duplication: 0.5,
+            ..Default::default()
+        },
+    );
+    env.network.execute_schedule(schedule);
+
+    let result = env.network.blocks_all_in_sequence();
+    assert!(result.is_ok(), "{:?}", result);
+}
+
+#[test]
+fn ffi_duplicate_votes_before_gossip() {
+    let mut env = Environment::<ParsecFfiImpl>::new(&PeerCount(4), &TransactionCount(1), SEED);
 
     let schedule = Schedule::new(
         &mut env,
@@ -149,7 +229,33 @@ fn faulty_third_never_gossip() {
     let num_peers = 10;
     let num_transactions = 10;
     let num_faulty = (num_peers - 1) / 3;
-    let mut env = Environment::new(
+    let mut env = Environment::<ParsecRustImpl>::new(
+        &PeerCount(num_peers),
+        &TransactionCount(num_transactions),
+        SEED,
+    );
+
+    let mut failures = BTreeMap::new();
+    let _ = failures.insert(0, num_faulty);
+    let schedule = Schedule::new(
+        &mut env,
+        &ScheduleOptions {
+            deterministic_failures: failures,
+            ..Default::default()
+        },
+    );
+    env.network.execute_schedule(schedule);
+
+    let result = env.network.blocks_all_in_sequence();
+    assert!(result.is_ok(), "{:?}", result);
+}
+
+#[test]
+fn ffi_faulty_third_never_gossip() {
+    let num_peers = 10;
+    let num_transactions = 10;
+    let num_faulty = (num_peers - 1) / 3;
+    let mut env = Environment::<ParsecFfiImpl>::new(
         &PeerCount(num_peers),
         &TransactionCount(num_transactions),
         SEED,
@@ -175,7 +281,33 @@ fn faulty_third_terminate_concurrently() {
     let num_peers = 10;
     let num_transactions = 10;
     let num_faulty = (num_peers - 1) / 3;
-    let mut env = Environment::new(
+    let mut env = Environment::<ParsecRustImpl>::new(
+        &PeerCount(num_peers),
+        &TransactionCount(num_transactions),
+        SEED,
+    );
+
+    let mut failures = BTreeMap::new();
+    let _ = failures.insert(env.rng.gen_range(10, 50), num_faulty);
+    let schedule = Schedule::new(
+        &mut env,
+        &ScheduleOptions {
+            deterministic_failures: failures,
+            ..Default::default()
+        },
+    );
+    env.network.execute_schedule(schedule);
+
+    let result = env.network.blocks_all_in_sequence();
+    assert!(result.is_ok(), "{:?}", result);
+}
+
+#[test]
+fn ffi_faulty_third_terminate_concurrently() {
+    let num_peers = 10;
+    let num_transactions = 10;
+    let num_faulty = (num_peers - 1) / 3;
+    let mut env = Environment::<ParsecFfiImpl>::new(
         &PeerCount(num_peers),
         &TransactionCount(num_transactions),
         SEED,
@@ -201,7 +333,7 @@ fn faulty_nodes_terminate_at_random_points() {
     let num_peers = 10;
     let num_transactions = 10;
     let prob_failure = 0.05;
-    let mut env = Environment::new(
+    let mut env = Environment::<ParsecRustImpl>::new(
         &PeerCount(num_peers),
         &TransactionCount(num_transactions),
         SEED,
@@ -222,7 +354,11 @@ fn faulty_nodes_terminate_at_random_points() {
 #[test]
 fn random_schedule_no_delays() {
     let num_transactions = 10;
-    let mut env = Environment::new(&PeerCount(4), &TransactionCount(num_transactions), SEED);
+    let mut env = Environment::<ParsecRustImpl>::new(
+        &PeerCount(4),
+        &TransactionCount(num_transactions),
+        SEED,
+    );
     let schedule = Schedule::new(
         &mut env,
         &ScheduleOptions {
@@ -239,7 +375,11 @@ fn random_schedule_no_delays() {
 #[test]
 fn random_schedule_probabilistic_gossip() {
     let num_transactions = 10;
-    let mut env = Environment::new(&PeerCount(4), &TransactionCount(num_transactions), SEED);
+    let mut env = Environment::<ParsecRustImpl>::new(
+        &PeerCount(4),
+        &TransactionCount(num_transactions),
+        SEED,
+    );
     let schedule = Schedule::new(
         &mut env,
         &ScheduleOptions {

--- a/tests/utils/environment.rs
+++ b/tests/utils/environment.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use super::ParsecImpl;
 use maidsafe_utilities::SeededRng;
 use parsec::mock::Transaction;
 use rand::{Rng, SeedableRng, XorShiftRng};
@@ -20,8 +21,8 @@ pub trait RngDebug: Rng + fmt::Debug {}
 impl RngDebug for SeededRng {}
 impl RngDebug for XorShiftRng {}
 
-pub struct Environment {
-    pub network: Network,
+pub struct Environment<P: ParsecImpl> {
+    pub network: Network<P>,
     pub transactions: Vec<Transaction>,
     pub rng: Box<RngDebug>,
 }
@@ -34,7 +35,7 @@ pub enum RngChoice {
     SeededXor([u32; 4]),
 }
 
-impl Environment {
+impl<P: ParsecImpl> Environment<P> {
     /// Initialise the test environment with the given number of peers and transactions.  The random
     /// number generator will be seeded with `seed` or randomly if this is `SeededRandom`.
     pub fn new(
@@ -63,7 +64,7 @@ impl Environment {
     }
 }
 
-impl fmt::Debug for Environment {
+impl<P: ParsecImpl> fmt::Debug for Environment<P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,

--- a/tests/utils/ffi.rs
+++ b/tests/utils/ffi.rs
@@ -1,0 +1,229 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+#![allow(unsafe_code)]
+
+use super::{BlockImpl, ParsecImpl};
+use maidsafe_utilities::serialisation::{deserialise, serialise};
+use parsec::ffi::*;
+use parsec::mock::{PeerId, Transaction};
+use parsec::Error;
+use std::collections::BTreeSet;
+use std::{mem, ptr, slice};
+
+pub struct RequestWrapper(*const Request);
+
+impl Drop for RequestWrapper {
+    fn drop(&mut self) {
+        unsafe {
+            assert_ffi!(request_free(self.0));
+        }
+    }
+}
+
+pub struct ResponseWrapper(*const Response);
+
+impl Drop for ResponseWrapper {
+    fn drop(&mut self) {
+        unsafe {
+            assert_ffi!(response_free(self.0));
+        }
+    }
+}
+
+pub struct ParsecFfiImpl {
+    parsec: *mut Parsec,
+}
+
+impl Drop for ParsecFfiImpl {
+    fn drop(&mut self) {
+        unsafe {
+            assert_ffi!(parsec_free(self.parsec));
+            err_clear();
+        }
+    }
+}
+
+impl ParsecImpl for ParsecFfiImpl {
+    type Block = BlockFfiImpl;
+    type Request = RequestWrapper;
+    type Response = ResponseWrapper;
+
+    fn new(our_id: PeerId, genesis_group: &BTreeSet<PeerId>) -> Self {
+        unsafe {
+            let genesis_vec: Vec<*const PublicId> = genesis_group
+                .iter()
+                .map(|id| {
+                    let mut pub_id = mem::zeroed();
+                    let id_bytes = id.as_bytes();
+                    assert_ffi!(public_id_from_bytes(
+                        id_bytes.as_ptr(),
+                        id_bytes.len(),
+                        &mut pub_id
+                    ));
+                    pub_id
+                }).collect();
+
+            let mut parsec: *mut Parsec = mem::zeroed();
+            let mut our_secret_id = mem::zeroed();
+
+            let id = our_id.as_bytes();
+
+            assert_ffi!(secret_id_from_bytes(
+                id.as_ptr(),
+                id.len(),
+                &mut our_secret_id
+            ));
+
+            assert_ffi!(parsec_new(
+                our_secret_id,
+                genesis_vec.as_ptr(),
+                genesis_vec.len(),
+                &mut parsec,
+            ));
+
+            for id in genesis_vec {
+                assert_ffi!(public_id_free(id));
+            }
+            assert_ffi!(secret_id_free(our_secret_id));
+
+            Self { parsec }
+        }
+    }
+
+    fn poll(&mut self) -> Option<Self::Block> {
+        unsafe {
+            let mut o_block = mem::zeroed();
+            assert_ffi!(parsec_poll(self.parsec, &mut o_block));
+
+            if o_block.is_null() {
+                None
+            } else {
+                Some(BlockFfiImpl(o_block))
+            }
+        }
+    }
+
+    fn have_voted_for(&mut self, event: &Transaction) -> bool {
+        let event_data = unwrap!(serialise(event));
+        let mut voted = 0;
+        unsafe {
+            assert_ffi!(parsec_have_voted_for(
+                self.parsec,
+                event_data.as_ptr(),
+                event_data.len(),
+                &mut voted,
+            ));
+        }
+        voted == 1
+    }
+
+    fn vote_for(&mut self, event: Transaction) -> Result<(), Error> {
+        let event_data = unwrap!(serialise(&event));
+        unsafe {
+            assert_ffi!(parsec_vote_for(
+                self.parsec,
+                event_data.as_ptr(),
+                event_data.len()
+            ));
+        }
+        Ok(())
+    }
+
+    fn handle_request(
+        &mut self,
+        src: &PeerId,
+        req: Self::Request,
+    ) -> Result<Self::Response, Error> {
+        let mut o_resp = unsafe { mem::zeroed() };
+        let src_bytes = src.as_bytes();
+        unsafe {
+            let mut src_id = mem::zeroed();
+
+            assert_ffi!(public_id_from_bytes(
+                src_bytes.as_ptr(),
+                src_bytes.len(),
+                &mut src_id
+            ));
+            assert_ffi!(parsec_handle_request(
+                self.parsec,
+                src_id,
+                req.0,
+                &mut o_resp
+            ));
+            assert_ffi!(public_id_free(src_id));
+        }
+        Ok(ResponseWrapper(o_resp))
+    }
+
+    fn handle_response(&mut self, src: &PeerId, resp: Self::Response) -> Result<(), Error> {
+        let src_bytes = src.as_bytes();
+        unsafe {
+            let mut src_id = mem::zeroed();
+
+            assert_ffi!(public_id_from_bytes(
+                src_bytes.as_ptr(),
+                src_bytes.len(),
+                &mut src_id
+            ));
+            assert_ffi!(parsec_handle_response(self.parsec, src_id, resp.0));
+            assert_ffi!(public_id_free(src_id));
+        }
+        Ok(())
+    }
+
+    fn create_gossip(&self, peer_id: Option<PeerId>) -> Result<Self::Request, Error> {
+        unsafe {
+            let mut o_request = mem::zeroed();
+            let mut src_id = ptr::null();
+
+            if let Some(id) = peer_id {
+                let id_bytes = id.as_bytes();
+
+                assert_ffi!(public_id_from_bytes(
+                    id_bytes.as_ptr(),
+                    id_bytes.len(),
+                    &mut src_id
+                ));
+            }
+
+            assert_ffi!(parsec_create_gossip(self.parsec, src_id, &mut o_request));
+
+            if !src_id.is_null() {
+                assert_ffi!(public_id_free(src_id));
+            }
+
+            Ok(RequestWrapper(o_request))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct BlockFfiImpl(*const Block);
+
+impl Drop for BlockFfiImpl {
+    fn drop(&mut self) {
+        unsafe {
+            assert_ffi!(block_free(self.0 as *mut _));
+        }
+    }
+}
+
+impl BlockImpl for BlockFfiImpl {
+    fn payload(&self) -> Transaction {
+        let mut payload_bytes: *const u8 = unsafe { mem::zeroed() };
+        let mut payload_len: usize = 0;
+
+        let payload: &[u8] = unsafe {
+            assert_ffi!(block_payload(self.0, &mut payload_bytes, &mut payload_len));
+            slice::from_raw_parts(payload_bytes, payload_len)
+        };
+
+        unwrap!(deserialise(&payload))
+    }
+}

--- a/tests/utils/implementation.rs
+++ b/tests/utils/implementation.rs
@@ -1,0 +1,88 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use parsec::mock::{PeerId, Transaction};
+use parsec::{Block, Error, Parsec, Request as ParsecReq, Response as ParsecResp};
+use std::collections::BTreeSet;
+use std::fmt::Debug;
+
+/// Provides a wrapper for testing of different PARSEC facades (FFI and native).
+/// It is biased for `Transaction` as a payload and `PeerId` as the peer identity.
+pub trait ParsecImpl {
+    type Block: BlockImpl;
+    type Response;
+    type Request;
+
+    fn new(our_id: PeerId, genesis_group: &BTreeSet<PeerId>) -> Self;
+
+    fn poll(&mut self) -> Option<Self::Block>;
+
+    fn have_voted_for(&mut self, network_event: &Transaction) -> bool;
+
+    fn vote_for(&mut self, network_event: Transaction) -> Result<(), Error>;
+
+    fn handle_request(&mut self, src: &PeerId, req: Self::Request)
+        -> Result<Self::Response, Error>;
+
+    fn handle_response(&mut self, src: &PeerId, resp: Self::Response) -> Result<(), Error>;
+
+    fn create_gossip(&self, peer_id: Option<PeerId>) -> Result<Self::Request, Error>;
+}
+
+pub trait BlockImpl: Debug {
+    fn payload(&self) -> Transaction;
+}
+
+#[derive(Debug)]
+pub struct BlockRustImpl(Block<Transaction, PeerId>);
+
+impl BlockImpl for BlockRustImpl {
+    fn payload(&self) -> Transaction {
+        self.0.payload().clone()
+    }
+}
+
+pub struct ParsecRustImpl(Parsec<Transaction, PeerId>);
+
+impl ParsecImpl for ParsecRustImpl {
+    type Block = BlockRustImpl;
+    type Request = ParsecReq<Transaction, PeerId>;
+    type Response = ParsecResp<Transaction, PeerId>;
+
+    fn new(our_id: PeerId, genesis_group: &BTreeSet<PeerId>) -> Self {
+        ParsecRustImpl(Parsec::new(our_id, genesis_group))
+    }
+
+    fn poll(&mut self) -> Option<Self::Block> {
+        self.0.poll().map(BlockRustImpl)
+    }
+
+    fn have_voted_for(&mut self, network_event: &Transaction) -> bool {
+        self.0.have_voted_for(network_event)
+    }
+
+    fn vote_for(&mut self, network_event: Transaction) -> Result<(), Error> {
+        self.0.vote_for(network_event)
+    }
+
+    fn handle_request(
+        &mut self,
+        src: &PeerId,
+        req: Self::Request,
+    ) -> Result<Self::Response, Error> {
+        self.0.handle_request(src, req)
+    }
+
+    fn handle_response(&mut self, src: &PeerId, resp: Self::Response) -> Result<(), Error> {
+        self.0.handle_response(src, resp)
+    }
+
+    fn create_gossip(&self, peer_id: Option<PeerId>) -> Result<Self::Request, Error> {
+        self.0.create_gossip(peer_id)
+    }
+}

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -7,12 +7,16 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 mod environment;
+mod ffi;
+mod implementation;
 mod network;
 mod peer;
 pub mod proptest;
 mod schedule;
 
 pub use self::environment::{Environment, PeerCount, RngChoice, TransactionCount};
+pub use self::ffi::{BlockFfiImpl, ParsecFfiImpl};
+pub use self::implementation::*;
 pub use self::network::Network;
 pub use self::peer::Peer;
 pub use self::schedule::*;

--- a/tests/utils/peer.rs
+++ b/tests/utils/peer.rs
@@ -6,23 +6,23 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use super::{BlockImpl, ParsecImpl};
 use parsec::mock::{PeerId, Transaction};
-use parsec::{Block, Parsec};
 use std::collections::BTreeSet;
 use std::fmt::{self, Debug, Formatter};
 
-pub struct Peer {
+pub struct Peer<P: ParsecImpl> {
     pub id: PeerId,
-    pub parsec: Parsec<Transaction, PeerId>,
+    pub parsec: P,
     // The blocks returned by `parsec.poll()`, held in the order in which they were returned.
-    pub blocks: Vec<Block<Transaction, PeerId>>,
+    pub blocks: Vec<P::Block>,
 }
 
-impl Peer {
+impl<P: ParsecImpl> Peer<P> {
     pub fn new(id: PeerId, genesis_group: &BTreeSet<PeerId>) -> Self {
         Self {
             id: id.clone(),
-            parsec: Parsec::new(id, genesis_group),
+            parsec: P::new(id, genesis_group),
             blocks: vec![],
         }
     }
@@ -43,12 +43,12 @@ impl Peer {
     }
 
     // Returns the payloads of `self.blocks` in the order in which they were returned by `poll()`.
-    pub fn blocks_payloads(&self) -> Vec<&Transaction> {
-        self.blocks.iter().map(Block::payload).collect()
+    pub fn blocks_payloads(&self) -> Vec<Transaction> {
+        self.blocks.iter().map(P::Block::payload).collect()
     }
 }
 
-impl Debug for Peer {
+impl<P: ParsecImpl> Debug for Peer<P> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(formatter, "{:?}: Blocks: {:?}", self.id, self.blocks)
     }

--- a/tests/utils/schedule.rs
+++ b/tests/utils/schedule.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Environment;
+use super::ParsecImpl;
 use parsec::mock::{PeerId, Transaction};
 #[cfg(feature = "dump-graphs")]
 use parsec::DIR;
@@ -413,7 +414,7 @@ impl Schedule {
     // The `let_and_return` clippy lint is allowed since it is actually necessary to create the
     // `result` variable so the result can be saved when the `dump-graphs` feature is used.
     #[cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
-    pub fn new(env: &mut Environment, options: &ScheduleOptions) -> Schedule {
+    pub fn new<P: ParsecImpl>(env: &mut Environment<P>, options: &ScheduleOptions) -> Schedule {
         let mut peers: Vec<_> = env.network.peers.iter().map(|p| p.id.clone()).collect();
         let num_peers = env.network.peers.len();
         let mut pending = PendingTransactions::new(&mut env.rng, &peers, &env.transactions);


### PR DESCRIPTION
* Add FFI functions to be used from languages other than Rust.
* Make integration tests more generic and implementation-independent (for testing FFI).