### PR TITLE
MAID-3044: add observation enum

### DIFF
--- a/dev_utils/src/network.rs
+++ b/dev_utils/src/network.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use parsec::mock::{self, PeerId, Transaction};
-use parsec::{Request, Response};
+use parsec::{Request, Response, Observation};
 use peer::Peer;
 use schedule::{self, RequestTiming, Schedule, ScheduleEvent};
 use std::collections::{BTreeMap, BTreeSet};
@@ -30,9 +30,9 @@ pub struct Network {
 
 type DifferingBlocksOrder<'a> = (
     &'a PeerId,
-    Vec<&'a Transaction>,
+    Vec<&'a Observation<Transaction, PeerId>>,
     &'a PeerId,
-    Vec<&'a Transaction>,
+    Vec<&'a Observation<Transaction, PeerId>>,
 );
 
 impl Network {

--- a/dev_utils/src/peer.rs
+++ b/dev_utils/src/peer.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use parsec::mock::{PeerId, Transaction};
-use parsec::{self, Block, Parsec};
+use parsec::{self, Block, Parsec, Observation};
 use std::collections::BTreeSet;
 use std::fmt::{self, Debug, Formatter};
 
@@ -43,7 +43,7 @@ impl Peer {
     }
 
     // Returns the payloads of `self.blocks` in the order in which they were returned by `poll()`.
-    pub fn blocks_payloads(&self) -> Vec<&Transaction> {
+    pub fn blocks_payloads(&self) -> Vec<&Observation<Transaction, PeerId>> {
         self.blocks.iter().map(Block::payload).collect()
     }
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -63,7 +63,7 @@ extern crate unwrap;
 use clap::{App, Arg};
 use maidsafe_utilities::{log, SeededRng};
 use parsec::mock::{self, PeerId, Transaction};
-use parsec::{Block, Parsec};
+use parsec::{Block, Observation, Parsec};
 use rand::Rng;
 use std::collections::BTreeSet;
 use std::process;
@@ -114,7 +114,7 @@ impl Peer {
         }
     }
 
-    fn blocks_payloads(&self) -> Vec<&Transaction> {
+    fn blocks_payloads(&self) -> Vec<&Observation<Transaction, PeerId>> {
         self.blocks.iter().map(Block::payload).collect::<Vec<_>>()
     }
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -9,20 +9,21 @@
 use error::Error;
 use id::{Proof, PublicId};
 use network_event::NetworkEvent;
+use observation::Observation;
 use std::collections::{BTreeMap, BTreeSet};
 use vote::Vote;
 
-/// A struct representing a collection of votes by peers for a network event of type `T`.
+/// A struct representing a collection of votes by peers for an `Observation`.
 #[serde(bound = "")]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug)]
 pub struct Block<T: NetworkEvent, P: PublicId> {
-    payload: T,
+    payload: Observation<T, P>,
     proofs: BTreeSet<Proof<P>>,
 }
 
 impl<T: NetworkEvent, P: PublicId> Block<T, P> {
     /// Creates a `Block` from `payload` and `votes`.
-    pub fn new(payload: T, votes: &BTreeMap<P, Vote<T, P>>) -> Result<Self, Error> {
+    pub fn new(payload: Observation<T, P>, votes: &BTreeMap<P, Vote<T, P>>) -> Result<Self, Error> {
         let proofs: BTreeSet<Proof<P>> = votes
             .iter()
             .filter_map(|(public_id, vote)| {
@@ -39,7 +40,7 @@ impl<T: NetworkEvent, P: PublicId> Block<T, P> {
     }
 
     /// Returns the payload of this block.
-    pub fn payload(&self) -> &T {
+    pub fn payload(&self) -> &Observation<T, P> {
         &self.payload
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ mod hash;
 mod id;
 mod meta_vote;
 mod network_event;
+mod observation;
 mod parsec;
 mod peer_list;
 mod round_hash;
@@ -106,6 +107,7 @@ pub use error::Error;
 pub use gossip::{Request, Response};
 pub use id::{Proof, PublicId, SecretId};
 pub use network_event::NetworkEvent;
+pub use observation::Observation;
 pub use parsec::{is_supermajority, Parsec};
 pub use vote::Vote;
 

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use id::PublicId;
+use network_event::NetworkEvent;
+
+/// An enum of the various network events for which a peer can vote.
+#[serde(bound = "")]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug)]
+pub enum Observation<T: NetworkEvent, P: PublicId> {
+    /// Vote to add the indicated peer to the network.
+    Add(P),
+    /// Vote to remove the indicated peer from the network.
+    Remove(P),
+    /// Vote for an event which is opaque to Parsec.
+    OpaquePayload(T),
+}

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -9,25 +9,26 @@
 use error::Error;
 use id::{Proof, PublicId, SecretId};
 use network_event::NetworkEvent;
+use observation::Observation;
 use serialise;
 
-/// A helper struct carrying some data and a signature of this data.
+/// A helper struct carrying an `Observation` and a signature of this `Observation`.
 #[serde(bound = "")]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug)]
 pub struct Vote<T: NetworkEvent, P: PublicId> {
-    payload: T,
+    payload: Observation<T, P>,
     signature: P::Signature,
 }
 
 impl<T: NetworkEvent, P: PublicId> Vote<T, P> {
     /// Creates a `Vote` for `payload`.
-    pub fn new<S: SecretId<PublicId = P>>(secret_id: &S, payload: T) -> Self {
+    pub fn new<S: SecretId<PublicId = P>>(secret_id: &S, payload: Observation<T, P>) -> Self {
         let signature = secret_id.sign_detached(&serialise(&payload));
         Self { payload, signature }
     }
 
     /// Returns the payload being voted for.
-    pub fn payload(&self) -> &T {
+    pub fn payload(&self) -> &Observation<T, P> {
         &self.payload
     }
 


### PR DESCRIPTION
This provides visibility of some network events about which Parsec is interested; namely add and remove peer.