### PR TITLE
MAID-3140: Rename test_duplicate_votes_before_gossip

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -130,7 +130,7 @@ mod test {
     }
 
     #[test]
-    fn duplicate_votes_before_gossip() {
+    fn duplicate_vote_is_reduced_to_single() {
         let mut env = Environment::new(&PeerCount(4), &ObservationCount(1), SEED);
 
         let schedule = Schedule::new(

--- a/tutorial.md
+++ b/tutorial.md
@@ -39,7 +39,7 @@ The output must contain lines analogous to these:
 Writing dot files in /tmp/parsec_graphs/53srr3/test_minimal_network
 Writing dot files in /tmp/parsec_graphs/53srr3/test_multiple_votes_before_gossip
 Writing dot files in /tmp/parsec_graphs/53srr3/test_faulty_third_terminate_concurrently
-Writing dot files in /tmp/parsec_graphs/53srr3/test_duplicate_votes_before_gossip
+Writing dot files in /tmp/parsec_graphs/53srr3/test_duplicate_vote_is_reduced_to_single
 Writing dot files in /tmp/parsec_graphs/53srr3/test_faulty_third_never_gossip
 Writing dot files in /tmp/parsec_graphs/53srr3/test_faulty_third_terminate_at_random_points
 Writing dot files in /tmp/parsec_graphs/53srr3/test_multiple_votes_during_gossip


### PR DESCRIPTION
When looking at the output of the test:
test_duplicate_votes_before_gossip, one observes no duplicate vote. This
is because the behaviour of PARSEC is to only vote for a given event
once.

To make this obvious when casually browsing the test output, rename the
test to test_duplicate_vote_is_reduced_to_single.

MAID-3140