### PR TITLE
Minor updates

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -25,8 +25,6 @@
     non_shorthand_field_patterns,
     overflowing_literals,
     plugin_as_library,
-    private_no_mangle_fns,
-    private_no_mangle_statics,
     stable_features,
     unconditional_recursion,
     unknown_lints,

--- a/dot_gen/src/main.rs
+++ b/dot_gen/src/main.rs
@@ -60,8 +60,6 @@
     non_shorthand_field_patterns,
     overflowing_literals,
     plugin_as_library,
-    private_no_mangle_fns,
-    private_no_mangle_statics,
     stable_features,
     unconditional_recursion,
     unknown_lints,

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -23,8 +23,6 @@
     non_shorthand_field_patterns,
     overflowing_literals,
     plugin_as_library,
-    private_no_mangle_fns,
-    private_no_mangle_statics,
     stable_features,
     unconditional_recursion,
     unknown_lints,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,6 @@
     non_shorthand_field_patterns,
     overflowing_literals,
     plugin_as_library,
-    private_no_mangle_fns,
-    private_no_mangle_statics,
     stable_features,
     unconditional_recursion,
     unknown_lints,

--- a/src/peer_list.rs
+++ b/src/peer_list.rs
@@ -468,26 +468,26 @@ impl Debug for PeerState {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let mut separator = false;
 
-        write!(f, "PeerState(");
+        write!(f, "PeerState(")?;
 
         if self.contains(Self::VOTE) {
             separator = true;
-            write!(f, "VOTE");
+            write!(f, "VOTE")?;
         }
 
         if self.contains(Self::SEND) {
             if separator {
-                write!(f, "|");
+                write!(f, "|")?;
             }
             separator = true;
-            write!(f, "SEND");
+            write!(f, "SEND")?;
         }
 
         if self.contains(Self::RECV) {
             if separator {
-                write!(f, "|");
+                write!(f, "|")?;
             }
-            write!(f, "RECV");
+            write!(f, "RECV")?;
         }
 
         write!(f, ")")

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -27,8 +27,6 @@
     non_shorthand_field_patterns,
     overflowing_literals,
     plugin_as_library,
-    private_no_mangle_fns,
-    private_no_mangle_statics,
     stable_features,
     unconditional_recursion,
     unknown_lints,


### PR DESCRIPTION
These two commits fix a couple of issues exposed when I ran the benchmark suite using the latest nightly compiler.  Certainly the unused results seem to be a worthwhile fix.  The removed lints could probably be delayed, but I'd think the sooner we start updating our libs the better.