### PR TITLE
chore/parsec: concentrate dot-handling in event

### DIFF
--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -351,25 +351,6 @@ mod detail {
         }
     }
 
-    fn write_full<T: NetworkEvent, P: PublicId>(
-        writer: &mut Write,
-        gossip_graph: &BTreeMap<Hash, Event<T, P>>,
-    ) -> io::Result<()> {
-        for (hash, event) in gossip_graph.iter() {
-            writeln!(writer, "/// {{ {:?}", hash)?;
-            writeln!(writer, "/// cause: {}", event.cause())?;
-            writeln!(
-                writer,
-                "/// interesting_content: {:?}",
-                event.interesting_content
-            )?;
-            writeln!(writer, "/// last_ancestors: {:?}", event.last_ancestors())?;
-
-            writeln!(writer, "/// }}")?;
-        }
-        Ok(())
-    }
-
     fn write_gossip_graph_dot<T: NetworkEvent, P: PublicId>(
         writer: &mut Write,
         gossip_graph: &BTreeMap<Hash, Event<T, P>>,
@@ -393,7 +374,9 @@ mod detail {
         writeln!(writer, "  splines=false")?;
         writeln!(writer, "  rankdir=BT")?;
 
-        write_full(writer, gossip_graph)?;
+        for event in gossip_graph.values() {
+            event.write_to_dot_format(writer)?;
+        }
 
         for node in &nodes {
             let mut events: Vec<&Event<T, P>> = gossip_graph

--- a/src/gossip/cause.rs
+++ b/src/gossip/cause.rs
@@ -14,7 +14,7 @@ use vote::Vote;
 
 #[serde(bound = "")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub(crate) enum Cause<T: NetworkEvent, P: PublicId> {
+pub(super) enum Cause<T: NetworkEvent, P: PublicId> {
     // Hashes are the latest `Event` of own and the peer which sent the request.
     Request {
         self_parent: Hash,

--- a/src/gossip/mod.rs
+++ b/src/gossip/mod.rs
@@ -12,8 +12,6 @@ mod event;
 mod messages;
 mod packed_event;
 
-#[cfg(test)]
-pub(super) use self::cause::Cause;
 pub(super) use self::event::Event;
 pub use self::messages::{Request, Response};
 pub(super) use self::packed_event::PackedEvent;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -20,12 +20,6 @@ const NAMES: &[&str] = &[
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug)]
 pub struct Signature(String);
 
-impl Signature {
-    pub fn new(sig: &str) -> Self {
-        Signature(sig.to_string())
-    }
-}
-
 /// **NOT FOR PRODUCTION USE**: Mock type implementing `PublicId` and `SecretId` traits.  For
 /// non-mocks, these two traits must be implemented by two separate types; a public key and secret
 /// key respectively.

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -21,12 +21,6 @@ pub struct Vote<T: NetworkEvent, P: PublicId> {
 }
 
 impl<T: NetworkEvent, P: PublicId> Vote<T, P> {
-    /// Creates a `Vote` with input parameters. Only being used by the dot_parser.
-    #[cfg(test)]
-    pub fn new_from_input(payload: Observation<T, P>, signature: P::Signature) -> Self {
-        Self { payload, signature }
-    }
-
     /// Creates a `Vote` for `payload`.
     pub fn new<S: SecretId<PublicId = P>>(secret_id: &S, payload: Observation<T, P>) -> Self {
         let signature = secret_id.sign_detached(&serialise(&payload));


### PR DESCRIPTION
This reduces almost all of the feature-gated functionality required for dot file reading and writing to just dump_graph.rs, dot_parser.rs and event.rs.