### PR TITLE
MAID-3140: Rename test_duplicate_votes_before_gossip

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -133,7 +133,7 @@ fn multiple_votes_during_gossip() {
 }
 
 #[test]
-fn duplicate_votes_before_gossip() {
+fn duplicate_vote_is_reduced_to_single() {
     let mut env = Environment::new(SEED);
 
     let schedule = Schedule::new(


### PR DESCRIPTION
This was done in 93d058132b6cad1a1dcb93ac5d2eb45d89ac9236 but the change
was accidentally reverted during a rebase.

MAID-3140