### PR TITLE
MAID-3152: Use safe_crypto signing key pair

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/maidsafe/parsec"
 version = "0.5.0"
 
 [dependencies]
-lazy_static = { version = "~1.0.1", optional = true }
+lazy_static = "~1.0.1"
 log = "~0.3.8"
 maidsafe_utilities = "~0.17.0"
 proptest = "~0.8.6"
@@ -28,7 +28,7 @@ clap = "~2.31.2"
 criterion = "~0.2.5"
 
 [features]
-dump-graphs = ["lazy_static"]
+dump-graphs = []
 testing = ["maidsafe_utilities/testing"]
 default = ["safe_crypto/mock"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = "~1.0.66"
 serde_derive = "~1.0.66"
 tiny-keccak = "~1.4.2"
 unwrap = "~1.2.0"
+safe_crypto = "0.4.0"
 
 [dev-dependencies]
 clap = "~2.31.2"
@@ -29,6 +30,7 @@ criterion = "~0.2.5"
 [features]
 dump-graphs = ["lazy_static"]
 testing = ["maidsafe_utilities/testing"]
+default = ["safe_crypto/mock"]
 
 [[bench]]
 name = "bench"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@
     variant_size_differences
 )]
 
-#[cfg(feature = "dump-graphs")]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ extern crate tiny_keccak;
 #[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
 #[macro_use]
 extern crate unwrap;
+extern crate safe_crypto;
 
 mod block;
 mod dump_graph;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -20,6 +20,13 @@ const NAMES: &[&str] = &[
     "Lucy", "Mike", "Nina", "Oran", "Paul", "Quin", "Rose", "Stan", "Tina",
 ];
 
+lazy_static! {
+    static ref PEERS: Vec<PeerId> = NAMES
+        .iter()
+        .map(|name| PeerId::new_with_random_keypair(name))
+        .collect();
+}
+
 /// **NOT FOR PRODUCTION USE**: Mock signature type.
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Signature(SafeSignature);
@@ -42,6 +49,14 @@ pub struct PeerId {
 
 impl PeerId {
     pub fn new(id: &str) -> Self {
+        PEERS
+            .iter()
+            .find(|peer| peer.id == id)
+            .unwrap_or(&PeerId::new_with_random_keypair(id))
+            .clone()
+    }
+
+    fn new_with_random_keypair(id: &str) -> Self {
         let (pub_sign, sec_sign) = gen_sign_keypair();
         Self {
             id: id.to_string(),

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -9,7 +9,11 @@
 use id::{PublicId, SecretId};
 use network_event::NetworkEvent;
 use rand::{Rand, Rng};
+use safe_crypto::Signature as SafeSignature;
+use safe_crypto::{gen_sign_keypair, PublicSignKey, SecretSignKey};
+use std::cmp::Ordering;
 use std::fmt::{self, Debug, Display, Formatter};
+use std::hash::{Hash, Hasher};
 
 const NAMES: &[&str] = &[
     "Alice", "Bob", "Carol", "Dave", "Eric", "Fred", "Gina", "Hank", "Iris", "Judy", "Kent",
@@ -17,20 +21,33 @@ const NAMES: &[&str] = &[
 ];
 
 /// **NOT FOR PRODUCTION USE**: Mock signature type.
-#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug)]
-pub struct Signature(String);
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Signature(SafeSignature);
+
+impl Debug for Signature {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "..")
+    }
+}
 
 /// **NOT FOR PRODUCTION USE**: Mock type implementing `PublicId` and `SecretId` traits.  For
 /// non-mocks, these two traits must be implemented by two separate types; a public key and secret
 /// key respectively.
-#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct PeerId {
     id: String,
+    pub_sign: PublicSignKey,
+    sec_sign: SecretSignKey,
 }
 
 impl PeerId {
     pub fn new(id: &str) -> Self {
-        Self { id: id.to_string() }
+        let (pub_sign, sec_sign) = gen_sign_keypair();
+        Self {
+            id: id.to_string(),
+            pub_sign,
+            sec_sign,
+        }
     }
 
     // Only being used by the dot_parser.
@@ -54,10 +71,37 @@ impl Debug for PeerId {
     }
 }
 
+impl Hash for PeerId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.pub_sign.hash(state);
+    }
+}
+
+impl PartialEq for PeerId {
+    fn eq(&self, other: &PeerId) -> bool {
+        self.id == other.id && self.pub_sign == other.pub_sign
+    }
+}
+
+impl Eq for PeerId {}
+
+impl PartialOrd for PeerId {
+    fn partial_cmp(&self, other: &PeerId) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PeerId {
+    fn cmp(&self, other: &PeerId) -> Ordering {
+        self.id.cmp(&other.id)
+    }
+}
+
 impl PublicId for PeerId {
     type Signature = Signature;
-    fn verify_signature(&self, _signature: &Self::Signature, _data: &[u8]) -> bool {
-        true
+    fn verify_signature(&self, signature: &Self::Signature, data: &[u8]) -> bool {
+        self.pub_sign.verify_detached(&signature.0, data)
     }
 }
 
@@ -66,8 +110,8 @@ impl SecretId for PeerId {
     fn public_id(&self) -> &Self::PublicId {
         &self
     }
-    fn sign_detached(&self, _data: &[u8]) -> Signature {
-        Signature(format!("of {:?}", self))
+    fn sign_detached(&self, data: &[u8]) -> Signature {
+        Signature(self.sec_sign.sign_detached(data))
     }
 }
 


### PR DESCRIPTION
To be able to properly test other components relying on signature
verification, plug in safe_crypto into PeerId by adding a public and
private signing pair. We want to keep the traits inside id.rs as they
are.

MAID-3152