### PR TITLE
MAID-3212: Switch the dot-parser to use the pom crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ safe_crypto = "0.4.0"
 [dev-dependencies]
 clap = "~2.31.2"
 criterion = "~0.2.5"
+pom = "1.1"
 
 [features]
 dump-graphs = []

--- a/src/dev_utils/mod.rs
+++ b/src/dev_utils/mod.rs
@@ -16,7 +16,7 @@ pub mod proptest;
 mod schedule;
 
 #[cfg(test)]
-pub(crate) use self::dot_parser::{parse_peer_ids, parse_test_dot_file, ParsedContents};
+pub(crate) use self::dot_parser::{parse_test_dot_file, ParsedContents};
 pub use self::environment::{Environment, RngChoice};
 pub use self::network::Network;
 pub use self::peer::{Peer, PeerStatus, PeerStatuses};

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -389,25 +389,21 @@ impl Event<Transaction, PeerId> {
         index: u64,
         last_ancestors: BTreeMap<PeerId, u64>,
     ) -> Self {
-        use dev_utils::parse_peer_ids;
-
         let cause = match cause {
-            "cause: Initial" => Cause::Initial,
+            "Initial" => Cause::Initial,
             // For the dot file contains only partial graph, we have to manually change the info of
             // ancestor to null for some events. In that case, populate ancestors with empty hash.
-            "cause: Request" => Cause::Request {
+            "Request" => Cause::Request {
                 self_parent: self_parent.unwrap_or(Hash::ZERO),
                 other_parent: other_parent.unwrap_or(Hash::ZERO),
             },
-            "cause: Response" => Cause::Response {
+            "Response" => Cause::Response {
                 self_parent: self_parent.unwrap_or(Hash::ZERO),
                 other_parent: other_parent.unwrap_or(Hash::ZERO),
             },
             _ => {
                 let content = unwrap!(unwrap!(cause.split('(').nth(2)).split(')').next());
-                let observation = if cause.contains("Genesis") {
-                    Observation::Genesis(parse_peer_ids(content))
-                } else if cause.contains("OpaquePayload") {
+                let observation = if cause.contains("OpaquePayload") {
                     Observation::OpaquePayload(Transaction::new(content))
                 } else if cause.contains("Genesis") {
                     // `content` will contain e.g. "{Alice, Bob, Carol, Dave, Eric}".

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,8 @@ extern crate lazy_static;
 extern crate log;
 #[macro_use]
 extern crate maidsafe_utilities;
+#[cfg(test)]
+extern crate pom;
 #[cfg(any(test, feature = "testing"))]
 #[macro_use]
 extern crate proptest as proptest_crate;

--- a/src/meta_voting/meta_elections.rs
+++ b/src/meta_voting/meta_elections.rs
@@ -18,7 +18,7 @@ use std::fmt::{self, Debug};
 use std::{iter, mem, usize};
 
 /// Handle that uniquely identifies a `MetaElection`.
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 pub(crate) struct MetaElectionHandle(usize);
 
 impl MetaElectionHandle {
@@ -40,6 +40,8 @@ impl Debug for MetaElectionHandle {
     }
 }
 
+#[serde(bound = "")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct MetaElection<T: NetworkEvent, P: PublicId> {
     meta_events: BTreeMap<Hash, MetaEvent<T, P>>,
     // The "round hash" for each set of meta votes.  They are held in sequence in the `Vec`, i.e.
@@ -104,6 +106,8 @@ impl<T: NetworkEvent, P: PublicId> MetaElection<T, P> {
     }
 }
 
+#[serde(bound = "")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct MetaElections<T: NetworkEvent, P: PublicId> {
     // Index of next decided meta-election
     next_index: usize,

--- a/src/meta_voting/meta_event.rs
+++ b/src/meta_voting/meta_event.rs
@@ -14,7 +14,8 @@ use network_event::NetworkEvent;
 use observation::Observation;
 use std::collections::BTreeSet;
 
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[serde(bound = "")]
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub(crate) struct MetaEvent<T: NetworkEvent, P: PublicId> {
     // The set of peers for which this event can strongly-see an event by that peer which carries a
     // valid block.  If there are a supermajority of peers here, this event is an "observer".


### PR DESCRIPTION
This is only the first part of changes that will constitute MAID-3212.

If I may suggest something regarding reviewing - it will probably be much easier to review the final state of `dot_parser.rs` instead of the diff, as the file is essentially rewritten and very little remained the same. The rest of the files only have small diffs, so they should cause less headaches :wink: 