### PR TITLE
MAID-3067: Detect and handle malice: IncorrectGenesis

### DIFF
--- a/src/observation.rs
+++ b/src/observation.rs
@@ -41,5 +41,7 @@ pub enum Malice {
     DuplicateVote(Hash, Hash),
     /// Event should be carrying a vote for `Observation::Genesis`, but doesn't
     MissingGenesis(Hash),
+    /// Event carries a vote for `Observation::Genesis` which doesn't correspond to what we know.
+    IncorrectGenesis(Hash),
     // TODO: add other malice variants
 }


### PR DESCRIPTION
A node creates an event with Observation::Genesis. Their observation is in disagreement with my consensus list (either my Genesis::Observation or the genesis being consensused if I was added after genesis).