### PR TITLE
MAID-3070: Detect and handle MissingGenesis

### DIFF
--- a/src/observation.rs
+++ b/src/observation.rs
@@ -39,5 +39,7 @@ pub enum Malice {
     UnexpectedGenesis(Hash),
     /// Two or more votes with the same observation by the same creator.
     DuplicateVote(Hash, Hash),
+    /// Event should be carrying a vote for `Observation::Genesis`, but doesn't
+    MissingGenesis(Hash),
     // TODO: add other malice variants
 }


### PR DESCRIPTION
This handles MissingGenesis based on the assumption that we will always get initialised with a genesis group that is a result of consensus of some section - so we will either have the correct genesis group in events carrying `Observation::Genesis`, or in the peer list.

Supersedes #122