### PR TITLE
MAID-2974: Add constructor initialising Parsec using dot_parser

### DIFF
--- a/src/dot_parser.rs
+++ b/src/dot_parser.rs
@@ -21,9 +21,9 @@ use std::path::Path;
 #[allow(unused)]
 /// The event graph and associated info that were parsed from the dumped dot file.
 pub struct ParsedContents {
-    events: BTreeMap<Hash, Event<Transaction, PeerId>>,
-    events_order: Vec<Hash>,
-    meta_votes: BTreeMap<Hash, BTreeMap<PeerId, Vec<MetaVote>>>,
+    pub(crate) events: BTreeMap<Hash, Event<Transaction, PeerId>>,
+    pub(crate) events_order: Vec<Hash>,
+    pub(crate) meta_votes: BTreeMap<Hash, BTreeMap<PeerId, Vec<MetaVote>>>,
 }
 
 /// Reading a dumped dot file and return with parsed event graph and associated info.

--- a/src/meta_vote.rs
+++ b/src/meta_vote.rs
@@ -88,7 +88,7 @@ impl BoolSet {
 }
 
 // This holds the state of a (binary) meta vote about which we're trying to achieve consensus.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq)]
 pub(crate) struct MetaVote {
     pub round: usize,
     pub step: Step,


### PR DESCRIPTION
To help with functional testing, create an extra constructor for Parsec
tagged that can initialise a partial Parsec with a few events from a
gossip graph using the dot_parser.

MAID-2974