### PR TITLE
MAID-3248: Ensure PARSEC works with consensus on single opaque transaction

### DIFF
--- a/src/dev_utils/schedule.rs
+++ b/src/dev_utils/schedule.rs
@@ -368,13 +368,13 @@ impl ObservationSchedule {
             }
             if added_peers < options.peers_to_add && rng.gen::<f64>() < options.prob_add {
                 let next_id = PeerId::new(names_iter.next().unwrap());
-                peers.add_peer(next_id.clone());
+                peers.add_peer(next_id.clone(), step);
                 schedule.push((step, ObservationEvent::AddPeer(next_id)));
                 num_observations += 1;
                 added_peers += 1;
             }
             if removed_peers < options.peers_to_remove && rng.gen::<f64>() < options.prob_remove {
-                if let Some(id) = peers.remove_random_peer(rng, options.min_peers) {
+                if let Some(id) = peers.remove_random_peer(rng, options.min_peers, step) {
                     schedule.push((step, ObservationEvent::RemovePeer(id)));
                     num_observations += 1;
                     removed_peers += 1;
@@ -383,7 +383,7 @@ impl ObservationSchedule {
 
             // generate a random failure
             if rng.gen::<f64>() < options.prob_failure {
-                if let Some(id) = peers.fail_random_peer(rng, options.min_peers) {
+                if let Some(id) = peers.fail_random_peer(rng, options.min_peers, step) {
                     schedule.push((step, ObservationEvent::Fail(id)));
                 }
             }
@@ -395,7 +395,7 @@ impl ObservationSchedule {
                 .unwrap_or(0);
 
             for _ in 0..num_deterministic_fails {
-                if let Some(id) = peers.fail_random_peer(rng, options.min_peers) {
+                if let Some(id) = peers.fail_random_peer(rng, options.min_peers, step) {
                     schedule.push((step, ObservationEvent::Fail(id)));
                 }
             }
@@ -558,7 +558,7 @@ impl Schedule {
                             related_info: vec![],
                         };
 
-                        peers.add_peer(new_peer.clone());
+                        peers.add_peer(new_peer.clone(), step);
                         pending.peers_make_observation(
                             &mut env.rng,
                             peers.active_peers(),

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -792,22 +792,30 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
                     this_payload,
                     start_index,
                 );
-                if (self.is_interesting_event)(
-                    &peers_that_did_vote.keys().cloned().collect(),
-                    &peers_that_can_vote,
-                ) {
-                    Some((
-                        this_payload.clone(),
-                        peers_that_did_vote
+                {
+                    let check_interesting: IsInterestingEventFn<S::PublicId> =
+                        if let &Observation::OpaquePayload(_) = this_payload {
+                            self.is_interesting_event
+                        } else {
+                            is_supermajority
+                        };
+                    if check_interesting(
+                        &peers_that_did_vote.keys().cloned().collect(),
+                        &peers_that_can_vote,
+                    ) {
+                        Some((
+                            this_payload.clone(),
+                            peers_that_did_vote
                             .get(builder.event().creator())
                             .cloned()
                             // Sometimes the interesting event's creator won't have voted for the
                             // payload that became interesting - in such a case we would like it
                             // sorted at the end of the "queue"
                             .unwrap_or(u64::MAX),
-                    ))
-                } else {
-                    None
+                        ))
+                    } else {
+                        None
+                    }
                 }
             }).collect();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -358,7 +358,6 @@ fn fail_add_remove() {
 }
 
 #[test]
-#[ignore]
 fn custom_is_interesting_event_that_requires_only_one_vote() {
     fn at_least_one(did_vote: &BTreeSet<PeerId>, can_vote: &BTreeSet<PeerId>) -> bool {
         did_vote.intersection(can_vote).next().is_some()


### PR DESCRIPTION
This modifies PARSEC so that opaque transactions that only require a single vote are handled correctly.

One of the bigger changes is the introduction of "interesting payload inheritance": if an event has an ancestor that contains a given interesting payload, and it is a viable interesting payload candidate (i.e. no self-ancestor carries it already), then it automatically becomes an interesting payload of this event as well. This was already happening indirectly in the absence of forks, but this change ensures that this desired property also holds if forks are present.

There are still possible performance enhancements to be made; TBD if they should be done as a part of this PR.