### PR TITLE
MAID-3202: avoid remove Carol too quick

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -327,8 +327,8 @@ fn fail_add_remove() {
             (10, Fail(PeerId::new("Alice"))),
             (20, RemovePeer(PeerId::new("Bob"))),
             (200, AddPeer(PeerId::new("Hank"))),
-            (700, RemovePeer(PeerId::new("Carol"))),
-            (850, Opaque(Transaction::new("whatever"))),
+            (1000, RemovePeer(PeerId::new("Carol"))),
+            (1500, Opaque(Transaction::new("whatever"))),
         ],
     };
     let schedule =


### PR DESCRIPTION
We experienced the situation that Carol got removed too quick that
before Hank got consensused to be added. Which blocks Add(Hank) to
get consensused.