### PR TITLE
MAID-3225: meta-election data

### DIFF
--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -24,7 +24,7 @@ pub(crate) struct ParsedContents {
     pub our_id: PeerId,
     pub events: BTreeMap<Hash, Event<Transaction, PeerId>>,
     pub events_order: Vec<Hash>,
-    pub meta_events: BTreeMap<Hash, MetaEvent<PeerId>>,
+    pub meta_events: BTreeMap<Hash, MetaEvent<Transaction, PeerId>>,
     pub peer_list: PeerList<PeerId>,
 }
 
@@ -250,13 +250,13 @@ fn read(mut file: File) -> io::Result<ParsedContents> {
             other_parent,
             mv.event_index,
             event.last_ancestors,
-            event.interesting_content,
         );
 
         let hash = *parsed_event.hash();
-        if !mv.meta_votes.is_empty() {
+        if !event.interesting_content.is_empty() || !mv.meta_votes.is_empty() {
             let mut meta_event = MetaEvent::new();
             meta_event.meta_votes = mv.meta_votes;
+            meta_event.interesting_content = event.interesting_content;
 
             let _ = meta_events.insert(hash, meta_event);
         }

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -646,9 +646,6 @@ mod tests {
             let parsed_result = unwrap!(parse_dot_file(&dot_file_path));
 
             assert_eq!(gossip_graph.len(), parsed_result.events_order.len());
-            for event in &mut gossip_graph.values_mut() {
-                event.observations.clear();
-            }
             assert_eq!(gossip_graph, parsed_result.events);
 
             // The dumped dot file doesn't contain all the meta_votes

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -655,6 +655,10 @@ mod tests {
             assert_eq!(gossip_graph, parsed_result.events);
 
             // The dumped dot file doesn't contain all the meta_votes
+            // NOTE: We only serialise meta-votes in the core file, not complete meta-events.
+            // This is why we compare the number of meta-votes (from the core) to the number of
+            // meta-events (in the parsed result) here. There is, however, one-to-one mapping
+            // between meta-events and sets of meta-votes, so this is correct.
             assert!(meta_votes.len() >= parsed_result.meta_events.len());
             for (hash, meta_event) in &parsed_result.meta_events {
                 let ori_meta_vote = unwrap!(meta_votes.get(hash));

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -475,6 +475,8 @@ mod detail {
                 "/// interesting_content: {:?}",
                 meta_event.interesting_content
             )?;
+        } else {
+            writeln!(writer, "/// interesting_content: []",)?;
         }
 
         writeln!(writer, "/// last_ancestors: {:?}", event.last_ancestors())?;

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -9,7 +9,7 @@
 use gossip::Event;
 use hash::Hash;
 use id::SecretId;
-use meta_voting::MetaVote;
+use meta_voting::MetaEvent;
 use network_event::NetworkEvent;
 use peer_list::PeerList;
 use std::collections::BTreeMap;
@@ -33,16 +33,16 @@ pub(crate) fn init() {
 pub(crate) fn to_file<T: NetworkEvent, S: SecretId>(
     owner_id: &S::PublicId,
     gossip_graph: &BTreeMap<Hash, Event<T, S::PublicId>>,
-    meta_votes: &BTreeMap<Hash, BTreeMap<S::PublicId, Vec<MetaVote>>>,
+    meta_events: &BTreeMap<Hash, MetaEvent<S::PublicId>>,
     peer_list: &PeerList<S>,
 ) {
-    detail::to_file(owner_id, gossip_graph, meta_votes, peer_list)
+    detail::to_file(owner_id, gossip_graph, meta_events, peer_list)
 }
 #[cfg(not(feature = "dump-graphs"))]
 pub(crate) fn to_file<T: NetworkEvent, S: SecretId>(
     _: &S::PublicId,
     _: &BTreeMap<Hash, Event<T, S::PublicId>>,
-    _: &BTreeMap<Hash, BTreeMap<S::PublicId, Vec<MetaVote>>>,
+    _: &BTreeMap<Hash, MetaEvent<S::PublicId>>,
     _: &PeerList<S>,
 ) {
 }
@@ -55,7 +55,7 @@ mod detail {
     use gossip::Event;
     use hash::Hash;
     use id::{PublicId, SecretId};
-    use meta_voting::MetaVote;
+    use meta_voting::MetaEvent;
     use network_event::NetworkEvent;
     use peer_list::PeerList;
     use rand::{self, Rng};
@@ -108,10 +108,15 @@ mod detail {
     fn catch_dump<T: NetworkEvent, P: PublicId>(
         mut file_path: PathBuf,
         gossip_graph: &BTreeMap<Hash, Event<T, P>>,
-        meta_votes: &BTreeMap<Hash, BTreeMap<P, Vec<MetaVote>>>,
+        meta_events: &BTreeMap<Hash, MetaEvent<P>>,
     ) {
         if let Some("dev_utils::dot_parser::tests::dot_parser") = thread::current().name() {
+            let meta_votes: BTreeMap<_, _> = meta_events
+                .into_iter()
+                .map(|(hash, me)| (*hash, me.meta_votes.clone()))
+                .collect();
             let dumped_info = serialise(&(gossip_graph, meta_votes));
+
             assert!(file_path.set_extension("core"));
             let mut file = unwrap!(File::create(&file_path));
             unwrap!(file.write_all(&dumped_info));
@@ -125,7 +130,7 @@ mod detail {
     pub(crate) fn to_file<T: NetworkEvent, S: SecretId>(
         owner_id: &S::PublicId,
         gossip_graph: &BTreeMap<Hash, Event<T, S::PublicId>>,
-        meta_votes: &BTreeMap<Hash, BTreeMap<S::PublicId, Vec<MetaVote>>>,
+        meta_events: &BTreeMap<Hash, MetaEvent<S::PublicId>>,
         peer_list: &PeerList<S>,
     ) {
         let id = format!("{:?}", owner_id);
@@ -136,7 +141,7 @@ mod detail {
             *count
         });
         let file_path = DIR.with(|dir| dir.join(format!("{}-{:03}.dot", id, call_count)));
-        catch_dump(file_path.clone(), gossip_graph, meta_votes);
+        catch_dump(file_path.clone(), gossip_graph, meta_events);
 
         if let Ok(mut file) = File::create(&file_path) {
             let initial_events: Vec<Hash> = gossip_graph
@@ -151,7 +156,7 @@ mod detail {
             if let Err(error) = write_gossip_graph_dot(
                 &mut file,
                 gossip_graph,
-                meta_votes,
+                meta_events,
                 peer_list,
                 &initial_events,
             ) {
@@ -277,13 +282,13 @@ mod detail {
     fn write_evaluates<T: NetworkEvent, P: PublicId>(
         writer: &mut Write,
         gossip_graph: &BTreeMap<Hash, Event<T, P>>,
-        meta_votes: &BTreeMap<Hash, BTreeMap<P, Vec<MetaVote>>>,
+        meta_events: &BTreeMap<Hash, MetaEvent<P>>,
         initial_events: &[Hash],
     ) -> io::Result<()> {
         writeln!(writer, "/// meta-vote section")?;
         for (event_hash, event) in gossip_graph.iter() {
             write!(writer, " \"{:?}\" [", event.hash())?;
-            if meta_votes.contains_key(event_hash) {
+            if meta_events.contains_key(event_hash) {
                 write!(writer, " shape=rectangle, ")?;
             }
             write!(writer, "fillcolor=white, label=\"{}", event.short_name())?;
@@ -298,13 +303,13 @@ mod detail {
             }
 
             // Write the `meta_votes` if have
-            if let Some(event_meta_votes) = meta_votes.get(event_hash) {
-                if event_meta_votes.len() >= initial_events.len() {
-                    let mut peer_ids: Vec<&P> = event_meta_votes.keys().collect();
+            if let Some(meta_event) = meta_events.get(event_hash) {
+                if meta_event.meta_votes.len() >= initial_events.len() {
+                    let mut peer_ids: Vec<&P> = meta_event.meta_votes.keys().collect();
                     peer_ids.sort_by(|lhs, rhs| first_char(lhs).cmp(&first_char(rhs)));
 
                     for peer in &peer_ids {
-                        if let Some(votes) = event_meta_votes.get(peer) {
+                        if let Some(votes) = meta_event.meta_votes.get(peer) {
                             if votes.is_empty() {
                                 write!(writer, "\n{}: []", first_char(peer).unwrap_or('?'))?;
                             } else {
@@ -391,7 +396,7 @@ mod detail {
     fn write_gossip_graph_dot<T: NetworkEvent, S: SecretId>(
         writer: &mut Write,
         gossip_graph: &BTreeMap<Hash, Event<T, S::PublicId>>,
-        meta_votes: &BTreeMap<Hash, BTreeMap<S::PublicId, Vec<MetaVote>>>,
+        meta_events: &BTreeMap<Hash, MetaEvent<S::PublicId>>,
         peer_list: &PeerList<S>,
         initial_events: &[Hash],
     ) -> io::Result<()> {
@@ -433,7 +438,7 @@ mod detail {
             write_other_parents(writer, &events)?;
         }
 
-        write_evaluates(writer, gossip_graph, meta_votes, initial_events)?;
+        write_evaluates(writer, gossip_graph, meta_events, initial_events)?;
 
         write_nodes(writer, &nodes)?;
         writeln!(writer, "}}")

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -36,8 +36,6 @@ pub(crate) struct Event<T: NetworkEvent, P: PublicId> {
     index: u64,
     // Index of each peer's latest event that is an ancestor of this event.
     last_ancestors: BTreeMap<P, u64>,
-    // Payloads of all the votes deemed interesting by this event.
-    pub interesting_content: Vec<Observation<T, P>>,
 }
 
 impl<T: NetworkEvent, P: PublicId> Event<T, P> {
@@ -127,7 +125,6 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
             hash,
             index,
             last_ancestors,
-            interesting_content: vec![],
         }))
     }
 
@@ -229,14 +226,12 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
                 }
             };
 
-        // `interesting_content` and `observations` still need to be set correctly by the caller.
         Self {
             content,
             signature: peer_list.our_id().sign_detached(&serialised_content),
             hash: Hash::from(serialised_content.as_slice()),
             index,
             last_ancestors,
-            interesting_content: vec![],
         }
     }
 
@@ -290,16 +285,8 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
     }
 
     #[cfg(feature = "dump-graphs")]
-    pub fn write_to_dot_format(&self, writer: &mut Write) -> io::Result<()> {
-        writeln!(writer, "/// {{ {:?}", self.hash)?;
-        writeln!(writer, "/// cause: {}", self.content.cause)?;
-        writeln!(
-            writer,
-            "/// interesting_content: {:?}",
-            self.interesting_content
-        )?;
-        writeln!(writer, "/// last_ancestors: {:?}", self.last_ancestors)?;
-        writeln!(writer, "/// }}")
+    pub fn write_cause_to_dot_format(&self, writer: &mut Write) -> io::Result<()> {
+        writeln!(writer, "/// cause: {}", self.content.cause)
     }
 }
 
@@ -323,11 +310,6 @@ impl<T: NetworkEvent, P: PublicId> Debug for Event<T, P> {
             self.content.other_parent()
         )?;
         write!(formatter, ", last_ancestors: {:?}", self.last_ancestors)?;
-        write!(
-            formatter,
-            ", interesting_content: {:?}",
-            self.interesting_content
-        )?;
         write!(formatter, " }}")
     }
 }
@@ -342,7 +324,6 @@ impl Event<Transaction, PeerId> {
         other_parent: Option<Hash>,
         index: u64,
         last_ancestors: BTreeMap<PeerId, u64>,
-        interesting_content: Vec<Observation<Transaction, PeerId>>,
     ) -> Self {
         use dev_utils::parse_peer_ids;
 
@@ -396,7 +377,6 @@ impl Event<Transaction, PeerId> {
             hash: Hash::from(serialised_content.as_slice()),
             index,
             last_ancestors,
-            interesting_content,
         }
     }
 }

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -19,7 +19,7 @@ use observation::Observation;
 use peer_list::PeerList;
 use serialise;
 use std::cmp;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fmt::{self, Debug, Formatter};
 #[cfg(feature = "dump-graphs")]
 use std::io::{self, Write};
@@ -38,9 +38,6 @@ pub(crate) struct Event<T: NetworkEvent, P: PublicId> {
     last_ancestors: BTreeMap<P, u64>,
     // Payloads of all the votes deemed interesting by this event.
     pub interesting_content: Vec<Observation<T, P>>,
-    // The set of peers for which this event can strongly-see an event by that peer which carries a
-    // valid block.  If there are a supermajority of peers here, this event is an "observer".
-    pub observations: BTreeSet<P>,
 }
 
 impl<T: NetworkEvent, P: PublicId> Event<T, P> {
@@ -131,7 +128,6 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
             index,
             last_ancestors,
             interesting_content: vec![],
-            observations: BTreeSet::new(),
         }))
     }
 
@@ -241,7 +237,6 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
             index,
             last_ancestors,
             interesting_content: vec![],
-            observations: BTreeSet::new(),
         }
     }
 
@@ -333,7 +328,6 @@ impl<T: NetworkEvent, P: PublicId> Debug for Event<T, P> {
             ", interesting_content: {:?}",
             self.interesting_content
         )?;
-        write!(formatter, ", observations: {:?}", self.observations)?;
         write!(formatter, " }}")
     }
 }
@@ -403,7 +397,6 @@ impl Event<Transaction, PeerId> {
             index,
             last_ancestors,
             interesting_content,
-            observations: BTreeSet::new(),
         }
     }
 }

--- a/src/meta_voting/meta_elections.rs
+++ b/src/meta_voting/meta_elections.rs
@@ -6,7 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{MetaVote, MetaVotes};
+use super::meta_event::MetaEvent;
+use super::meta_vote::MetaVote;
 use hash::Hash;
 use id::PublicId;
 use network_event::NetworkEvent;
@@ -104,30 +105,6 @@ struct Outcome<T: NetworkEvent, P: PublicId> {
     payload: Observation<T, P>,
     // List of voters at the time this election was decided.
     voters: BTreeSet<P>,
-}
-
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub(crate) struct MetaEvent<T: NetworkEvent, P: PublicId> {
-    // The set of peers for which this event can strongly-see an event by that peer which carries a
-    // valid block.  If there are a supermajority of peers here, this event is an "observer".
-    pub observations: BTreeSet<P>,
-    // Payloads of all the votes deemed interesting by this event.
-    pub interesting_content: Vec<Observation<T, P>>,
-    pub meta_votes: MetaVotes<P>,
-}
-
-impl<T: NetworkEvent, P: PublicId> MetaEvent<T, P> {
-    pub fn new() -> Self {
-        MetaEvent {
-            observations: BTreeSet::new(),
-            interesting_content: Vec::new(),
-            meta_votes: MetaVotes::new(),
-        }
-    }
-
-    pub fn add_meta_votes(&mut self, peer_id: P, votes: Vec<MetaVote>) {
-        let _ = self.meta_votes.insert(peer_id, votes);
-    }
 }
 
 pub(crate) struct MetaElections<T: NetworkEvent, P: PublicId> {

--- a/src/meta_voting/meta_event.rs
+++ b/src/meta_voting/meta_event.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeSet;
 pub(crate) struct MetaEvent<T: NetworkEvent, P: PublicId> {
     // The set of peers for which this event can strongly-see an event by that peer which carries a
     // valid block.  If there are a supermajority of peers here, this event is an "observer".
-    pub observations: BTreeSet<P>,
+    pub observees: BTreeSet<P>,
     // Payloads of all the votes deemed interesting by this event.
     pub interesting_content: Vec<Observation<T, P>>,
     pub meta_votes: MetaVotes<P>,
@@ -30,7 +30,7 @@ impl<T: NetworkEvent, P: PublicId> MetaEvent<T, P> {
             election,
             event,
             meta_event: MetaEvent {
-                observations: BTreeSet::new(),
+                observees: BTreeSet::new(),
                 interesting_content: Vec::new(),
                 meta_votes: MetaVotes::new(),
             },
@@ -53,16 +53,16 @@ impl<'a, T: NetworkEvent + 'a, P: PublicId + 'a> MetaEventBuilder<'a, T, P> {
         self.event
     }
 
-    pub fn observation_count(&self) -> usize {
-        self.meta_event.observations.len()
+    pub fn observee_count(&self) -> usize {
+        self.meta_event.observees.len()
     }
 
-    pub fn has_observation(&self, peer_id: &P) -> bool {
-        self.meta_event.observations.contains(peer_id)
+    pub fn has_observee(&self, peer_id: &P) -> bool {
+        self.meta_event.observees.contains(peer_id)
     }
 
-    pub fn set_observations(&mut self, observations: BTreeSet<P>) {
-        self.meta_event.observations = observations;
+    pub fn set_observees(&mut self, observees: BTreeSet<P>) {
+        self.meta_event.observees = observees;
     }
 
     pub fn set_interesting_content(&mut self, content: Vec<Observation<T, P>>) {

--- a/src/meta_voting/meta_event.rs
+++ b/src/meta_voting/meta_event.rs
@@ -1,0 +1,37 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::meta_vote::{MetaVote, MetaVotes};
+use id::PublicId;
+use network_event::NetworkEvent;
+use observation::Observation;
+use std::collections::BTreeSet;
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub(crate) struct MetaEvent<T: NetworkEvent, P: PublicId> {
+    // The set of peers for which this event can strongly-see an event by that peer which carries a
+    // valid block.  If there are a supermajority of peers here, this event is an "observer".
+    pub observations: BTreeSet<P>,
+    // Payloads of all the votes deemed interesting by this event.
+    pub interesting_content: Vec<Observation<T, P>>,
+    pub meta_votes: MetaVotes<P>,
+}
+
+impl<T: NetworkEvent, P: PublicId> MetaEvent<T, P> {
+    pub fn new() -> Self {
+        MetaEvent {
+            observations: BTreeSet::new(),
+            interesting_content: Vec::new(),
+            meta_votes: MetaVotes::new(),
+        }
+    }
+
+    pub fn add_meta_votes(&mut self, peer_id: P, votes: Vec<MetaVote>) {
+        let _ = self.meta_votes.insert(peer_id, votes);
+    }
+}

--- a/src/meta_voting/meta_vote.rs
+++ b/src/meta_voting/meta_vote.rs
@@ -11,6 +11,8 @@ use super::meta_vote_counts::MetaVoteCounts;
 use std::collections::BTreeMap;
 use std::fmt::{self, Debug, Formatter};
 
+pub(crate) type MetaVotes<P> = BTreeMap<P, Vec<MetaVote>>;
+
 // This holds the state of a (binary) meta vote about which we're trying to achieve consensus.
 #[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct MetaVote {

--- a/src/meta_voting/mod.rs
+++ b/src/meta_voting/mod.rs
@@ -13,10 +13,9 @@ mod meta_vote_counts;
 
 #[cfg(test)]
 pub(crate) use self::bool_set::BoolSet;
-pub(crate) use self::meta_elections::{MetaElectionHandle, MetaElections};
+pub(crate) use self::meta_elections::{MetaElectionHandle, MetaElections, MetaEvent};
 pub(crate) use self::meta_vote::{MetaVote, Step};
 
-use hash::Hash;
 use std::collections::BTreeMap;
 
-pub(crate) type MetaVotes<P> = BTreeMap<Hash, BTreeMap<P, Vec<MetaVote>>>;
+pub(crate) type MetaVotes<P> = BTreeMap<P, Vec<MetaVote>>;

--- a/src/meta_voting/mod.rs
+++ b/src/meta_voting/mod.rs
@@ -8,14 +8,12 @@
 
 mod bool_set;
 mod meta_elections;
+mod meta_event;
 mod meta_vote;
 mod meta_vote_counts;
 
 #[cfg(test)]
 pub(crate) use self::bool_set::BoolSet;
-pub(crate) use self::meta_elections::{MetaElectionHandle, MetaElections, MetaEvent};
+pub(crate) use self::meta_elections::{MetaElectionHandle, MetaElections};
+pub(crate) use self::meta_event::MetaEvent;
 pub(crate) use self::meta_vote::{MetaVote, Step};
-
-use std::collections::BTreeMap;
-
-pub(crate) type MetaVotes<P> = BTreeMap<P, Vec<MetaVote>>;

--- a/src/meta_voting/mod.rs
+++ b/src/meta_voting/mod.rs
@@ -15,5 +15,5 @@ mod meta_vote_counts;
 #[cfg(test)]
 pub(crate) use self::bool_set::BoolSet;
 pub(crate) use self::meta_elections::{MetaElectionHandle, MetaElections};
-pub(crate) use self::meta_event::MetaEvent;
+pub(crate) use self::meta_event::{MetaEvent, MetaEventBuilder};
 pub(crate) use self::meta_vote::{MetaVote, Step};

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -458,11 +458,11 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             return false;
         }
 
-        let self_parent = if let Some(event) = self.self_parent(event) {
-            event
+        let self_parent = if let Some(self_parent) = self.self_parent(event) {
+            self_parent
         } else {
             log_or_panic!(
-                "{:?} has event {:?} with observarions, but not self-parent",
+                "{:?} has event {:?} with observations, but not self-parent",
                 self.our_pub_id(),
                 event
             );


### PR DESCRIPTION
This PR takes all data that is used for deciding meta-election and puts them under meta-election, so when multiple meta-elections are evaluated in parallel, the don't interfere with each other. Summary of changes:

- Introduced a struct called `MetaEvent` to contain all per-event, per-meta-election data.
- Added map of `Hash` -> `MetaEvent` to `MetaElection`.
- Moved `meta_votes` to `MetaEvent`.
- Moved `observations` from `Event` to `MetaEvent`.
- Moved `interesting_content` from `Event` to `MetaEvent`.
- Moved `interesting_events` from `Parsec` to `MetaElection`.
- A full list of voters is now stored in decided `MetaElection`s, instead of just the count.

This PR also includes some refactoring.