### PR TITLE
Fix issue with invalid block signatory when ConsensusMode is Single

### DIFF
--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -289,7 +289,12 @@ impl Network {
         } else {
             ConsensusMode::Supermajority
         };
-        let correct_signatories = consensus_mode.check(signatories.len(), section.len());
+        let correct_signatories = match consensus_mode {
+            ConsensusMode::Single => !signatories.is_empty(),
+            ConsensusMode::Supermajority => {
+                is_more_than_two_thirds(signatories.len(), section.len())
+            }
+        };
         if !correct_signatories {
             return Err(ConsensusError::TooFewSignatures {
                 observation: block.payload().clone(),

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -186,6 +186,16 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
         }
     }
 
+    pub fn vote_with_payload_hash(&self) -> Option<(&Vote<T, P>, &ObservationHash)> {
+        self.vote().and_then(|vote| match self.cache.payload_hash {
+            Some(ref hash) => Some((vote, hash)),
+            None => {
+                log_or_panic!("Event has payload but no payload hash: {:?}", self);
+                None
+            }
+        })
+    }
+
     pub fn payload(&self) -> Option<&Observation<T, P>> {
         self.vote().map(Vote::payload)
     }
@@ -195,13 +205,8 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
     }
 
     pub fn payload_with_hash(&self) -> Option<(&Observation<T, P>, &ObservationHash)> {
-        self.vote().and_then(|vote| match self.cache.payload_hash {
-            Some(ref hash) => Some((vote.payload(), hash)),
-            None => {
-                log_or_panic!("Event has payload but no payload hash: {:?}", self);
-                None
-            }
-        })
+        self.vote_with_payload_hash()
+            .map(|(vote, hash)| (vote.payload(), hash))
     }
 
     pub fn creator(&self) -> &P {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -368,7 +368,7 @@ fn fail_add_remove() {
 }
 
 #[test]
-fn custom_is_interesting_event_that_requires_only_one_vote() {
+fn consensus_mode_single() {
     let mut env = Environment::with_consensus_mode(SEED, ConsensusMode::Single);
     let options = ScheduleOptions {
         genesis_size: 4,


### PR DESCRIPTION
This PR changes the way blocks are created. Now a block is signed only by peers who are still voters at the time of the block creation. If there are no such peers, the block is skipped. That can happen when a peer votes first and is removed shortly after, but the removal is consensused before the vote. 

This PR also implements minor optimizations by replacing comparisons of `Observation`s with  comparison of `ObservationHash`es in a couple of places.