### PR TITLE
MAID-3052: Impl - detect invalid accusation

### DIFF
--- a/src/observation.rs
+++ b/src/observation.rs
@@ -47,5 +47,8 @@ pub enum Malice {
     StaleOtherParent(Hash),
     /// More than one events having this event as its self_parent.
     Fork(Hash),
+    /// A node incorrectly accused other node of malice. Contains hash of the invalid Accusation
+    /// event.
+    InvalidAccusation(Hash),
     // TODO: add other malice variants
 }

--- a/src/peer_list.rs
+++ b/src/peer_list.rs
@@ -169,7 +169,6 @@ impl<S: SecretId> PeerList<S> {
     }
 
     /// Hashes of our events in insertion order.
-    #[cfg(test)]
     pub fn our_events(&self) -> impl DoubleEndedIterator<Item = &Hash> {
         self.peer_events(self.our_id.public_id())
     }


### PR DESCRIPTION
The detection of invalid accusation is based on the idea that if we encounter an event carrying `Accusation`, we should have already processed the corresponding offending events, so it should be enough to look in our pending accusations or already raised accusation to see whether we have the same accusation. If we don't, their accusation is invalid. This relies heavily on the assumption that accusations are raised immediately after sync events which implies that any accusation is always a descendant of its offending event(s). Unless I'm wrong :grimacing: .