### PR TITLE
MAID-3222 and MAID-3223: Expand the public API to support routing integration

### DIFF
--- a/src/peer_list.rs
+++ b/src/peer_list.rs
@@ -40,6 +40,10 @@ impl<S: SecretId> PeerList<S> {
         &self.our_id
     }
 
+    pub fn our_pub_id(&self) -> &S::PublicId {
+        self.our_id.public_id()
+    }
+
     /// Returns all sorted peer_ids.
     pub fn all_ids(&self) -> impl Iterator<Item = &S::PublicId> {
         self.peers.keys()


### PR DESCRIPTION
- add method to check whether there are any not yet consensused observations in the graph
- add method to retrieve all unpolled observations created by us