### PR TITLE
MAID-3259: only shorten debug hashes for dump-graphs

### DIFF
--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -8,7 +8,7 @@
 
 use gossip::{CauseInput, Event};
 use hash::Hash;
-use hash::{HASH_LEN, HEX_DIGITS_PER_BYTE};
+use hash::HASH_LEN;
 use meta_voting::{
     BoolSet, MetaElection, MetaElectionHandle, MetaElections, MetaEvent, MetaVote, Step,
 };
@@ -25,6 +25,8 @@ use std::fs::File;
 use std::io::{self, Read};
 use std::path::Path;
 use std::str::FromStr;
+
+pub const HEX_DIGITS_PER_BYTE: usize = 2;
 
 fn newline() -> Parser<u8, ()> {
     (seq(b"\n") | seq(b"\r\n")).discard()

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -7,12 +7,11 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use std::cmp::Ordering;
+use std::fmt::Display;
 use std::fmt::{self, Debug, Formatter};
 use tiny_keccak;
 
 pub const HASH_LEN: usize = 32;
-#[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
-pub const HEX_DIGITS_PER_BYTE: usize = 2;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Hash([u8; HASH_LEN]);
@@ -39,11 +38,7 @@ impl Hash {
 
     #[cfg(feature = "dump-graphs")]
     pub fn as_full_string(&self) -> String {
-        let mut result = String::with_capacity(HEX_DIGITS_PER_BYTE * HASH_LEN);
-        for i in 0..HASH_LEN {
-            result.push_str(&format!("{:02x}", self.0[i]));
-        }
-        result
+        format!("{}", HashDisplay(self))
     }
 }
 
@@ -54,11 +49,28 @@ impl<'a> From<&'a [u8]> for Hash {
 }
 
 impl Debug for Hash {
+    #[cfg(feature = "dump-graphs")]
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(
             formatter,
             "{:02x}{:02x}{:02x}{:02x}{:02x}..",
             self.0[0], self.0[1], self.0[2], self.0[3], self.0[4]
         )
+    }
+
+    #[cfg(not(feature = "dump-graphs"))]
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "{}", HashDisplay(self))
+    }
+}
+
+struct HashDisplay<'a>(&'a Hash);
+
+impl<'a> Display for HashDisplay<'a> {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        for byte in &(self.0).0 {
+            write!(formatter, "{:02x}", byte)?;
+        }
+        Ok(())
     }
 }

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -61,6 +61,11 @@ impl<T: NetworkEvent, P: PublicId> Debug for Observation<T, P> {
             Observation::Accusation { offender, malice } => {
                 write!(formatter, "Accusation {{ {:?}, {:?} }}", offender, malice)
             }
+            #[cfg(not(feature = "dump-graphs"))]
+            Observation::OpaquePayload(payload) => {
+                write!(formatter, "OpaquePayload({:?})", payload)
+            }
+            #[cfg(feature = "dump-graphs")]
             Observation::OpaquePayload(payload) => {
                 let max_length = 16;
                 let mut payload_str = format!("{:?}", payload);


### PR DESCRIPTION
It's useful for clients like routing to have the whole hash printed by the Debug trait. Let's print the whole one except for when dumping graphs.