### PR TITLE
MAID-3260: fix the test for single-vote interesting events

### DIFF
--- a/src/dev_utils/schedule.rs
+++ b/src/dev_utils/schedule.rs
@@ -366,7 +366,10 @@ impl ObservationSchedule {
                 num_observations += 1;
                 opaque_count += 1;
             }
-            if added_peers < options.peers_to_add && rng.gen::<f64>() < options.prob_add {
+            if added_peers < options.peers_to_add
+                && rng.gen::<f64>() < options.prob_add
+                && peers.can_mutate(step)
+            {
                 let next_id = PeerId::new(names_iter.next().unwrap());
                 peers.add_peer(next_id.clone(), step);
                 schedule.push((step, ObservationEvent::AddPeer(next_id)));

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -462,6 +462,12 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             return true;
         }
 
+        // If self-parent is earlier in history than the start of the meta-election, it won't have
+        // a meta-event; but it also means that it wasn't an observer, so this event is
+        if self.meta_elections.start_index(builder.election()) > self_parent.topological_index() {
+            return true;
+        }
+
         if let Some(meta_parent) = self
             .meta_elections
             .meta_event(builder.election(), self_parent.hash())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -357,9 +357,7 @@ fn fail_add_remove() {
     assert!(result.is_ok(), "{:?}", result);
 }
 
-// TODO: find the reason behind intermittent failures, fix it and unignore the test
 #[test]
-#[ignore]
 fn custom_is_interesting_event_that_requires_only_one_vote() {
     fn at_least_one(did_vote: &BTreeSet<PeerId>, can_vote: &BTreeSet<PeerId>) -> bool {
         did_vote.intersection(can_vote).next().is_some()


### PR DESCRIPTION
This PR modifies the test framework so that it is much less likely to make too many network mutations at once (which caused the simulated section to stall and the test to fail), as well as fixes a bug in `is_observer`.