### PR TITLE
Decouple testing framework from implementation

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -66,7 +66,7 @@ mod utils;
 
 use self::utils::proptest::{arbitrary_delay, ScheduleOptionsStrategy, ScheduleStrategy};
 use self::utils::{
-    DelayDistribution, Environment, GossipStrategy, PeerCount, RngChoice, Schedule,
+    DelayDistribution, Environment, GossipStrategy, ParsecRustImpl, PeerCount, RngChoice, Schedule,
     ScheduleOptions, TransactionCount,
 };
 use proptest::prelude::ProptestConfig;
@@ -81,7 +81,8 @@ static SEED: RngChoice = RngChoice::SeededRandom;
 fn minimal_network() {
     // 4 is the minimal network size for which the super majority is less than it.
     let num_peers = 4;
-    let mut env = Environment::new(&PeerCount(num_peers), &TransactionCount(1), SEED);
+    let mut env =
+        Environment::<ParsecRustImpl>::new(&PeerCount(num_peers), &TransactionCount(1), SEED);
 
     let schedule = Schedule::new(
         &mut env,
@@ -99,7 +100,11 @@ fn minimal_network() {
 #[test]
 fn multiple_votes_before_gossip() {
     let num_transactions = 10;
-    let mut env = Environment::new(&PeerCount(4), &TransactionCount(num_transactions), SEED);
+    let mut env = Environment::<ParsecRustImpl>::new(
+        &PeerCount(4),
+        &TransactionCount(num_transactions),
+        SEED,
+    );
 
     let schedule = Schedule::new(
         &mut env,
@@ -117,7 +122,11 @@ fn multiple_votes_before_gossip() {
 #[test]
 fn multiple_votes_during_gossip() {
     let num_transactions = 10;
-    let mut env = Environment::new(&PeerCount(4), &TransactionCount(num_transactions), SEED);
+    let mut env = Environment::<ParsecRustImpl>::new(
+        &PeerCount(4),
+        &TransactionCount(num_transactions),
+        SEED,
+    );
 
     let schedule = Schedule::new(&mut env, &Default::default());
     env.network.execute_schedule(schedule);
@@ -128,7 +137,7 @@ fn multiple_votes_during_gossip() {
 
 #[test]
 fn duplicate_votes_before_gossip() {
-    let mut env = Environment::new(&PeerCount(4), &TransactionCount(1), SEED);
+    let mut env = Environment::<ParsecRustImpl>::new(&PeerCount(4), &TransactionCount(1), SEED);
 
     let schedule = Schedule::new(
         &mut env,
@@ -149,7 +158,7 @@ fn faulty_third_never_gossip() {
     let num_peers = 10;
     let num_transactions = 10;
     let num_faulty = (num_peers - 1) / 3;
-    let mut env = Environment::new(
+    let mut env = Environment::<ParsecRustImpl>::new(
         &PeerCount(num_peers),
         &TransactionCount(num_transactions),
         SEED,
@@ -175,7 +184,7 @@ fn faulty_third_terminate_concurrently() {
     let num_peers = 10;
     let num_transactions = 10;
     let num_faulty = (num_peers - 1) / 3;
-    let mut env = Environment::new(
+    let mut env = Environment::<ParsecRustImpl>::new(
         &PeerCount(num_peers),
         &TransactionCount(num_transactions),
         SEED,
@@ -201,7 +210,7 @@ fn faulty_nodes_terminate_at_random_points() {
     let num_peers = 10;
     let num_transactions = 10;
     let prob_failure = 0.05;
-    let mut env = Environment::new(
+    let mut env = Environment::<ParsecRustImpl>::new(
         &PeerCount(num_peers),
         &TransactionCount(num_transactions),
         SEED,
@@ -222,7 +231,11 @@ fn faulty_nodes_terminate_at_random_points() {
 #[test]
 fn random_schedule_no_delays() {
     let num_transactions = 10;
-    let mut env = Environment::new(&PeerCount(4), &TransactionCount(num_transactions), SEED);
+    let mut env = Environment::<ParsecRustImpl>::new(
+        &PeerCount(4),
+        &TransactionCount(num_transactions),
+        SEED,
+    );
     let schedule = Schedule::new(
         &mut env,
         &ScheduleOptions {
@@ -239,7 +252,11 @@ fn random_schedule_no_delays() {
 #[test]
 fn random_schedule_probabilistic_gossip() {
     let num_transactions = 10;
-    let mut env = Environment::new(&PeerCount(4), &TransactionCount(num_transactions), SEED);
+    let mut env = Environment::<ParsecRustImpl>::new(
+        &PeerCount(4),
+        &TransactionCount(num_transactions),
+        SEED,
+    );
     let schedule = Schedule::new(
         &mut env,
         &ScheduleOptions {

--- a/tests/utils/environment.rs
+++ b/tests/utils/environment.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use super::ParsecImpl;
 use maidsafe_utilities::SeededRng;
 use parsec::mock::Transaction;
 use rand::{Rng, SeedableRng, XorShiftRng};
@@ -20,8 +21,8 @@ pub trait RngDebug: Rng + fmt::Debug {}
 impl RngDebug for SeededRng {}
 impl RngDebug for XorShiftRng {}
 
-pub struct Environment {
-    pub network: Network,
+pub struct Environment<P: ParsecImpl> {
+    pub network: Network<P>,
     pub transactions: Vec<Transaction>,
     pub rng: Box<RngDebug>,
 }
@@ -34,7 +35,7 @@ pub enum RngChoice {
     SeededXor([u32; 4]),
 }
 
-impl Environment {
+impl<P: ParsecImpl> Environment<P> {
     /// Initialise the test environment with the given number of peers and transactions.  The random
     /// number generator will be seeded with `seed` or randomly if this is `SeededRandom`.
     pub fn new(
@@ -63,7 +64,7 @@ impl Environment {
     }
 }
 
-impl fmt::Debug for Environment {
+impl<P: ParsecImpl> fmt::Debug for Environment<P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,

--- a/tests/utils/implementation.rs
+++ b/tests/utils/implementation.rs
@@ -1,0 +1,88 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use parsec::mock::{PeerId, Transaction};
+use parsec::{Block, Error, Parsec, Request as ParsecReq, Response as ParsecResp};
+use std::collections::BTreeSet;
+use std::fmt::Debug;
+
+/// Provides a wrapper for testing of different PARSEC facades (FFI and native).
+/// It is biased for `Transaction` as a payload and `PeerId` as the peer identity.
+pub trait ParsecImpl {
+    type Block: BlockImpl;
+    type Response;
+    type Request;
+
+    fn new(our_id: PeerId, genesis_group: &BTreeSet<PeerId>) -> Self;
+
+    fn poll(&mut self) -> Option<Self::Block>;
+
+    fn have_voted_for(&mut self, network_event: &Transaction) -> bool;
+
+    fn vote_for(&mut self, network_event: Transaction) -> Result<(), Error>;
+
+    fn handle_request(&mut self, src: &PeerId, req: Self::Request)
+        -> Result<Self::Response, Error>;
+
+    fn handle_response(&mut self, src: &PeerId, resp: Self::Response) -> Result<(), Error>;
+
+    fn create_gossip(&self, peer_id: Option<PeerId>) -> Result<Self::Request, Error>;
+}
+
+pub trait BlockImpl: Debug {
+    fn payload(&self) -> Transaction;
+}
+
+#[derive(Debug)]
+pub struct BlockRustImpl(Block<Transaction, PeerId>);
+
+impl BlockImpl for BlockRustImpl {
+    fn payload(&self) -> Transaction {
+        self.0.payload().clone()
+    }
+}
+
+pub struct ParsecRustImpl(Parsec<Transaction, PeerId>);
+
+impl ParsecImpl for ParsecRustImpl {
+    type Block = BlockRustImpl;
+    type Request = ParsecReq<Transaction, PeerId>;
+    type Response = ParsecResp<Transaction, PeerId>;
+
+    fn new(our_id: PeerId, genesis_group: &BTreeSet<PeerId>) -> Self {
+        ParsecRustImpl(Parsec::new(our_id, genesis_group))
+    }
+
+    fn poll(&mut self) -> Option<Self::Block> {
+        self.0.poll().map(BlockRustImpl)
+    }
+
+    fn have_voted_for(&mut self, network_event: &Transaction) -> bool {
+        self.0.have_voted_for(network_event)
+    }
+
+    fn vote_for(&mut self, network_event: Transaction) -> Result<(), Error> {
+        self.0.vote_for(network_event)
+    }
+
+    fn handle_request(
+        &mut self,
+        src: &PeerId,
+        req: Self::Request,
+    ) -> Result<Self::Response, Error> {
+        self.0.handle_request(src, req)
+    }
+
+    fn handle_response(&mut self, src: &PeerId, resp: Self::Response) -> Result<(), Error> {
+        self.0.handle_response(src, resp)
+    }
+
+    fn create_gossip(&self, peer_id: Option<PeerId>) -> Result<Self::Request, Error> {
+        self.0.create_gossip(peer_id)
+    }
+}

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -7,12 +7,14 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 mod environment;
+mod implementation;
 mod network;
 mod peer;
 pub mod proptest;
 mod schedule;
 
 pub use self::environment::{Environment, PeerCount, RngChoice, TransactionCount};
+pub use self::implementation::*;
 pub use self::network::Network;
 pub use self::peer::Peer;
 pub use self::schedule::*;

--- a/tests/utils/peer.rs
+++ b/tests/utils/peer.rs
@@ -6,23 +6,23 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use super::{BlockImpl, ParsecImpl};
 use parsec::mock::{PeerId, Transaction};
-use parsec::{Block, Parsec};
 use std::collections::BTreeSet;
 use std::fmt::{self, Debug, Formatter};
 
-pub struct Peer {
+pub struct Peer<P: ParsecImpl> {
     pub id: PeerId,
-    pub parsec: Parsec<Transaction, PeerId>,
+    pub parsec: P,
     // The blocks returned by `parsec.poll()`, held in the order in which they were returned.
-    pub blocks: Vec<Block<Transaction, PeerId>>,
+    pub blocks: Vec<P::Block>,
 }
 
-impl Peer {
+impl<P: ParsecImpl> Peer<P> {
     pub fn new(id: PeerId, genesis_group: &BTreeSet<PeerId>) -> Self {
         Self {
             id: id.clone(),
-            parsec: Parsec::new(id, genesis_group),
+            parsec: P::new(id, genesis_group),
             blocks: vec![],
         }
     }
@@ -43,12 +43,12 @@ impl Peer {
     }
 
     // Returns the payloads of `self.blocks` in the order in which they were returned by `poll()`.
-    pub fn blocks_payloads(&self) -> Vec<&Transaction> {
-        self.blocks.iter().map(Block::payload).collect()
+    pub fn blocks_payloads(&self) -> Vec<Transaction> {
+        self.blocks.iter().map(P::Block::payload).collect()
     }
 }
 
-impl Debug for Peer {
+impl<P: ParsecImpl> Debug for Peer<P> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(formatter, "{:?}: Blocks: {:?}", self.id, self.blocks)
     }

--- a/tests/utils/schedule.rs
+++ b/tests/utils/schedule.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Environment;
+use super::ParsecImpl;
 use parsec::mock::{PeerId, Transaction};
 #[cfg(feature = "dump-graphs")]
 use parsec::DIR;
@@ -413,7 +414,7 @@ impl Schedule {
     // The `let_and_return` clippy lint is allowed since it is actually necessary to create the
     // `result` variable so the result can be saved when the `dump-graphs` feature is used.
     #[cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
-    pub fn new(env: &mut Environment, options: &ScheduleOptions) -> Schedule {
+    pub fn new<P: ParsecImpl>(env: &mut Environment<P>, options: &ScheduleOptions) -> Schedule {
         let mut peers: Vec<_> = env.network.peers.iter().map(|p| p.id.clone()).collect();
         let num_peers = env.network.peers.len();
         let mut pending = PendingTransactions::new(&mut env.rng, &peers, &env.transactions);


### PR DESCRIPTION
This PR makes the further integration of the FFI testing much easier and allows for code reuse.

I.e. instead of introducing a new test suite and duplicating the code, we can just make a new implementation struct calling into FFI functions.