### PR TITLE
MAID-3210: Change malice handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use peer_list::PeerState;
+use std::result;
 
 quick_error! {
     /// Parsec error variants.
@@ -66,3 +67,6 @@ quick_error! {
         }
     }
 }
+
+/// A specialised `Result` type for Parsec.
+pub type Result<T> = result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub mod mock;
 pub use block::Block;
 #[cfg(feature = "dump-graphs")]
 pub use dump_graph::DIR;
-pub use error::Error;
+pub use error::{Error, Result};
 pub use gossip::{Request, Response};
 pub use id::{Proof, PublicId, SecretId};
 pub use network_event::NetworkEvent;


### PR DESCRIPTION
This PR introduces the following changes to malice handling:
1. Malice detection now happens before the event is added to the graph
2. Accusations are raised only after all events from the gossip message has been processed
3. Exception is the `IncorrectGenesis` malice, which raises the accusation immediately and interrupts processing of all the events in the message to prevent populating the graph with potentially large number of invalid events.

There is also a minor refactoring in a separate commit which adds type alias for `Result<T, Error>` to reduce verbosity.