### PR TITLE
MAID-3055: detect invalid gossip creator

### DIFF
--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -198,6 +198,14 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
         &self.last_ancestors
     }
 
+    pub fn is_request(&self) -> bool {
+        if let Cause::Request { .. } = self.content.cause {
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn is_response(&self) -> bool {
         if let Cause::Response { .. } = self.content.cause {
             true

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -58,7 +58,7 @@ pub enum Malice {
     /// A node incorrectly accused other node of malice. Contains hash of the invalid Accusation
     /// event.
     InvalidAccusation(Hash),
-    /// We receive a gossip containing a event whose creator should not be known to the sender.
+    /// We receive a gossip containing an event whose creator should not be known to the sender.
     /// Contains hash of the sync event whose ancestor has the invalid creator.
     InvalidGossipCreator(Hash),
     // TODO: add other malice variants

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -58,5 +58,8 @@ pub enum Malice {
     /// A node incorrectly accused other node of malice. Contains hash of the invalid Accusation
     /// event.
     InvalidAccusation(Hash),
+    /// We receive a gossip containing a event whose creator should not be known to the sender.
+    /// Contains hash of the sync event whose ancestor has the invalid creator.
+    InvalidGossipCreator(Hash),
     // TODO: add other malice variants
 }

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -1640,12 +1640,6 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
     }
 
     fn detect_invalid_gossip_creator(&mut self, event: &Event<T, S::PublicId>) {
-        // Skip this detection on ourselves, because our membership list is always empty so we
-        // would end up always accusing ourselves.
-        if event.creator() == self.our_pub_id() {
-            return;
-        }
-
         let detected = {
             let parent = if let Some(parent) = self.self_parent(event) {
                 parent
@@ -1670,7 +1664,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             // accusations of the same malice.
             self.peer_list
                 .all_ids()
-                .filter(|peer_id| *peer_id != event.creator() && !membership_list.contains(peer_id))
+                .filter(|peer_id| !membership_list.contains(peer_id))
                 .filter_map(|peer_id| {
                     event
                         .last_ancestors()

--- a/src/peer_list.rs
+++ b/src/peer_list.rs
@@ -69,6 +69,10 @@ impl<S: SecretId> PeerList<S> {
         self.peers.contains_key(peer_id)
     }
 
+    pub fn peer(&self, peer_id: &S::PublicId) -> Option<&Peer<S::PublicId>> {
+        self.peers.get(peer_id)
+    }
+
     pub fn peer_state(&self, peer_id: &S::PublicId) -> PeerState {
         self.peers
             .get(peer_id)


### PR DESCRIPTION
This PR implemented detection of invalid gossip creator. It splits the malice detection into two phases: ~before-add~ before-process and ~after-consensus~ after-process. Invalid gossip creator is currently the only type of malice detected in the after-process phase, because it requires the membership list to be initialised to work.

This PR also fixes an issue with initialising the membership list, where if the other-parent were created by us, the membership list would end up empty. It also simplifies membership list handling by letting the peer's id to be stored in their own membership list too. It was originally omitted to prevent redundancy, but it created lot of special cases and complicated the code.

Finally, this PR fixes a bug in the graph dumping where the meta-votes would be missing from the graphs, by moving the dump before the new meta-election creation.

Edit: this PR also changes the way membership lists are initialised and handled. This is explained in more detail in the last commit message https://github.com/maidsafe/parsec/pull/149/commits/f039d9b1cf2f5089102b7a75cdc02ac91d75ada9).