### PR TITLE
MAID-3139: Send the Schedule output to lower log level

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -54,6 +54,8 @@
     variant_size_differences
 )]
 
+#[macro_use]
+extern crate log;
 extern crate maidsafe_utilities;
 extern crate parsec;
 extern crate rand;
@@ -271,6 +273,7 @@ proptest! {
         },
         ..Default::default()
     }) {
+        let _ = maidsafe_utilities::log::init(true);
         env.network.execute_schedule(sched);
 
         let result = env.network.blocks_all_in_sequence();

--- a/tests/utils/proptest/schedule.rs
+++ b/tests/utils/proptest/schedule.rs
@@ -236,15 +236,15 @@ impl ValueTree for ScheduleValueTree {
     type Value = (Environment, Schedule);
 
     fn current(&self) -> (Environment, Schedule) {
-        println!("Scheduling with options: {:?}", self.opts.current());
+        trace!("Scheduling with options: {:?}", self.opts.current());
         let env = self.env.current();
-        println!(
+        trace!(
             "{} peers, {} transactions",
             env.network.peers.len(),
             env.transactions.len()
         );
         let schedule = self.filtered_schedule(&env);
-        println!("{:?}", schedule);
+        trace!("{:?}", schedule);
         (env, schedule)
     }
 


### PR DESCRIPTION
Send the Schedule output to a lower log level to avoid hiding the
directory where the graphs go from the output.

Note that the Schedule output is still logged to schedule.txt when
dumping graphs.

MAID-3139