### PR TITLE
Fix invalid InvalidGossipCreator accusations

### DIFF
--- a/src/dev_utils/schedule.rs
+++ b/src/dev_utils/schedule.rs
@@ -562,14 +562,17 @@ impl Schedule {
             for observation in obs_for_step {
                 match observation {
                     ObservationEvent::AddPeer(new_peer) => {
+                        let observation = ParsecObservation::Add(new_peer.clone());
+
                         peers.add_peer(new_peer.clone());
                         pending.peers_make_observation(
                             &mut env.rng,
                             peers.active_peers(),
                             step,
-                            &ParsecObservation::Add(new_peer.clone()),
+                            &observation,
                         );
                         schedule.push(ScheduleEvent::AddPeer(new_peer.clone()));
+
                         // vote for all observations that were made before this peer joined
                         // this prevents situations in which peers joining reach consensus before
                         // some other observations they haven't seen, which cause those
@@ -584,16 +587,22 @@ impl Schedule {
                                 obs,
                             );
                         }
+
+                        observations_made.push(observation);
                     }
                     ObservationEvent::RemovePeer(peer) => {
+                        let observation = ParsecObservation::Remove(peer.clone());
+
                         peers.remove_peer(&peer);
                         pending.peers_make_observation(
                             &mut env.rng,
                             peers.active_peers(),
                             step,
-                            &ParsecObservation::Remove(peer.clone()),
+                            &observation,
                         );
                         schedule.push(ScheduleEvent::RemovePeer(peer));
+
+                        observations_made.push(observation);
                     }
                     ObservationEvent::Opaque(payload) => {
                         let observation = ParsecObservation::OpaquePayload(payload);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -233,12 +233,15 @@ fn random_schedule_no_delays() {
 }
 
 #[test]
-fn add_peers() {
+fn add_many_peers() {
     let mut env = Environment::new(SEED);
+
     let schedule = Schedule::new(
         &mut env,
         &ScheduleOptions {
-            peers_to_add: 2,
+            genesis_size: 2,
+            peers_to_add: 8,
+            opaque_to_add: 0,
             ..Default::default()
         },
     );
@@ -247,7 +250,7 @@ fn add_peers() {
 }
 
 #[test]
-fn add_peers_and_vote() {
+fn add_few_peers_and_vote() {
     use parsec::dev_utils::ObservationEvent::*;
 
     let mut names = NAMES.iter();
@@ -267,6 +270,23 @@ fn add_peers_and_vote() {
 
     let schedule =
         Schedule::from_observation_schedule(&mut env, &ScheduleOptions::default(), obs_schedule);
+
+    unwrap!(env.network.execute_schedule(schedule));
+}
+
+#[test]
+fn add_many_peers_and_vote() {
+    let mut env = Environment::new(SEED);
+
+    let schedule = Schedule::new(
+        &mut env,
+        &ScheduleOptions {
+            genesis_size: 2,
+            peers_to_add: 8,
+            opaque_to_add: 10,
+            ..Default::default()
+        },
+    );
 
     unwrap!(env.network.execute_schedule(schedule));
 }


### PR DESCRIPTION
This commit includes multiple changes:

1. Modify the testing framework to fail when a node raises invalid accusation
2. Modify the testing framework so a joining node always votes for all previous `Add`s and `Remove`s, in addition to `OpaquePayload`s
3. In `Parsec::from_existing`, do not initialise membership list of non-genesis peers. Instead, leave the initialization to when we receive their first event with other-parent.
4. When detecting `InvalidGossipCreator`, consider only the direct other-parent, instead of all ancestors.
5. Modify the `add_peers` integration test to start at 2 peers and add 8 more peers (for the total of 10) one by one. Also rename to `add_many_peers`.