### PR TITLE
Fix the Validity property of consensus

### DIFF
--- a/input_graphs/parsec_functional_tests_add_peer/add_fred.dot
+++ b/input_graphs/parsec_functional_tests_add_peer/add_fred.dot
@@ -5,397 +5,397 @@ digraph GossipGraph {
 /// peer_states: {Alice: "PeerState(VOTE|SEND|RECV)", Bob: "PeerState(VOTE|SEND|RECV)", Carol: "PeerState(VOTE|SEND|RECV)", Dave: "PeerState(VOTE|SEND|RECV)", Eric: "PeerState(VOTE|SEND|RECV)"}
 /// { 0401d8..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 8, Carol: 6, Dave: 4, Eric: 7}
 /// }
 /// { 0be3da..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 2, Carol: 2, Dave: 4, Eric: 4}
 /// }
 /// { 0f0c81..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 14, Bob: 13, Carol: 13, Dave: 13, Eric: 13}
 /// }
 /// { 12d233..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 11, Carol: 12, Dave: 13, Eric: 13}
 /// }
 /// { 17fc8d..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 2, Carol: 4, Dave: 4, Eric: 4}
 /// }
 /// { 1d133e..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 14, Bob: 15, Carol: 13, Dave: 15, Eric: 13}
 /// }
 /// { 1de169..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 14, Bob: 14, Carol: 13, Dave: 13, Eric: 13}
 /// }
 /// { 1ee1ea..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 2, Carol: 2, Dave: 2, Eric: 3}
 /// }
 /// { 243f9b..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 2, Carol: 2, Dave: 4, Eric: 3}
 /// }
 /// { 283af0..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 14, Bob: 13, Carol: 13, Dave: 15, Eric: 13}
 /// }
 /// { 285d4a..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 5, Bob: 5, Carol: 4, Dave: 4, Eric: 4}
 /// }
 /// { 2d9c69..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 7, Carol: 8, Dave: 8, Eric: 7}
 /// }
 /// { 2ef82a..
 /// cause: Observation(Add(Fred))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 2, Carol: 2, Dave: 6, Eric: 4}
 /// }
 /// { 305576..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 11, Carol: 13, Dave: 13, Eric: 13}
 /// }
 /// { 3529f4..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 8, Carol: 11, Dave: 9, Eric: 11}
 /// }
 /// { 3a6b54..
 /// cause: Response
-/// interesting_content: {Add(Fred)}
+/// interesting_content: [Add(Fred)]
 /// last_ancestors: {Alice: 6, Bob: 9, Carol: 9, Dave: 7, Eric: 7}
 /// }
 /// { 3d95e4..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 13, Carol: 13, Dave: 13, Eric: 13}
 /// }
 /// { 3dd87c..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 13, Bob: 11, Carol: 12, Dave: 13, Eric: 11}
 /// }
 /// { 401025..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 13, Carol: 14, Dave: 13, Eric: 13}
 /// }
 /// { 416f90..
 /// cause: Observation(Genesis({Alice, Bob, Carol, Dave, Eric}))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Bob: 1}
 /// }
 /// { 417f5a..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 11, Carol: 12, Dave: 14, Eric: 13}
 /// }
 /// { 435be2..
 /// cause: Request
-/// interesting_content: {Add(Fred)}
+/// interesting_content: [Add(Fred)]
 /// last_ancestors: {Alice: 6, Bob: 7, Carol: 8, Dave: 7, Eric: 7}
 /// }
 /// { 44802a..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 14, Bob: 15, Carol: 15, Dave: 15, Eric: 15}
 /// }
 /// { 44b01b..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 10, Carol: 10, Dave: 9, Eric: 11}
 /// }
 /// { 463e55..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 8, Carol: 10, Dave: 7, Eric: 9}
 /// }
 /// { 47ac53..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 5, Bob: 6, Carol: 4, Dave: 4, Eric: 4}
 /// }
 /// { 4ee0c8..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Carol: 2, Dave: 2, Eric: 1}
 /// }
 /// { 50c6a5..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Carol: 0}
 /// }
 /// { 57c856..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 8, Carol: 9, Dave: 7, Eric: 9}
 /// }
 /// { 5c5533..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 11, Carol: 12, Dave: 11, Eric: 11}
 /// }
 /// { 5fb390..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 14, Bob: 15, Carol: 15, Dave: 15, Eric: 13}
 /// }
 /// { 655532..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 2, Carol: 2, Dave: 5, Eric: 4}
 /// }
 /// { 659e9d..
 /// cause: Observation(Add(Fred))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 5, Carol: 6, Dave: 4, Eric: 4}
 /// }
 /// { 665ca3..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 2, Carol: 2, Dave: 2, Eric: 1}
 /// }
 /// { 67ceff..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Carol: 3, Dave: 2, Eric: 1}
 /// }
 /// { 74b811..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 7, Carol: 6, Dave: 4, Eric: 7}
 /// }
 /// { 77916c..
 /// cause: Observation(Add(Fred))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 10, Carol: 9, Dave: 9, Eric: 9}
 /// }
 /// { 80358a..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Bob: 2, Carol: 2, Dave: 2, Eric: 1}
 /// }
 /// { 821f15..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Carol: 2, Eric: 1}
 /// }
 /// { 8627d8..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Carol: 2, Eric: 2}
 /// }
 /// { 8d3f49..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 5, Carol: 4, Dave: 4, Eric: 4}
 /// }
 /// { 8de30c..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 7, Carol: 6, Dave: 4, Eric: 4}
 /// }
 /// { 8efa1a..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 8, Carol: 9, Dave: 7, Eric: 7}
 /// }
 /// { 91c17a..
 /// cause: Observation(Add(Fred))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 4, Carol: 2, Dave: 2, Eric: 1}
 /// }
 /// { 94ba43..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 5, Carol: 5, Dave: 4, Eric: 4}
 /// }
 /// { 956aa5..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Bob: 2, Carol: 2, Dave: 3, Eric: 1}
 /// }
 /// { 95961e..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 5, Carol: 6, Dave: 4, Eric: 4}
 /// }
 /// { 9868ef..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 5, Carol: 7, Dave: 4, Eric: 4}
 /// }
 /// { 9a6599..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 11, Carol: 12, Dave: 13, Eric: 11}
 /// }
 /// { 9aea8e..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 11, Carol: 13, Dave: 13, Eric: 14}
 /// }
 /// { 9b33e8..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 8, Carol: 9, Dave: 10, Eric: 9}
 /// }
 /// { 9dfe29..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 2, Carol: 4, Dave: 4, Eric: 5}
 /// }
 /// { a0ac51..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 12, Carol: 10, Dave: 11, Eric: 11}
 /// }
 /// { a3073b..
 /// cause: Observation(Genesis({Alice, Bob, Carol, Dave, Eric}))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Eric: 1}
 /// }
 /// { a92c26..
 /// cause: Observation(Genesis({Alice, Bob, Carol, Dave, Eric}))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Dave: 1}
 /// }
 /// { abbb12..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 9, Bob: 10, Carol: 9, Dave: 9, Eric: 9}
 /// }
 /// { b016b3..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 3, Carol: 2, Dave: 2, Eric: 1}
 /// }
 /// { b10d0c..
 /// cause: Request
-/// interesting_content: {Add(Fred)}
+/// interesting_content: [Add(Fred)]
 /// last_ancestors: {Alice: 8, Bob: 8, Carol: 9, Dave: 9, Eric: 9}
 /// }
 /// { b1b418..
 /// cause: Observation(Genesis({Alice, Bob, Carol, Dave, Eric}))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Carol: 1}
 /// }
 /// { b41198..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 8, Carol: 9, Dave: 9, Eric: 10}
 /// }
 /// { b438d4..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 2, Carol: 2, Dave: 4, Eric: 3}
 /// }
 /// { b496f3..
 /// cause: Observation(Add(Fred))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 2, Carol: 4, Dave: 4, Eric: 6}
 /// }
 /// { b5a216..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 7, Carol: 6, Dave: 4, Eric: 4}
 /// }
 /// { b68e32..
 /// cause: Response
-/// interesting_content: {Add(Fred)}
+/// interesting_content: [Add(Fred)]
 /// last_ancestors: {Alice: 6, Bob: 7, Carol: 6, Dave: 7, Eric: 8}
 /// }
 /// { b98cb7..
 /// cause: Observation(Genesis({Alice, Bob, Carol, Dave, Eric}))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 1}
 /// }
 /// { c0b638..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 11, Carol: 10, Dave: 11, Eric: 11}
 /// }
 /// { c151a7..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 2, Carol: 2, Dave: 2, Eric: 3}
 /// }
 /// { c2dd4f..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Dave: 0}
 /// }
 /// { c94909..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 11, Carol: 10, Dave: 9, Eric: 11}
 /// }
 /// { ca3ea5..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 10, Carol: 10, Dave: 9, Eric: 12}
 /// }
 /// { cda4a9..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 8, Carol: 10, Dave: 9, Eric: 11}
 /// }
 /// { e0064a..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Eric: 0}
 /// }
 /// { e8a201..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 11, Carol: 10, Dave: 9, Eric: 11}
 /// }
 /// { ea315d..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 8, Carol: 9, Dave: 9, Eric: 9}
 /// }
 /// { f1e228..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0}
 /// }
 /// { f4f960..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 10, Carol: 9, Dave: 9, Eric: 9}
 /// }
 /// { f75e95..
 /// cause: Request
-/// interesting_content: {Add(Fred)}
+/// interesting_content: [Add(Fred)]
 /// last_ancestors: {Alice: 6, Bob: 7, Carol: 6, Dave: 7, Eric: 7}
 /// }
 /// { f776cd..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 11, Carol: 12, Dave: 12, Eric: 11}
 /// }
 /// { f93793..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Bob: 0}
 /// }
     style=invis
@@ -629,7 +629,7 @@ D: [ { 0/0, est:{t} bin:{} aux:{} dec:{} }]
 E: [ { 0/0, est:{t} bin:{} aux:{} dec:{} }]"]
  "3529f4.." [fillcolor=white, label="C_11"]
  "3a6b54.." [fillcolor=white, label="B_9
-{Add(Fred)}"]
+[Add(Fred)]"]
  "3a6b54.." [shape=rectangle, style=filled, fillcolor=crimson]
  "3d95e4.." [ shape=rectangle, fillcolor=white, label="B_13
 A: [ { 0/0, est:{t} bin:{t} aux:{t} dec:{} }]
@@ -659,7 +659,7 @@ C: [ { 0/0, est:{t} bin:{} aux:{} dec:{} }]
 D: [ { 0/0, est:{t} bin:{} aux:{} dec:{} }]
 E: [ { 0/0, est:{t} bin:{} aux:{} dec:{} }]"]
  "435be2.." [fillcolor=white, label="C_8
-{Add(Fred)}"]
+[Add(Fred)]"]
  "435be2.." [shape=rectangle, style=filled, fillcolor=crimson]
  "44802a.." [ shape=rectangle, fillcolor=white, label="E_15
 A: [ { 0/0, est:{t} bin:{t} aux:{t} dec:{t} }]
@@ -732,7 +732,7 @@ Genesis({Alice, Bob, Carol, Dave, Eric})"]
  "abbb12.." [fillcolor=white, label="A_9"]
  "b016b3.." [fillcolor=white, label="B_3"]
  "b10d0c.." [fillcolor=white, label="A_8
-{Add(Fred)}"]
+[Add(Fred)]"]
  "b10d0c.." [shape=rectangle, style=filled, fillcolor=crimson]
  "b1b418.." [fillcolor=white, label="C_1
 Genesis({Alice, Bob, Carol, Dave, Eric})"]
@@ -744,7 +744,7 @@ Add(Fred)"]
  "b496f3.." [shape=rectangle, style=filled, fillcolor=cyan]
  "b5a216.." [fillcolor=white, label="B_7"]
  "b68e32.." [fillcolor=white, label="E_8
-{Add(Fred)}"]
+[Add(Fred)]"]
  "b68e32.." [shape=rectangle, style=filled, fillcolor=crimson]
  "b98cb7.." [fillcolor=white, label="A_1
 Genesis({Alice, Bob, Carol, Dave, Eric})"]
@@ -761,7 +761,7 @@ Genesis({Alice, Bob, Carol, Dave, Eric})"]
  "f1e228.." [fillcolor=white, label="A_0"]
  "f4f960.." [fillcolor=white, label="B_10"]
  "f75e95.." [fillcolor=white, label="D_7
-{Add(Fred)}"]
+[Add(Fred)]"]
  "f75e95.." [shape=rectangle, style=filled, fillcolor=crimson]
  "f776cd.." [ shape=rectangle, fillcolor=white, label="D_12
 A: [ { 0/0, est:{t} bin:{} aux:{} dec:{} }]

--- a/input_graphs/parsec_functional_tests_add_peer/naughty_carol.dot
+++ b/input_graphs/parsec_functional_tests_add_peer/naughty_carol.dot
@@ -5,377 +5,377 @@ digraph GossipGraph {
 /// peer_states: {Alice: "PeerState(VOTE|SEND|RECV)", Bob: "PeerState(VOTE|SEND|RECV)", Carol: "PeerState(VOTE|SEND|RECV)", Dave: "PeerState(VOTE|SEND|RECV)"}
 /// { 07092c..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 5, Bob: 4, Carol: 4, Dave: 5}
 /// }
 /// { 0d47f9..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 17, Bob: 14, Carol: 17, Dave: 16}
 /// }
 /// { 0f1b09..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 17, Bob: 16, Carol: 17, Dave: 18}
 /// }
 /// { 0f773d..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 9, Bob: 8, Carol: 10, Dave: 10}
 /// }
 /// { 142b66..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 10, Carol: 10, Dave: 12}
 /// }
 /// { 1664f5..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 11, Carol: 12, Dave: 10}
 /// }
 /// { 1c2555..
 /// cause: Observation(Add(Fred))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 6, Dave: 3}
 /// }
 /// { 1ec013..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 16, Bob: 14, Carol: 15, Dave: 14}
 /// }
 /// { 2037dc..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 17, Bob: 14, Carol: 15, Dave: 17}
 /// }
 /// { 256ed2..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 4, Dave: 5}
 /// }
 /// { 29fc7e..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 17, Bob: 16, Carol: 18, Dave: 16}
 /// }
 /// { 2b3614..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Bob: 2, Dave: 2}
 /// }
 /// { 2c6018..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 9, Bob: 8, Carol: 10, Dave: 9}
 /// }
 /// { 310a11..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 6, Carol: 7, Dave: 5}
 /// }
 /// { 31a39d..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 4, Carol: 4, Dave: 5}
 /// }
 /// { 3953c1..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 17, Bob: 16, Carol: 18, Dave: 19}
 /// }
 /// { 3ce5f5..
 /// cause: Observation(Genesis({Alice, Bob, Carol, Dave}))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Carol: 1}
 /// }
 /// { 3da3d3..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 10, Carol: 12, Dave: 10}
 /// }
 /// { 3e12d3..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 15, Bob: 15, Carol: 15, Dave: 16}
 /// }
 /// { 3f0191..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 6, Carol: 8, Dave: 5}
 /// }
 /// { 409398..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 2, Carol: 2, Dave: 1}
 /// }
 /// { 4120c9..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 7, Carol: 7, Dave: 7}
 /// }
 /// { 41b699..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 2, Dave: 1}
 /// }
 /// { 468e9e..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 14, Bob: 12, Carol: 13, Dave: 12}
 /// }
 /// { 4a89b9..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 8, Carol: 10, Dave: 10}
 /// }
 /// { 4e696d..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 9, Bob: 8, Carol: 7, Dave: 7}
 /// }
 /// { 4fbfde..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 12, Carol: 12, Dave: 13}
 /// }
 /// { 50c6a5..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Carol: 0}
 /// }
 /// { 55e209..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 4, Carol: 2, Dave: 3}
 /// }
 /// { 560d21..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 17, Bob: 16, Carol: 17, Dave: 16}
 /// }
 /// { 56d49a..
 /// cause: Observation(Genesis({Alice, Bob, Carol, Dave}))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 1}
 /// }
 /// { 581aec..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 9, Bob: 8, Carol: 9, Dave: 9}
 /// }
 /// { 624572..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 4, Carol: 7, Dave: 5}
 /// }
 /// { 66a869..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 4, Dave: 3}
 /// }
 /// { 66ea23..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 17, Bob: 16, Carol: 19, Dave: 19}
 /// }
 /// { 690e2c..
 /// cause: Observation(Add(Fred))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 4, Carol: 4, Dave: 5}
 /// }
 /// { 6e43c9..
 /// cause: Observation(Add(Fred))
-/// interesting_content: {Add(Fred)}
+/// interesting_content: [Add(Fred)]
 /// last_ancestors: {Alice: 12, Bob: 12, Carol: 12, Dave: 14}
 /// }
 /// { 71eb29..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 12, Carol: 12, Dave: 12}
 /// }
 /// { 779eaa..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 8, Carol: 10, Dave: 11}
 /// }
 /// { 800530..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 10, Carol: 10, Dave: 10}
 /// }
 /// { 80ccef..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 14, Bob: 12, Carol: 15, Dave: 15}
 /// }
 /// { 81d17e..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 4, Carol: 4, Dave: 6}
 /// }
 /// { 8b486f..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 5, Dave: 3}
 /// }
 /// { 8cff1c..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 3, Dave: 1}
 /// }
 /// { 8ffec2..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 17, Bob: 14, Carol: 15, Dave: 16}
 /// }
 /// { 93f42f..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 14, Bob: 12, Carol: 14, Dave: 12}
 /// }
 /// { 9b0c34..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 2, Carol: 2, Dave: 1}
 /// }
 /// { 9b3f14..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 2, Carol: 2, Dave: 3}
 /// }
 /// { 9fbed3..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 2, Carol: 3, Dave: 3}
 /// }
 /// { a1ebbe..
 /// cause: Request
-/// interesting_content: {Add(Fred)}
+/// interesting_content: [Add(Fred)]
 /// last_ancestors: {Alice: 15, Bob: 14, Carol: 15, Dave: 14}
 /// }
 /// { a3b0c4..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 9, Bob: 9, Carol: 7, Dave: 7}
 /// }
 /// { a8246a..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 13, Bob: 10, Carol: 10, Dave: 12}
 /// }
 /// { ab37e5..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 4, Carol: 2, Dave: 4}
 /// }
 /// { bb4ca7..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 10, Carol: 10, Dave: 10}
 /// }
 /// { c04cde..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 15, Bob: 12, Carol: 16, Dave: 14}
 /// }
 /// { c156bd..
 /// cause: Observation(Genesis({Alice, Bob, Carol, Dave}))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Dave: 1}
 /// }
 /// { c2dd4f..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Dave: 0}
 /// }
 /// { c5704e..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Bob: 2, Dave: 1}
 /// }
 /// { c68956..
 /// cause: Observation(Genesis({Alice, Bob, Carol, Dave}))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Bob: 1}
 /// }
 /// { c704a8..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 12, Carol: 13, Dave: 12}
 /// }
 /// { cbe4a7..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 8, Carol: 9, Dave: 7}
 /// }
 /// { d3a463..
 /// cause: Request
-/// interesting_content: {Add(Fred)}
+/// interesting_content: [Add(Fred)]
 /// last_ancestors: {Alice: 15, Bob: 12, Carol: 15, Dave: 14}
 /// }
 /// { d3e30c..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 8, Carol: 7, Dave: 7}
 /// }
 /// { d751dc..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 15, Bob: 14, Carol: 15, Dave: 16}
 /// }
 /// { dae544..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 13, Carol: 13, Dave: 12}
 /// }
 /// { dd447e..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 4, Carol: 4, Dave: 3}
 /// }
 /// { e091c7..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 4, Carol: 7, Dave: 5}
 /// }
 /// { e3faaa..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 8, Carol: 7, Dave: 8}
 /// }
 /// { eb12e8..
 /// cause: Request
-/// interesting_content: {Add(Fred)}
+/// interesting_content: [Add(Fred)]
 /// last_ancestors: {Alice: 14, Bob: 12, Carol: 15, Dave: 14}
 /// }
 /// { ec6315..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 9, Bob: 8, Carol: 9, Dave: 7}
 /// }
 /// { f1e228..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0}
 /// }
 /// { f52700..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 9, Bob: 8, Carol: 11, Dave: 10}
 /// }
 /// { f86edd..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 6, Carol: 7, Dave: 7}
 /// }
 /// { f93793..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Bob: 0}
 /// }
 /// { fdbe91..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 5, Carol: 4, Dave: 3}
 /// }
     style=invis
@@ -627,7 +627,7 @@ Add(Fred)"]
  "690e2c.." [shape=rectangle, style=filled, fillcolor=cyan]
  "6e43c9.." [fillcolor=white, label="D_14
 Add(Fred)
-{Add(Fred)}"]
+[Add(Fred)]"]
  "6e43c9.." [shape=rectangle, style=filled, fillcolor=crimson]
  "71eb29.." [fillcolor=white, label="B_12"]
  "779eaa.." [fillcolor=white, label="D_11"]
@@ -646,7 +646,7 @@ D: [ { 0/0, est:{t} bin:{} aux:{} dec:{} }]"]
  "9b3f14.." [fillcolor=white, label="D_3"]
  "9fbed3.." [fillcolor=white, label="C_3"]
  "a1ebbe.." [fillcolor=white, label="B_14
-{Add(Fred)}"]
+[Add(Fred)]"]
  "a1ebbe.." [shape=rectangle, style=filled, fillcolor=crimson]
  "a3b0c4.." [fillcolor=white, label="B_9"]
  "a8246a.." [fillcolor=white, label="A_13"]
@@ -664,7 +664,7 @@ Genesis({Alice, Bob, Carol, Dave})"]
  "c704a8.." [fillcolor=white, label="C_13"]
  "cbe4a7.." [fillcolor=white, label="A_10"]
  "d3a463.." [fillcolor=white, label="A_15
-{Add(Fred)}"]
+[Add(Fred)]"]
  "d3a463.." [shape=rectangle, style=filled, fillcolor=crimson]
  "d3e30c.." [fillcolor=white, label="B_8"]
  "d751dc.." [ shape=rectangle, fillcolor=white, label="D_16
@@ -677,7 +677,7 @@ D: [ { 0/0, est:{t} bin:{} aux:{} dec:{} }]"]
  "e091c7.." [fillcolor=white, label="C_7"]
  "e3faaa.." [fillcolor=white, label="D_8"]
  "eb12e8.." [fillcolor=white, label="C_15
-{Add(Fred)}"]
+[Add(Fred)]"]
  "eb12e8.." [shape=rectangle, style=filled, fillcolor=crimson]
  "ec6315.." [fillcolor=white, label="C_9"]
  "f1e228.." [fillcolor=white, label="A_0"]

--- a/input_graphs/parsec_functional_tests_from_parsed_contents/0.dot
+++ b/input_graphs/parsec_functional_tests_from_parsed_contents/0.dot
@@ -5,262 +5,262 @@ digraph GossipGraph {
 /// peer_states: {Alice: "PeerState(VOTE|SEND|RECV)", Bob: "PeerState(VOTE|SEND|RECV)", Carol: "PeerState(VOTE|SEND|RECV)", Dave: "PeerState(VOTE|SEND|RECV)"}
 /// { 0979c6..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 8, Carol: 8, Dave: 6}
 /// }
 /// { 0c619d..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 5, Bob: 4, Carol: 1, Dave: 3}
 /// }
 /// { 0e4dd4..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 12, Carol: 10, Dave: 9}
 /// }
 /// { 1c241c..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 1, Dave: 3}
 /// }
 /// { 1efad0..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 5, Carol: 3, Dave: 3}
 /// }
 /// { 2383c3..
 /// cause: Response
-/// interesting_content: {OpaquePayload(l1SxY)}
+/// interesting_content: [OpaquePayload(l1SxY)]
 /// last_ancestors: {Alice: 5, Bob: 4, Carol: 6, Dave: 7}
 /// }
 /// { 305ffe..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 11, Carol: 10, Dave: 9}
 /// }
 /// { 364413..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 8, Carol: 8, Dave: 6}
 /// }
 /// { 3aef1e..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 9, Bob: 8, Carol: 8, Dave: 8}
 /// }
 /// { 3b2b82..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 4, Carol: 3, Dave: 6}
 /// }
 /// { 3c6f58..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 12, Carol: 10, Dave: 9}
 /// }
 /// { 3f0cc2..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 11, Carol: 8, Dave: 9}
 /// }
 /// { 4065c2..
 /// cause: Request
-/// interesting_content: {OpaquePayload(l1SxY)}
+/// interesting_content: [OpaquePayload(l1SxY)]
 /// last_ancestors: {Alice: 7, Bob: 7, Carol: 6, Dave: 6}
 /// }
 /// { 44999b..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 8, Carol: 6, Dave: 6}
 /// }
 /// { 4d531f..
 /// cause: Observation(OpaquePayload(l1SxY))
-/// interesting_content: {OpaquePayload(l1SxY)}
+/// interesting_content: [OpaquePayload(l1SxY)]
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 5, Dave: 5}
 /// }
 /// { 4deee0..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 11, Carol: 10, Dave: 10}
 /// }
 /// { 4e2559..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 3, Dave: 3}
 /// }
 /// { 50c6a5..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Carol: 0}
 /// }
 /// { 610448..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 1, Carol: 2, Dave: 1}
 /// }
 /// { 646aea..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 14, Carol: 11, Dave: 11}
 /// }
 /// { 6730ec..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 4, Dave: 5}
 /// }
 /// { 690131..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 1, Dave: 1}
 /// }
 /// { 6eed11..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 1, Carol: 1, Dave: 1}
 /// }
 /// { 7fbc90..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 3, Dave: 5}
 /// }
 /// { 8602c4..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 13, Carol: 10, Dave: 11}
 /// }
 /// { 86c3ea..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 1}
 /// }
 /// { 8975ce..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 1, Bob: 1}
 /// }
 /// { 901a99..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 1, Carol: 1, Dave: 3}
 /// }
 /// { 977b68..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 1, Carol: 1, Dave: 4}
 /// }
 /// { 9a3882..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 8, Carol: 8, Dave: 8}
 /// }
 /// { 9b3b26..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 9, Carol: 8, Dave: 6}
 /// }
 /// { 9bff8f..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 12, Carol: 10, Dave: 11}
 /// }
 /// { 9df17d..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 1, Carol: 1, Dave: 1}
 /// }
 /// { a1d14a..
 /// cause: Observation(OpaquePayload(EQCJS))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 1}
 /// }
 /// { a6bffb..
 /// cause: Observation(OpaquePayload(l1SxY))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 1, Carol: 1, Dave: 3}
 /// }
 /// { abe89f..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 5, Bob: 4, Carol: 6, Dave: 6}
 /// }
 /// { bb6802..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 5, Bob: 7, Carol: 7, Dave: 6}
 /// }
 /// { bc5605..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 5, Bob: 4, Carol: 3, Dave: 6}
 /// }
 /// { c28b29..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 11, Carol: 8, Dave: 8}
 /// }
 /// { c2dd4f..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Dave: 0}
 /// }
 /// { c677f6..
 /// cause: Observation(OpaquePayload(l1SxY))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 3, Dave: 1}
 /// }
 /// { c723a1..
 /// cause: Observation(OpaquePayload(EQCJS))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 10, Carol: 8, Dave: 6}
 /// }
 /// { d1cbea..
 /// cause: Observation(OpaquePayload(CC4Oj))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 6, Carol: 3, Dave: 3}
 /// }
 /// { e060b4..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 1, Carol: 1, Dave: 2}
 /// }
 /// { e8a333..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 2, Dave: 1}
 /// }
 /// { ec806d..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 14, Carol: 11, Dave: 11}
 /// }
 /// { ecd748..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 11, Carol: 11, Dave: 9}
 /// }
 /// { f0baba..
 /// cause: Request
-/// interesting_content: {OpaquePayload(l1SxY)}
+/// interesting_content: [OpaquePayload(l1SxY)]
 /// last_ancestors: {Alice: 5, Bob: 7, Carol: 6, Dave: 6}
 /// }
 /// { f1e228..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0}
 /// }
 /// { f2e3bb..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 11, Carol: 10, Dave: 9}
 /// }
 /// { f73660..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 8, Carol: 9, Dave: 6}
 /// }
 /// { f93793..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Bob: 0}
 /// }
     style=invis
@@ -404,7 +404,7 @@ D: [ { 0/0, est:{f} bin:{f} aux:{f} dec:{} }
  "1c241c.." [fillcolor=white, label="B_4"]
  "1efad0.." [fillcolor=white, label="B_5"]
  "2383c3.." [fillcolor=white, label="D_7
-{OpaquePayload(l1SxY)}"]
+[OpaquePayload(l1SxY)]"]
  "2383c3.." [shape=rectangle, style=filled, fillcolor=crimson]
  "305ffe.." [ shape=rectangle, fillcolor=white, label="C_10
 A: [ { 0/0, est:{t} bin:{t} aux:{t} dec:{t} }]
@@ -435,12 +435,12 @@ B: [ { 0/0, est:{t} bin:{t} aux:{t} dec:{} }]
 C: [ { 0/0, est:{t} bin:{t} aux:{t} dec:{} }]
 D: [ { 0/0, est:{f} bin:{f} aux:{f} dec:{} }]"]
  "4065c2.." [fillcolor=white, label="A_7
-{OpaquePayload(l1SxY)}"]
+[OpaquePayload(l1SxY)]"]
  "4065c2.." [shape=rectangle, style=filled, fillcolor=crimson]
  "44999b.." [fillcolor=white, label="B_8"]
  "4d531f.." [fillcolor=white, label="C_5
 OpaquePayload(l1SxY)
-{OpaquePayload(l1SxY)}"]
+[OpaquePayload(l1SxY)]"]
  "4d531f.." [shape=rectangle, style=filled, fillcolor=crimson]
  "4deee0.." [ shape=rectangle, fillcolor=white, label="D_10
 A: [ { 0/0, est:{t} bin:{t} aux:{t} dec:{t} }]
@@ -531,7 +531,7 @@ C: [ { 0/0, est:{t} bin:{t} aux:{t} dec:{t} }]
 D: [ { 0/0, est:{f} bin:{f} aux:{f} dec:{} }
 { 0/1, est:{f} bin:{} aux:{} dec:{} }]"]
  "f0baba.." [fillcolor=white, label="B_7
-{OpaquePayload(l1SxY)}"]
+[OpaquePayload(l1SxY)]"]
  "f0baba.." [shape=rectangle, style=filled, fillcolor=crimson]
  "f1e228.." [fillcolor=white, label="A_0"]
  "f2e3bb.." [ shape=rectangle, fillcolor=white, label="A_10

--- a/input_graphs/parsec_functional_tests_from_parsed_contents/1.dot
+++ b/input_graphs/parsec_functional_tests_from_parsed_contents/1.dot
@@ -5,267 +5,267 @@ digraph GossipGraph {
 /// peer_states: {Alice: "PeerState(VOTE|SEND|RECV)", Bob: "PeerState(VOTE|SEND|RECV)", Carol: "PeerState(VOTE|SEND|RECV)", Dave: "PeerState(VOTE|SEND|RECV)"}
 /// { 0979c6..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 8, Carol: 8, Dave: 6}
 /// }
 /// { 0c619d..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 5, Bob: 4, Carol: 1, Dave: 3}
 /// }
 /// { 0e4dd4..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 12, Carol: 10, Dave: 9}
 /// }
 /// { 1c241c..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 1, Dave: 3}
 /// }
 /// { 1efad0..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 5, Carol: 3, Dave: 3}
 /// }
 /// { 2383c3..
 /// cause: Response
-/// interesting_content: {OpaquePayload(l1SxY)}
+/// interesting_content: [OpaquePayload(l1SxY)]
 /// last_ancestors: {Alice: 5, Bob: 4, Carol: 6, Dave: 7}
 /// }
 /// { 305ffe..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 11, Carol: 10, Dave: 9}
 /// }
 /// { 364413..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 8, Carol: 8, Dave: 6}
 /// }
 /// { 3aef1e..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 9, Bob: 8, Carol: 8, Dave: 8}
 /// }
 /// { 3b2b82..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 6, Bob: 4, Carol: 3, Dave: 6}
 /// }
 /// { 3c6f58..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 11, Bob: 12, Carol: 10, Dave: 9}
 /// }
 /// { 3f0cc2..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 11, Carol: 8, Dave: 9}
 /// }
 /// { 4065c2..
 /// cause: Request
-/// interesting_content: {OpaquePayload(l1SxY)}
+/// interesting_content: [OpaquePayload(l1SxY)]
 /// last_ancestors: {Alice: 7, Bob: 7, Carol: 6, Dave: 6}
 /// }
 /// { 44999b..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 8, Carol: 6, Dave: 6}
 /// }
 /// { 4d531f..
 /// cause: Observation(OpaquePayload(l1SxY))
-/// interesting_content: {OpaquePayload(l1SxY)}
+/// interesting_content: [OpaquePayload(l1SxY)]
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 5, Dave: 5}
 /// }
 /// { 4deee0..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 11, Carol: 10, Dave: 10}
 /// }
 /// { 4e2559..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 3, Dave: 3}
 /// }
 /// { 50c6a5..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Carol: 0}
 /// }
 /// { 610448..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 1, Carol: 2, Dave: 1}
 /// }
 /// { 646aea..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 14, Carol: 11, Dave: 11}
 /// }
 /// { 6730ec..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 4, Dave: 5}
 /// }
 /// { 690131..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 1, Dave: 1}
 /// }
 /// { 6eed11..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 3, Bob: 1, Carol: 1, Dave: 1}
 /// }
 /// { 7fbc90..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 4, Carol: 3, Dave: 5}
 /// }
 /// { 8602c4..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 13, Carol: 10, Dave: 11}
 /// }
 /// { 86c3ea..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 1}
 /// }
 /// { 8975ce..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 1, Bob: 1}
 /// }
 /// { 901a99..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 1, Carol: 1, Dave: 3}
 /// }
 /// { 977b68..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 1, Carol: 1, Dave: 4}
 /// }
 /// { 9943d7..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 12, Bob: 15, Carol: 11, Dave: 11}
 /// }
 /// { 9a3882..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 8, Carol: 8, Dave: 8}
 /// }
 /// { 9b3b26..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 9, Carol: 8, Dave: 6}
 /// }
 /// { 9bff8f..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 12, Carol: 10, Dave: 11}
 /// }
 /// { 9df17d..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 1, Carol: 1, Dave: 1}
 /// }
 /// { a1d14a..
 /// cause: Observation(OpaquePayload(EQCJS))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 2, Bob: 1}
 /// }
 /// { a6bffb..
 /// cause: Observation(OpaquePayload(l1SxY))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 1, Carol: 1, Dave: 3}
 /// }
 /// { abe89f..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 5, Bob: 4, Carol: 6, Dave: 6}
 /// }
 /// { bb6802..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 5, Bob: 7, Carol: 7, Dave: 6}
 /// }
 /// { bc5605..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 5, Bob: 4, Carol: 3, Dave: 6}
 /// }
 /// { c28b29..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 11, Carol: 8, Dave: 8}
 /// }
 /// { c2dd4f..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Dave: 0}
 /// }
 /// { c677f6..
 /// cause: Observation(OpaquePayload(l1SxY))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 3, Dave: 1}
 /// }
 /// { c723a1..
 /// cause: Observation(OpaquePayload(EQCJS))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 7, Bob: 10, Carol: 8, Dave: 6}
 /// }
 /// { d1cbea..
 /// cause: Observation(OpaquePayload(CC4Oj))
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 4, Bob: 6, Carol: 3, Dave: 3}
 /// }
 /// { e060b4..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 1, Carol: 1, Dave: 2}
 /// }
 /// { e8a333..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0, Bob: 2, Dave: 1}
 /// }
 /// { ec806d..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 14, Carol: 11, Dave: 11}
 /// }
 /// { ecd748..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 11, Carol: 11, Dave: 9}
 /// }
 /// { f0baba..
 /// cause: Request
-/// interesting_content: {OpaquePayload(l1SxY)}
+/// interesting_content: [OpaquePayload(l1SxY)]
 /// last_ancestors: {Alice: 5, Bob: 7, Carol: 6, Dave: 6}
 /// }
 /// { f1e228..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 0}
 /// }
 /// { f2e3bb..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 10, Bob: 11, Carol: 10, Dave: 9}
 /// }
 /// { f73660..
 /// cause: Response
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 8, Bob: 8, Carol: 9, Dave: 6}
 /// }
 /// { f93793..
 /// cause: Initial
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Bob: 0}
 /// }
     style=invis
@@ -411,7 +411,7 @@ D: [ { 0/0, est:{f} bin:{f} aux:{f} dec:{} }
  "1c241c.." [fillcolor=white, label="B_4"]
  "1efad0.." [fillcolor=white, label="B_5"]
  "2383c3.." [fillcolor=white, label="D_7
-{OpaquePayload(l1SxY)}"]
+[OpaquePayload(l1SxY)]"]
  "2383c3.." [shape=rectangle, style=filled, fillcolor=crimson]
  "305ffe.." [ shape=rectangle, fillcolor=white, label="C_10
 A: [ { 0/0, est:{t} bin:{t} aux:{t} dec:{t} }]
@@ -442,12 +442,12 @@ B: [ { 0/0, est:{t} bin:{t} aux:{t} dec:{} }]
 C: [ { 0/0, est:{t} bin:{t} aux:{t} dec:{} }]
 D: [ { 0/0, est:{f} bin:{f} aux:{f} dec:{} }]"]
  "4065c2.." [fillcolor=white, label="A_7
-{OpaquePayload(l1SxY)}"]
+[OpaquePayload(l1SxY)]"]
  "4065c2.." [shape=rectangle, style=filled, fillcolor=crimson]
  "44999b.." [fillcolor=white, label="B_8"]
  "4d531f.." [fillcolor=white, label="C_5
 OpaquePayload(l1SxY)
-{OpaquePayload(l1SxY)}"]
+[OpaquePayload(l1SxY)]"]
  "4d531f.." [shape=rectangle, style=filled, fillcolor=crimson]
  "4deee0.." [ shape=rectangle, fillcolor=white, label="D_10
 A: [ { 0/0, est:{t} bin:{t} aux:{t} dec:{t} }]
@@ -544,7 +544,7 @@ C: [ { 0/0, est:{t} bin:{t} aux:{t} dec:{t} }]
 D: [ { 0/0, est:{f} bin:{f} aux:{f} dec:{} }
 { 0/1, est:{f} bin:{} aux:{} dec:{} }]"]
  "f0baba.." [fillcolor=white, label="B_7
-{OpaquePayload(l1SxY)}"]
+[OpaquePayload(l1SxY)]"]
  "f0baba.." [shape=rectangle, style=filled, fillcolor=crimson]
  "f1e228.." [fillcolor=white, label="A_0"]
  "f2e3bb.." [ shape=rectangle, fillcolor=white, label="A_10

--- a/input_graphs/parsec_functional_tests_remove_peer/remove_eric.dot
+++ b/input_graphs/parsec_functional_tests_remove_peer/remove_eric.dot
@@ -5,32 +5,32 @@ digraph GossipGraph {
 /// peer_states: {Alice: "PeerState(VOTE|SEND|RECV)", Bob: "PeerState(VOTE|SEND|RECV)", Carol: "PeerState(VOTE|SEND|RECV)", Dave: "PeerState(VOTE|SEND|RECV)", Eric: "PeerState(VOTE|SEND|RECV)"}
 /// { 59f84c..
 /// cause: Request
-/// interesting_content: {}
+/// interesting_content: []
 /// last_ancestors: {Alice: 15, Bob: 21, Carol: 17, Dave: 20, Eric: 16}
 /// }
 /// { f1cecc..
 /// cause: Request
-/// interesting_content: {Remove(Eric)}
+/// interesting_content: [Remove(Eric)]
 /// last_ancestors: {Alice: 14, Bob: 16, Carol: 17, Dave: 18, Eric: 14}
 /// }
 /// { 5984ee..
 /// cause: Request
-/// interesting_content: {Remove(Eric)}
+/// interesting_content: [Remove(Eric)]
 /// last_ancestors: {Alice: 12, Bob: 21, Carol: 15, Dave: 20, Eric: 16}
 /// }
 /// { 54df49..
 /// cause: Response
-/// interesting_content: {Remove(Eric)}
+/// interesting_content: [Remove(Eric)]
 /// last_ancestors: {Alice: 12, Bob: 16, Carol: 17, Dave: 18, Eric: 14}
 /// }
 /// { aaaac9..
 /// cause: Request
-/// interesting_content: {Remove(Eric)}
+/// interesting_content: [Remove(Eric)]
 /// last_ancestors: {Alice: 10, Bob: 15, Carol: 11, Dave: 20, Eric: 10}
 /// }
 /// { e2ab10..
 /// cause: Response
-/// interesting_content: {Remove(Eric)}
+/// interesting_content: [Remove(Eric)]
 /// last_ancestors: {Alice: 12, Bob: 20, Carol: 15, Dave: 20, Eric: 16}
 /// }
     style=invis

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -77,7 +77,7 @@ struct ParsedEvent {
     cause: String,
     self_parent: Option<String>,
     other_parent: Option<String>,
-    interesting_content: BTreeSet<Observation<Transaction, PeerId>>,
+    interesting_content: Vec<Observation<Transaction, PeerId>>,
     last_ancestors: BTreeMap<PeerId, u64>,
     observations: BTreeSet<PeerId>,
 }
@@ -109,18 +109,18 @@ impl ParsedEvent {
     }
 }
 
-fn parse_interesting_content(input: &str) -> BTreeSet<Observation<Transaction, PeerId>> {
+fn parse_interesting_content(input: &str) -> Vec<Observation<Transaction, PeerId>> {
     let mut input = input;
 
     skip_whitespace(&mut input);
     assert!(skip_string(&mut input, "interesting_content:"));
     skip_whitespace(&mut input);
-    assert!(skip_string(&mut input, "{"));
+    assert!(skip_string(&mut input, "["));
 
-    let mut result = BTreeSet::new();
+    let mut result = vec![];
 
-    while !skip_string(&mut input, "}") {
-        let _ = result.insert(parse_observation(&mut input));
+    while !skip_string(&mut input, "]") {
+        result.push(parse_observation(&mut input));
         let _ = skip_string(&mut input, ",");
     }
 

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -37,7 +37,7 @@ pub(crate) struct Event<T: NetworkEvent, P: PublicId> {
     // Index of each peer's latest event that is an ancestor of this event.
     last_ancestors: BTreeMap<P, u64>,
     // Payloads of all the votes deemed interesting by this event
-    pub interesting_content: BTreeSet<Observation<T, P>>,
+    pub interesting_content: Vec<Observation<T, P>>,
     // The set of peers for which this event can strongly-see an event by that peer which carries a
     // valid block.  If there are a supermajority of peers here, this event is an "observer".
     pub observations: BTreeSet<P>,
@@ -130,7 +130,7 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
             hash,
             index,
             last_ancestors,
-            interesting_content: BTreeSet::default(),
+            interesting_content: vec![],
             observations: BTreeSet::default(),
         }))
     }
@@ -240,7 +240,7 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
             hash: Hash::from(serialised_content.as_slice()),
             index,
             last_ancestors,
-            interesting_content: BTreeSet::default(),
+            interesting_content: vec![],
             observations: BTreeSet::default(),
         }
     }
@@ -348,7 +348,7 @@ impl Event<Transaction, PeerId> {
         other_parent: Option<Hash>,
         index: u64,
         last_ancestors: BTreeMap<PeerId, u64>,
-        interesting_content: BTreeSet<Observation<Transaction, PeerId>>,
+        interesting_content: Vec<Observation<Transaction, PeerId>>,
     ) -> Self {
         use dev_utils::parse_peer_ids;
 


### PR DESCRIPTION
This change makes it so that if all peers vote for observations in a particular order, the agreed order will be the same.

This is done by modifying the way interesting events store interesting content. Until now, the order was just lexical. Now, every interesting event stores the content in the order its creator voted for it, and the first payload is chosen as a candidate. This way, if a payload was the first voted for for all peers, it will be chosen as the next consensused one.