### PR TITLE
Move functional tests behind the mock feature gate

### DIFF
--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -664,7 +664,7 @@ impl ParsedContents {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mock"))]
 impl ParsedContents {
     /// Remove and return the last (newest) event from the `ParsedContents`, if any.
     pub fn remove_last_event(&mut self) -> Option<Event<Transaction, PeerId>> {

--- a/src/dev_utils/mod.rs
+++ b/src/dev_utils/mod.rs
@@ -18,10 +18,12 @@ pub mod proptest;
 mod record;
 mod schedule;
 
-#[cfg(all(test, feature = "malice-detection"))]
+#[cfg(all(test, feature = "mock", feature = "malice-detection"))]
 pub(crate) use self::dot_parser::parse_dot_file_with_test_name;
 #[cfg(test)]
-pub(crate) use self::dot_parser::{parse_test_dot_file, ParsedContents};
+pub(crate) use self::dot_parser::parse_test_dot_file;
+#[cfg(all(test, feature = "mock"))]
+pub(crate) use self::dot_parser::ParsedContents;
 pub use self::environment::{Environment, RngChoice};
 pub use self::network::Network;
 pub use self::peer::{Peer, PeerStatus, PeerStatuses};

--- a/src/gossip/graph/mod.rs
+++ b/src/gossip/graph/mod.rs
@@ -201,7 +201,7 @@ impl<'a, T: NetworkEvent, P: PublicId> Iterator for Iter<'a, T, P> {
     }
 }
 
-#[cfg(any(test, feature = "dump-graphs"))]
+#[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
 pub(crate) mod snapshot {
     use super::*;
 

--- a/src/gossip/mod.rs
+++ b/src/gossip/mod.rs
@@ -20,7 +20,7 @@ pub(super) use self::event::find_event_by_short_name;
 pub(super) use self::event::CauseInput;
 pub(super) use self::event::Event;
 pub use self::event_hash::EventHash;
-#[cfg(any(test, feature = "dump-graphs"))]
+#[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
 pub(super) use self::graph::snapshot::GraphSnapshot;
 pub(super) use self::graph::{EventIndex, Graph, IndexedEventRef};
 pub use self::messages::{Request, Response};

--- a/src/gossip/packed_event.rs
+++ b/src/gossip/packed_event.rs
@@ -7,13 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::content::Content;
-#[cfg(all(test, feature = "malice-detection"))]
+#[cfg(all(test, feature = "mock", feature = "malice-detection"))]
 use super::event_hash::EventHash;
-#[cfg(all(test, feature = "malice-detection"))]
+#[cfg(all(test, feature = "mock", feature = "malice-detection"))]
 use hash::Hash;
 use id::PublicId;
 use network_event::NetworkEvent;
-#[cfg(all(test, feature = "malice-detection"))]
+#[cfg(all(test, feature = "mock", feature = "malice-detection"))]
 use serialise;
 use std::fmt::{self, Debug, Formatter};
 
@@ -38,7 +38,7 @@ impl<T: NetworkEvent, P: PublicId> Debug for PackedEvent<T, P> {
     }
 }
 
-#[cfg(all(test, feature = "malice-detection"))]
+#[cfg(all(test, feature = "mock", feature = "malice-detection"))]
 impl<T: NetworkEvent, P: PublicId> PackedEvent<T, P> {
     pub(crate) fn self_parent(&self) -> Option<&EventHash> {
         self.content.self_parent()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ mod peer_list;
 mod round_hash;
 mod vote;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mock"))]
 mod functional_tests;
 
 #[doc(hidden)]

--- a/src/meta_voting/meta_elections.rs
+++ b/src/meta_voting/meta_elections.rs
@@ -375,7 +375,7 @@ impl<P: PublicId> MetaElections<P> {
         self.current_election.initialise(peer_ids, hash);
     }
 
-    #[cfg(any(test, feature = "dump-graphs"))]
+    #[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
     pub fn current_meta_events(&self) -> &BTreeMap<EventIndex, MetaEvent<P>> {
         &self.current_election.meta_events
     }
@@ -419,7 +419,7 @@ impl<P: PublicId> MetaElections<P> {
     }
 }
 
-#[cfg(any(test, feature = "dump-graphs"))]
+#[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
 pub(crate) mod snapshot {
     use super::*;
     use gossip::{EventHash, Graph};

--- a/src/meta_voting/mod.rs
+++ b/src/meta_voting/mod.rs
@@ -14,7 +14,7 @@ mod meta_vote_counts;
 
 #[cfg(any(test, feature = "testing"))]
 pub(crate) use self::bool_set::BoolSet;
-#[cfg(any(test, feature = "dump-graphs"))]
+#[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
 pub(crate) use self::meta_elections::snapshot::MetaElectionsSnapshot;
 #[cfg(any(test, feature = "testing"))]
 pub(crate) use self::meta_elections::MetaElection;

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use block::Block;
-#[cfg(test)]
+#[cfg(all(test, feature = "mock"))]
 use dev_utils::ParsedContents;
 use dump_graph;
 use error::{Error, Result};
@@ -16,13 +16,13 @@ use gossip::{
 };
 use id::{PublicId, SecretId};
 use meta_voting::{MetaElectionHandle, MetaElections, MetaEvent, MetaEventBuilder, MetaVote, Step};
-#[cfg(test)]
+#[cfg(all(test, feature = "mock"))]
 use mock::{PeerId, Transaction};
 use network_event::NetworkEvent;
 use observation::{Malice, Observation, ObservationHash};
 use peer_list::{PeerList, PeerState};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
-#[cfg(test)]
+#[cfg(all(test, feature = "mock"))]
 use std::ops::{Deref, DerefMut};
 use std::{mem, usize};
 use vote::Vote;
@@ -1957,7 +1957,7 @@ impl<T: NetworkEvent, P: PublicId> ObservationInfo<T, P> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mock"))]
 impl Parsec<Transaction, PeerId> {
     pub(crate) fn from_parsed_contents(mut parsed_contents: ParsedContents) -> Self {
         let mut parsec = Parsec::empty(parsed_contents.our_id, &BTreeSet::new(), is_supermajority);
@@ -2006,10 +2006,10 @@ impl Parsec<Transaction, PeerId> {
 }
 
 /// Wrapper around `Parsec` that exposes additional functionality useful for testing.
-#[cfg(test)]
+#[cfg(all(test, feature = "mock"))]
 pub(crate) struct TestParsec<T: NetworkEvent, S: SecretId>(Parsec<T, S>);
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mock"))]
 impl<T: NetworkEvent, S: SecretId> TestParsec<T, S> {
     pub fn from_genesis(our_id: S, genesis_group: &BTreeSet<S::PublicId>) -> Self {
         TestParsec(Parsec::from_genesis(
@@ -2117,14 +2117,14 @@ impl<T: NetworkEvent, S: SecretId> TestParsec<T, S> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mock"))]
 impl TestParsec<Transaction, PeerId> {
     pub(crate) fn from_parsed_contents(parsed_contents: ParsedContents) -> Self {
         TestParsec(Parsec::from_parsed_contents(parsed_contents))
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mock"))]
 impl<T: NetworkEvent, S: SecretId> Deref for TestParsec<T, S> {
     type Target = Parsec<T, S>;
 
@@ -2133,7 +2133,7 @@ impl<T: NetworkEvent, S: SecretId> Deref for TestParsec<T, S> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mock"))]
 impl<T: NetworkEvent, S: SecretId> DerefMut for TestParsec<T, S> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0

--- a/src/peer_list.rs
+++ b/src/peer_list.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mock"))]
 pub(crate) use self::snapshot::PeerListSnapshot;
 use error::Error;
 #[cfg(any(test, feature = "testing"))]
@@ -697,6 +697,7 @@ pub(crate) mod snapshot {
         BTreeMap<P, (PeerState, BTreeSet<(usize, EventHash)>)>,
     );
 
+    #[cfg(feature = "mock")]
     impl<P: PublicId> PeerListSnapshot<P> {
         pub fn new<T: NetworkEvent, S: SecretId<PublicId = P>>(
             peer_list: &PeerList<S>,


### PR DESCRIPTION
Move the functional tests behind the mock feature gate so that `cargo test` works out of the box.