### PR TITLE
Remove unused left over peers field in Peer struct

### DIFF
--- a/src/peer_list.rs
+++ b/src/peer_list.rs
@@ -499,7 +499,6 @@ pub struct Peer<P: PublicId> {
     id_hash: Hash,
     state: PeerState,
     events: BTreeSet<(u64, Hash)>,
-    peers: BTreeSet<P>,
     membership_list: BTreeSet<P>,
     membership_list_changes: Vec<(u64, MembershipListChange<P>)>,
 }
@@ -510,7 +509,6 @@ impl<P: PublicId> Peer<P> {
             id_hash: Hash::from(serialise(id).as_slice()),
             state,
             events: BTreeSet::new(),
-            peers: BTreeSet::new(),
             membership_list: BTreeSet::new(),
             membership_list_changes: Vec::new(),
         }


### PR DESCRIPTION
The peers field was accidentally left over and isn't actually used. A pretty minor change, probably the smallest in a while. But it's presence led me on a while goose chase when trying to understand the the code so I'd prefer to just get rid of it straight away.