### PR TITLE
Move the mock module behind a feature gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ script:
     cargo clippy --verbose --all-targets --features=testing,malice-detection &&
     cargo clippy --verbose --all-targets --features=dump-graphs,testing &&
     cargo clippy --verbose --all-targets --features=dump-graphs,testing,malice-detection &&
+    cargo clippy --verbose --all-targets --features=mock &&
+    cargo clippy --verbose --all-targets --features=mock,dump-graphs &&
+    cargo clippy --verbose --all-targets --features=mock,dump-graphs,malice-detection &&
     cargo clippy --verbose --manifest-path=dot_gen/Cargo.toml
 before_cache:
  - cargo prune

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,19 +21,24 @@ serde = "~1.0.66"
 serde_derive = "~1.0.66"
 tiny-keccak = "~1.4.2"
 unwrap = "~1.2.0"
-safe_crypto = "~0.4.0"
+safe_crypto = { version = "~0.4.0", optional = true }
 
 [dev-dependencies]
 clap = "~2.31.2"
 criterion = "~0.2.5"
 pom = "~1.1.0"
-proptest = "~0.8.6"
+safe_crypto = "~0.4.0"
 
 [features]
 dump-graphs = []
-testing = ["maidsafe_utilities/testing", "proptest"]
-default = ["safe_crypto/mock"]
+mock = ["safe_crypto/mock"]
+testing = ["maidsafe_utilities/testing", "proptest", "mock"]
 malice-detection = []
+
+[[example]]
+name = "basic"
+path = "examples/basic.rs"
+required-features = ["mock"]
 
 [[bench]]
 name = "bench"

--- a/src/dev_utils/mod.rs
+++ b/src/dev_utils/mod.rs
@@ -12,6 +12,7 @@ mod dot_parser;
 mod environment;
 mod network;
 mod peer;
+#[cfg(feature = "testing")]
 pub mod proptest;
 mod schedule;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@
     variant_size_differences
 )]
 
+#[cfg(any(test, feature = "dump-graphs", feature = "mock"))]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -68,11 +69,12 @@ extern crate log;
 extern crate maidsafe_utilities;
 #[cfg(test)]
 extern crate pom;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(feature = "testing")]
 #[macro_use]
 extern crate proptest as proptest_crate;
 #[macro_use]
 extern crate quick_error;
+#[cfg(any(test, feature = "dump-graphs", feature = "mock"))]
 extern crate rand;
 extern crate serde;
 #[macro_use]
@@ -81,6 +83,7 @@ extern crate tiny_keccak;
 #[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
 #[macro_use]
 extern crate unwrap;
+#[cfg(any(test, feature = "mock"))]
 extern crate safe_crypto;
 
 mod block;
@@ -107,6 +110,7 @@ pub mod dev_utils;
 /// This can be used to swap proper cryptographic functionality for inexpensive (in some cases
 /// no-op) replacements.  This is useful to allow tests to run quickly, but should not be used
 /// outside of testing code.
+#[cfg(any(test, feature = "mock"))]
 pub mod mock;
 
 pub use block::Block;


### PR DESCRIPTION
This trims the crate compiled for production a bit by feature-gating parts of the code that shouldn't be used in production, anyway.