### PR TITLE
MAID-3056: Add test for InvalidGossipCreator

### DIFF
--- a/input_graphs/parsec_functional_tests_handle_malice_invalid_gossip_creator/alice.dot
+++ b/input_graphs/parsec_functional_tests_handle_malice_invalid_gossip_creator/alice.dot
@@ -1,0 +1,88 @@
+digraph GossipGraph {
+  splines=false
+  rankdir=BT
+/// our_id: Alice
+/// peer_states: {Alice: "PeerState(VOTE|SEND|RECV)", Bob: "PeerState(VOTE|SEND|RECV)"}
+/// { 30d7e4394d..
+/// cause: Initial
+/// interesting_content: []
+/// last_ancestors: {Alice: 0}
+/// }
+/// { 3fae277c4b..
+/// cause: Observation(Genesis({Alice, Bob}))
+/// interesting_content: []
+/// last_ancestors: {Alice: 1}
+/// }
+/// { 47d2ba4b29..
+/// cause: Response
+/// interesting_content: []
+/// last_ancestors: {Alice: 2, Carol: 0}
+/// }
+/// { dc8296fe22..
+/// cause: Initial
+/// interesting_content: []
+/// last_ancestors: {Bob: 0}
+/// }
+/// { 1efae523fa..
+/// cause: Observation(Genesis({Alice, Bob}))
+/// interesting_content: []
+/// last_ancestors: {Bob: 1}
+/// }
+/// { d38f87882e..
+/// cause: Response
+/// interesting_content: []
+/// last_ancestors: {Bob: 2, Alice: 2, Carol: 0}
+/// }
+/// { 4541f98755..
+/// cause: Initial
+/// interesting_content: []
+/// last_ancestors: {Carol: 0}
+/// }
+    style=invis
+  subgraph cluster_Alice {
+    label=Alice
+    Alice [style=invis]
+    Alice -> "30d7e4394d.." [style=invis]
+    "30d7e4394d.." -> "3fae277c4b.." [minlen=1]
+    "3fae277c4b.." -> "47d2ba4b29.." [minlen=1]
+  }
+  "4541f98755.." -> "47d2ba4b29.." [constraint=false]
+
+    style=invis
+  subgraph cluster_Bob {
+    label=Bob
+    Bob [style=invis]
+    Bob -> "dc8296fe22.." [style=invis]
+    "dc8296fe22.." -> "1efae523fa.." [minlen=1]
+    "1efae523fa.." -> "d38f87882e.." [minlen=2]
+  }
+  "47d2ba4b29.." -> "d38f87882e.." [constraint=false]
+
+    style=invis
+  subgraph cluster_Carol {
+    label=Carol
+    Carol [style=invis]
+    Carol -> "4541f98755.." [style=invis]
+  }
+
+/// meta-vote section
+ "30d7e4394d.." [fillcolor=white, label="A_0"]
+ "3fae277c4b.." [fillcolor=white, label="A_1
+Genesis({Alice, Bob})"]
+ "3fae277c4b.." [shape=rectangle, style=filled, fillcolor=cyan]
+ "47d2ba4b29.." [fillcolor=white, label="A_2"]
+ "dc8296fe22.." [fillcolor=white, label="B_0"]
+ "1efae523fa.." [fillcolor=white, label="B_1
+Genesis({Alice, Bob})"]
+ "1efae523fa.." [shape=rectangle, style=filled, fillcolor=cyan]
+ "d38f87882e.." [fillcolor=white, label="B_2"]
+ "4541f98755.." [fillcolor=white, label="C_0"]
+
+  {
+    rank=same
+    Alice [style=filled, color=white]
+    Bob [style=filled, color=white]
+    Carol [style=filled, color=white]
+  }
+  Alice -> Bob -> Carol [style=invis]
+}

--- a/input_graphs/parsec_functional_tests_handle_malice_invalid_gossip_creator/bob.dot
+++ b/input_graphs/parsec_functional_tests_handle_malice_invalid_gossip_creator/bob.dot
@@ -1,0 +1,72 @@
+digraph GossipGraph {
+  splines=false
+  rankdir=BT
+/// our_id: Bob
+/// peer_states: {Alice: "PeerState(VOTE|SEND|RECV)", Bob: "PeerState(VOTE|SEND|RECV)"}
+/// { 30d7e4394d..
+/// cause: Initial
+/// interesting_content: []
+/// last_ancestors: {Alice: 0}
+/// }
+/// { 3fae277c4b..
+/// cause: Observation(Genesis({Alice, Bob}))
+/// interesting_content: []
+/// last_ancestors: {Alice: 1}
+/// }
+/// { dc8296fe22..
+/// cause: Initial
+/// interesting_content: []
+/// last_ancestors: {Bob: 0}
+/// }
+/// { 1efae523fa..
+/// cause: Observation(Genesis({Alice, Bob}))
+/// interesting_content: []
+/// last_ancestors: {Bob: 1}
+/// }
+/// { 4541f98755..
+/// cause: Initial
+/// interesting_content: []
+/// last_ancestors: {Carol: 0}
+/// }
+    style=invis
+  subgraph cluster_Alice {
+    label=Alice
+    Alice [style=invis]
+    Alice -> "30d7e4394d.." [style=invis]
+    "30d7e4394d.." -> "3fae277c4b.." [minlen=1]
+  }
+
+    style=invis
+  subgraph cluster_Bob {
+    label=Bob
+    Bob [style=invis]
+    Bob -> "dc8296fe22.." [style=invis]
+    "dc8296fe22.." -> "1efae523fa.." [minlen=1]
+  }
+
+    style=invis
+  subgraph cluster_Carol {
+    label=Carol
+    Carol [style=invis]
+    Carol -> "4541f98755.." [style=invis]
+  }
+
+/// meta-vote section
+ "30d7e4394d.." [fillcolor=white, label="A_0"]
+ "3fae277c4b.." [fillcolor=white, label="A_1
+Genesis({Alice, Bob})"]
+ "3fae277c4b.." [shape=rectangle, style=filled, fillcolor=cyan]
+ "dc8296fe22.." [fillcolor=white, label="B_0"]
+ "1efae523fa.." [fillcolor=white, label="B_1
+Genesis({Alice, Bob})"]
+ "1efae523fa.." [shape=rectangle, style=filled, fillcolor=cyan]
+ "4541f98755.." [fillcolor=white, label="C_0"]
+
+  {
+    rank=same
+    Alice [style=filled, color=white]
+    Bob [style=filled, color=white]
+    Carol [style=filled, color=white]
+  }
+  Alice -> Bob -> Carol [style=invis]
+}


### PR DESCRIPTION
InvalidGossipCreator is when a node reports gossip from another node
that isn’t in their section.

_Note:_ the test is disabled and the PR marked as WIP as the implementation has not yet landed. It seems likely that it might need tuning once the test can be tested!