### PR TITLE
MAID-3191: Enable handwritten schedules, improve testing framework

### DIFF
--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -33,16 +33,16 @@ pub struct Network {
 }
 
 #[derive(Debug)]
-pub struct BlocksOrder<'a> {
-    peer: &'a PeerId,
-    order: Vec<&'a Observation>,
+pub struct BlocksOrder {
+    peer: PeerId,
+    order: Vec<Observation>,
 }
 
 #[derive(Debug)]
-pub enum ConsensusError<'a> {
+pub enum ConsensusError {
     DifferingBlocksOrder {
-        order_1: BlocksOrder<'a>,
-        order_2: BlocksOrder<'a>,
+        order_1: BlocksOrder,
+        order_2: BlocksOrder,
     },
     WrongBlocksNumber {
         expected: usize,
@@ -94,12 +94,12 @@ impl Network {
         {
             Err(ConsensusError::DifferingBlocksOrder {
                 order_1: BlocksOrder {
-                    peer: &first_peer.id,
-                    order: payloads,
+                    peer: first_peer.id.clone(),
+                    order: payloads.into_iter().cloned().collect(),
                 },
                 order_2: BlocksOrder {
-                    peer: &peer.id,
-                    order: peer.blocks_payloads(),
+                    peer: peer.id.clone(),
+                    order: peer.blocks_payloads().into_iter().cloned().collect(),
                 },
             })
         } else {

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -89,6 +89,11 @@ impl Peer {
         }
     }
 
+    /// Returns self.blocks
+    pub fn blocks(&self) -> impl Iterator<Item = &Block<Transaction, PeerId>> {
+        self.blocks.iter()
+    }
+
     /// Returns the payloads of `self.blocks` in the order in which they were returned by `poll()`.
     pub fn blocks_payloads(&self) -> Vec<&Observation> {
         self.blocks.iter().map(Block::payload).collect()

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -90,8 +90,8 @@ impl Peer {
     }
 
     /// Returns self.blocks
-    pub fn blocks(&self) -> impl Iterator<Item = &Block<Transaction, PeerId>> {
-        self.blocks.iter()
+    pub fn blocks(&self) -> &[Block<Transaction, PeerId>] {
+        &self.blocks
     }
 
     /// Returns the payloads of `self.blocks` in the order in which they were returned by `poll()`.

--- a/src/dev_utils/schedule.rs
+++ b/src/dev_utils/schedule.rs
@@ -321,7 +321,7 @@ impl Default for ScheduleOptions {
     }
 }
 
-enum ObservationEvent {
+pub enum ObservationEvent {
     Opaque(Transaction),
     AddPeer(PeerId),
     RemovePeer(PeerId),
@@ -344,7 +344,7 @@ impl ObservationEvent {
     }
 }
 
-struct ObservationSchedule {
+pub struct ObservationSchedule {
     pub genesis: BTreeSet<PeerId>,
     /// A `Vec` of pairs (step number, event), carrying information about what events happen at
     /// which steps
@@ -521,14 +521,22 @@ impl Schedule {
         }
     }
 
+    pub fn new(env: &mut Environment, options: &ScheduleOptions) -> Schedule {
+        let obs_schedule = ObservationSchedule::gen(&mut env.rng, options);
+        Self::from_observation_schedule(env, options, obs_schedule)
+    }
+
     /// Creates a new pseudo-random schedule based on the given options
     ///
     /// The `let_and_return` clippy lint is allowed since it is actually necessary to create the
     /// `result` variable so the result can be saved when the `dump-graphs` feature is used.
     #[cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
-    pub fn new(env: &mut Environment, options: &ScheduleOptions) -> Schedule {
+    pub fn from_observation_schedule(
+        env: &mut Environment,
+        options: &ScheduleOptions,
+        mut obs_schedule: ObservationSchedule,
+    ) -> Schedule {
         let mut pending = PendingObservations::new(options);
-        let mut obs_schedule = ObservationSchedule::gen(&mut env.rng, options);
         // the +1 below is to account for genesis
         let num_observations = obs_schedule.count_observations() + 1;
 

--- a/src/meta_vote.rs
+++ b/src/meta_vote.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use parsec::is_more_than_two_thirds;
 use std::collections::BTreeMap;
 use std::fmt::{self, Debug, Formatter};
 use std::iter;
@@ -414,7 +415,7 @@ impl MetaVoteCounts {
     }
 
     fn is_super_majority(&self, count: usize) -> bool {
-        3 * count > 2 * self.total_peers
+        is_more_than_two_thirds(count, self.total_peers)
     }
 
     fn at_least_one_third(&self, count: usize) -> bool {

--- a/src/meta_vote.rs
+++ b/src/meta_vote.rs
@@ -213,7 +213,7 @@ impl MetaVote {
                 return None;
             }
             let counts = MetaVoteCounts::new(parent, others, total_peers);
-            if counts.is_super_majority(counts.aux_values_set()) {
+            if counts.is_supermajority(counts.aux_values_set()) {
                 let coin_toss = coin_tosses.get(&parent.round);
                 let mut next = parent.clone();
                 Self::increase_step(&mut next, &counts, coin_toss.cloned());
@@ -252,10 +252,10 @@ impl MetaVote {
     }
 
     fn calculate_new_bin_values(meta_vote: &mut MetaVote, counts: &mut MetaVoteCounts) {
-        if counts.is_super_majority(counts.estimates_true) && meta_vote.bin_values.insert(true) {
+        if counts.is_supermajority(counts.estimates_true) && meta_vote.bin_values.insert(true) {
             counts.bin_values_true += 1;
         }
-        if counts.is_super_majority(counts.estimates_false) && meta_vote.bin_values.insert(false) {
+        if counts.is_supermajority(counts.estimates_false) && meta_vote.bin_values.insert(false) {
             counts.bin_values_false += 1;
         }
     }
@@ -287,14 +287,14 @@ impl MetaVote {
     fn calculate_new_decision(meta_vote: &mut MetaVote, counts: &MetaVoteCounts) {
         let opt_decision = match meta_vote.step {
             Step::ForcedTrue => if meta_vote.bin_values.contains(true)
-                && counts.is_super_majority(counts.aux_values_true)
+                && counts.is_supermajority(counts.aux_values_true)
             {
                 Some(true)
             } else {
                 counts.decision
             },
             Step::ForcedFalse => if meta_vote.bin_values.contains(false)
-                && counts.is_super_majority(counts.aux_values_false)
+                && counts.is_supermajority(counts.aux_values_false)
             {
                 Some(false)
             } else {
@@ -321,25 +321,25 @@ impl MetaVote {
         // Set the estimates as per the concrete coin toss rules.
         match new_meta_vote.step {
             Step::ForcedTrue => {
-                if counts.is_super_majority(counts.aux_values_false) {
+                if counts.is_supermajority(counts.aux_values_false) {
                     new_meta_vote.estimates = BoolSet::from_bool(false);
-                } else if !counts.is_super_majority(counts.aux_values_true) {
+                } else if !counts.is_supermajority(counts.aux_values_true) {
                     new_meta_vote.estimates = BoolSet::from_bool(true);
                 }
                 new_meta_vote.step = Step::ForcedFalse;
             }
             Step::ForcedFalse => {
-                if counts.is_super_majority(counts.aux_values_true) {
+                if counts.is_supermajority(counts.aux_values_true) {
                     new_meta_vote.estimates = BoolSet::from_bool(true);
-                } else if !counts.is_super_majority(counts.aux_values_false) {
+                } else if !counts.is_supermajority(counts.aux_values_false) {
                     new_meta_vote.estimates = BoolSet::from_bool(false);
                 }
                 new_meta_vote.step = Step::GenuineFlip;
             }
             Step::GenuineFlip => {
-                if counts.is_super_majority(counts.aux_values_true) {
+                if counts.is_supermajority(counts.aux_values_true) {
                     new_meta_vote.estimates = BoolSet::from_bool(true);
-                } else if counts.is_super_majority(counts.aux_values_false) {
+                } else if counts.is_supermajority(counts.aux_values_false) {
                     new_meta_vote.estimates = BoolSet::from_bool(false);
                 } else if let Some(coin_toss_result) = coin_toss {
                     new_meta_vote.estimates = BoolSet::from_bool(coin_toss_result);
@@ -414,7 +414,7 @@ impl MetaVoteCounts {
         self.aux_values_true + self.aux_values_false
     }
 
-    fn is_super_majority(&self, count: usize) -> bool {
+    fn is_supermajority(&self, count: usize) -> bool {
         is_more_than_two_thirds(count, self.total_peers)
     }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -27,12 +27,17 @@ use std::iter;
 
 pub type IsInterestingEventFn<P> = fn(voters: &BTreeSet<&P>, current_peers: &BTreeSet<&P>) -> bool;
 
+/// Returns whether `small` is more than two thirds of `large`
+pub fn is_more_than_two_thirds(small: usize, large: usize) -> bool {
+    3 * small > 2 * large
+}
+
 /// Function which can be used as `is_interesting_event` in
 /// [`Parsec::new()`](struct.Parsec.html#method.new) and which returns `true` if there are >2/3
 /// `voters` which are members of `current_peers`.
 pub fn is_supermajority<P: Ord>(voters: &BTreeSet<&P>, current_peers: &BTreeSet<&P>) -> bool {
     let valid_voter_count = current_peers.intersection(voters).count();
-    3 * valid_voter_count > 2 * current_peers.len()
+    is_more_than_two_thirds(valid_voter_count, current_peers.len())
 }
 
 /// The main object which manages creating and receiving gossip about network events from peers, and

--- a/src/peer_list.rs
+++ b/src/peer_list.rs
@@ -13,6 +13,7 @@ use id::SecretId;
 #[cfg(test)]
 use mock::{PeerId, Transaction};
 use network_event::NetworkEvent;
+use parsec::is_more_than_two_thirds;
 use serialise;
 use std::collections::btree_map::{self, BTreeMap, Entry};
 use std::fmt::{self, Debug, Formatter};
@@ -106,7 +107,7 @@ impl<S: SecretId> PeerList<S> {
     /// Checks whether the input count becomes the super majority of the members
     /// that can vote.
     pub fn is_super_majority(&self, count: usize) -> bool {
-        3 * count > 2 * self.voters().count()
+        is_more_than_two_thirds(count, self.voters().count())
     }
 
     /// Returns the hash of the last event created by this peer. Returns `None` if cannot find.


### PR DESCRIPTION
This also improves the testing framework:
* blocks are now being checked for only being signed by valid voters
* error reporting is improved in cases when test is interrupted by broken consensus (can supersede #112)