### PR TITLE
MAID-3214: initialise new peer membership list

### DIFF
--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -435,7 +435,6 @@ mod tests {
     use observation::Observation;
     use peer_list::{PeerList, PeerState};
     use std::collections::BTreeMap;
-    use std::iter;
 
     struct PeerListAndEvent {
         peer_list: PeerList<PeerId>,
@@ -477,12 +476,10 @@ mod tests {
         peer_id0_list.add_peer(
             peer_id1,
             PeerState::VOTE | PeerState::SEND | PeerState::RECV,
-            iter::empty(),
         );
         peer_id1_list.add_peer(
             peer_id0,
             PeerState::VOTE | PeerState::SEND | PeerState::RECV,
-            iter::empty(),
         );
 
         (

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -722,13 +722,13 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         match *payload {
             Observation::Add(ref other_peer_id) => self
                 .peer_list
-                .add_peers_peer(peer_id, other_peer_id.clone()),
+                .add_to_membership_list(peer_id, other_peer_id.clone()),
             Observation::Remove(ref other_peer_id) => self
                 .peer_list
-                .remove_peers_peer(peer_id, other_peer_id.clone()),
-            Observation::Accusation { ref offender, .. } => {
-                self.peer_list.remove_peers_peer(peer_id, offender.clone())
-            }
+                .remove_from_membership_list(peer_id, other_peer_id.clone()),
+            Observation::Accusation { ref offender, .. } => self
+                .peer_list
+                .remove_from_membership_list(peer_id, offender.clone()),
             _ => (),
         }
     }

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -529,6 +529,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         }
 
         self.set_interesting_content(&event_hash)?;
+        self.initialise_membership_list(&event_hash);
         self.process_event(&event_hash)?;
 
         Ok(())
@@ -722,11 +723,11 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             Observation::Add(ref other_peer_id) => self
                 .peer_list
                 .add_peers_peer(peer_id, other_peer_id.clone()),
-            Observation::Remove(ref other_peer_id) => {
-                self.peer_list.remove_peers_peer(peer_id, other_peer_id)
-            }
+            Observation::Remove(ref other_peer_id) => self
+                .peer_list
+                .remove_peers_peer(peer_id, other_peer_id.clone()),
             Observation::Accusation { ref offender, .. } => {
-                self.peer_list.remove_peers_peer(peer_id, offender)
+                self.peer_list.remove_peers_peer(peer_id, offender.clone())
             }
             _ => (),
         }
@@ -836,6 +837,12 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
                     .find(sees_vote_for_same_payload)
                     .map(|(index, _hash)| (peer_id, index))
             }).collect()
+    }
+
+    // Initialise the membership list of the creator of the given event.
+    // Do nothing if already initialised.
+    fn initialise_membership_list(&mut self, _event_hash: &Hash) {
+        // TODO
     }
 
     fn set_observations(&mut self, event_hash: &Hash) -> Result<()> {


### PR DESCRIPTION
This PR attempts to fix an existing issue where a peer added via consensus on `Observation::Add` would not have their membership list properly initialized (see https://maidsafe.atlassian.net/browse/MAID-3214 for more detailed description of why this happens). The fix is to wait for the first sync-event by the new peer and then fetch the creator of the other-parent of that sync-event and use their historic membership list at the time the other-parent was created. To achieve this, we keep track of all the changes to the membership lists so we can reconstruct them at any given point in time.

- Why can we copy the other-parent's creator's membership list? Because the new peer (let's call him Eric) is guaranteed to know all the peers the other-parent's creator (let's call him Dave) knew at the time David created the other-parent.

- Why do we have to use historic list (as opposed to the current one)? Because at the time we receive Eric's sync-event, we might have already received events from Dave's that change his membership list, but Eric does now yet know about them.

This PR also includes some refactorings.