### PR TITLE
docs/parsec: use dump-graphs and new parameters for command lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 There is a basic example available in the examples folder.  This allows you to simulate a network of peers each running the Parsec protocol to reach consensus on a number of random network events.  There is also the ability to dump each peer's gossip graph in dot format to a file in your system temp dir.  This can be enabled via the feature `dump-graphs`.  So, e.g. to run the example for a network of five peers and ten network events:
 
 ```
-cargo run --example=basic --features=dump-graphs -- --peers=5 --events=10
+cargo run --example=basic --features=mock,dump-graphs -- --initial-peers=5 --opaque=10
 ```
 
 If you have `dot` from [graphviz](https://graphviz.gitlab.io/download) available in your path, then SVG graphs will also have been generated from each of these dot files.  If not, you can copy the contents of a generated dot file into an online converter (e.g. http://viz-js.com) to view the gossip graph.

--- a/tutorial.md
+++ b/tutorial.md
@@ -30,7 +30,7 @@ From the parsec repository, run the tests. Be sure to use the feature: `dump-gra
 
 ```
 cd parsec
-cargo test --release --features=mock -- --nocapture
+cargo test --release --features=dump-graphs,mock -- --nocapture
 ```
 
 # View the graphs
@@ -89,7 +89,7 @@ Now, `test_minimal_network` is a silly example as reaching consensus on a single
 
 For more control over the scenario, please run the example. To see which options you may use, run
 ```
-cargo run --release --example basic --features=mock -- --help
+cargo run --release --example basic --features=dump-graphs,mock -- --help
 ```
 
 For instance, for an example with 10 peers agreeing on the order of 5 events, run


### PR DESCRIPTION
Re-add dump-graphs unintentionally removed when updating parameters in tutorial.md.
Update README.md that need to be in sync with tutorial.md.
Keep the long name parameter for clarity.
Verify the command succeed.