### PR TITLE
MAID-3261: chore/parsec: fix performance regression

### DIFF
--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -215,6 +215,10 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
         }
     }
 
+    pub fn sees_fork(&self) -> bool {
+        !self.cache.forking_peers.is_empty()
+    }
+
     /// Returns the first char of the creator's ID, followed by an underscore and the event's index.
     pub fn short_name(&self) -> String {
         format!(

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -814,7 +814,8 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
                     &peers_that_can_vote,
                     &this_payload_hash,
                     start_index,
-                ) || event.sees_fork() && self.has_interesting_ancestor(builder, &this_payload_hash)
+                ) || event.sees_fork()
+                    && self.has_interesting_ancestor(builder, &this_payload_hash, start_index)
             }).map(|(_, hash)| hash)
             .cloned()
             .collect();
@@ -882,8 +883,10 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         &self,
         builder: &MetaEventBuilder<T, S::PublicId>,
         payload_hash: &ObservationHash,
+        start_index: usize,
     ) -> bool {
         graph::ancestors(&self.events, builder.event())
+            .take_while(|event| event.topological_index() >= start_index)
             .filter(|that_event| that_event.creator() != builder.event().creator())
             .any(|that_event| {
                 self.meta_elections


### PR DESCRIPTION
When we started evaluating wether events had interesting ancestors to
resolve an issue with votes becoming "unseen" due to forks, we
introduced a performance regression as checking wether an event has an
interesting ancestor is expensive.

Regain the performance in the happy case by only performing this check
when this event sees forks.