### PR TITLE
MAID-3257: avoid calling create_hash() as frequently

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -7,7 +7,6 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use error::Error;
-use hash::Hash;
 use id::{Proof, PublicId};
 use network_event::NetworkEvent;
 use observation::Observation;
@@ -48,11 +47,6 @@ impl<T: NetworkEvent, P: PublicId> Block<T, P> {
     /// Returns the proofs of this block.
     pub fn proofs(&self) -> &BTreeSet<Proof<P>> {
         &self.proofs
-    }
-
-    /// Returns the hash of this block's payload.
-    pub fn create_payload_hash(&self) -> Hash {
-        self.payload.create_hash()
     }
 
     /// Converts `vote` to a `Proof` and attempts to add it to the block.  Returns an error if

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -190,6 +190,7 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
         &self.cache.last_ancestors
     }
 
+    #[cfg(feature = "testing")]
     pub fn is_request(&self) -> bool {
         if let Cause::Request { .. } = self.content.cause {
             true

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -10,7 +10,6 @@ use gossip::PackedEvent;
 use hash::Hash;
 use id::PublicId;
 use network_event::NetworkEvent;
-use serialise;
 use std::collections::BTreeSet;
 use std::fmt::{self, Debug, Formatter};
 
@@ -45,10 +44,12 @@ pub enum Observation<T: NetworkEvent, P: PublicId> {
     OpaquePayload(T),
 }
 
-impl<T: NetworkEvent, P: PublicId> Observation<T, P> {
-    /// Compute hash of this `Observation`.
-    pub fn create_hash(&self) -> Hash {
-        Hash::from(serialise(self).as_slice())
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub(crate) struct ObservationHash(pub Hash);
+
+impl Debug for ObservationHash {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "{:?}", self.0)
     }
 }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -794,16 +794,13 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         let start_index = self.meta_elections.start_index(builder.election());
 
         let mut payloads_set: BTreeSet<_> = self
-            .peer_list
-            .iter()
-            .flat_map(|(_peer_id, peer)| {
-                peer.events().filter_map(|hash| {
-                    self.events.get(hash).and_then(|event| {
-                        event
-                            .vote()
-                            .and_then(|vote| self.hash_from_payload(vote.payload()))
-                    })
-                })
+            .events
+            .values()
+            .filter(|event| event.topological_index() >= start_index)
+            .filter_map(|event| {
+                event
+                    .vote()
+                    .and_then(|vote| self.hash_from_payload(vote.payload()))
             }).filter(|this_payload_hash| {
                 self.meta_elections.is_interesting_content_candidate(
                     builder.election(),

--- a/src/round_hash.rs
+++ b/src/round_hash.rs
@@ -8,19 +8,20 @@
 
 use hash::Hash;
 use id::PublicId;
+use observation::ObservationHash;
 use serialise;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
 pub(crate) struct RoundHash {
     public_id_hash: Hash,
-    latest_block_hash: Hash,
+    latest_block_hash: ObservationHash,
     round: usize,
     final_hash: Hash,
 }
 
 impl RoundHash {
     // Constructs a new `RoundHash` with the given `public_id` and `latest_block_hash` for round 0.
-    pub fn new<P: PublicId>(public_id: &P, latest_block_hash: Hash) -> Self {
+    pub fn new<P: PublicId>(public_id: &P, latest_block_hash: ObservationHash) -> Self {
         Self::new_with_round(public_id, latest_block_hash, 0)
     }
 
@@ -28,7 +29,7 @@ impl RoundHash {
     // round
     pub fn new_with_round<P: PublicId>(
         public_id: &P,
-        latest_block_hash: Hash,
+        latest_block_hash: ObservationHash,
         round: usize,
     ) -> Self {
         let public_id_hash = Hash::from(serialise(&public_id).as_slice());
@@ -61,7 +62,7 @@ impl RoundHash {
     }
 
     #[cfg(feature = "dump-graphs")]
-    pub fn latest_block_hash(&self) -> &Hash {
+    pub fn latest_block_hash(&self) -> &ObservationHash {
         &self.latest_block_hash
     }
 
@@ -70,7 +71,11 @@ impl RoundHash {
         &self.final_hash
     }
 
-    fn final_hash(public_id_hash: &Hash, latest_block_hash: &Hash, round: usize) -> Hash {
+    fn final_hash(
+        public_id_hash: &Hash,
+        latest_block_hash: &ObservationHash,
+        round: usize,
+    ) -> Hash {
         let round_hash = Hash::from(serialise(&round).as_slice());
         Hash::from(serialise(&(public_id_hash, latest_block_hash, round_hash)).as_slice())
     }


### PR DESCRIPTION
This commit adds a map of observations to their hashes, and uses `ObservationHash`s extensively in place of `Observation`s to reduce the number of times we serialise and hash `Observation`s.