### PR TITLE
MAID-3266: Support single-vote blocks

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -23,11 +23,11 @@ pub struct Block<T: NetworkEvent, P: PublicId> {
 
 impl<T: NetworkEvent, P: PublicId> Block<T, P> {
     /// Creates a `Block` from `votes`.
-    pub fn new(votes: &BTreeMap<P, Vote<T, P>>) -> Result<Option<Self>, Error> {
+    pub fn new(votes: &BTreeMap<P, Vote<T, P>>) -> Result<Self, Error> {
         let payload = if let Some(vote) = votes.values().next() {
             vote.payload().clone()
         } else {
-            return Ok(None);
+            return Err(Error::MissingVotes);
         };
 
         let proofs: Result<BTreeSet<_>, _> = votes
@@ -41,7 +41,7 @@ impl<T: NetworkEvent, P: PublicId> Block<T, P> {
             }).collect();
         let proofs = proofs?;
 
-        Ok(Some(Self { payload, proofs }))
+        Ok(Self { payload, proofs })
     }
 
     /// Returns the payload of this block.

--- a/src/dev_utils/environment.rs
+++ b/src/dev_utils/environment.rs
@@ -8,7 +8,7 @@
 
 use dev_utils::network::Network;
 use maidsafe_utilities::SeededRng;
-use parsec::ConsensusMode;
+use observation::ConsensusMode;
 use rand::{Rng, SeedableRng, XorShiftRng};
 use std::fmt;
 

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -9,8 +9,8 @@
 use super::Observation;
 use block::Block;
 use mock::{PeerId, Transaction};
-use observation::{Malice, Observation as ParsecObservation};
-use parsec::{ConsensusMode, Parsec};
+use observation::{ConsensusMode, Malice, Observation as ParsecObservation};
+use parsec::Parsec;
 use rand::Rng;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug, Formatter};

--- a/src/dev_utils/record.rs
+++ b/src/dev_utils/record.rs
@@ -9,8 +9,8 @@
 use super::dot_parser::{parse_dot_file, ParsedContents};
 use gossip::{Event, Request, Response};
 use mock::{PeerId, Transaction};
-use observation::Observation;
-use parsec::{ConsensusMode, Parsec};
+use observation::{ConsensusMode, Observation};
+use parsec::Parsec;
 use std::collections::BTreeSet;
 use std::io;
 use std::path::Path;

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -567,12 +567,12 @@ mod detail {
                 Self::COMMENT,
                 self.indentation()
             ));
-            for hash in self.meta_elections.consensus_history() {
+            for key in self.meta_elections.consensus_history() {
                 lines.push(format!(
                     "{}{}{}",
                     Self::COMMENT,
                     self.indentation(),
-                    hash.0.full_display()
+                    key.hash().0.full_display()
                 ));
             }
             for handle in self.meta_elections.all() {
@@ -661,8 +661,8 @@ mod detail {
                 ));
 
                 // write payload
-                if let Some(ref payload_hash) = election.payload_hash {
-                    if let Some(payload) = self.observations.get(payload_hash) {
+                if let Some(ref payload_key) = election.payload_key {
+                    if let Some(payload) = self.observations.get(payload_key.hash()) {
                         lines.push(format!(
                             "{}{}payload: {:?}",
                             Self::COMMENT,
@@ -717,7 +717,7 @@ mod detail {
                     let interesting_content = mev
                         .interesting_content
                         .iter()
-                        .map(|obs_hash| unwrap!(self.observations.get(obs_hash)))
+                        .map(|obs_key| unwrap!(self.observations.get(obs_key.hash())))
                         .cloned()
                         .collect::<Vec<_>>();
                     lines.push(format!(
@@ -793,7 +793,7 @@ mod detail {
                     let interesting_content = meta_event
                         .interesting_content
                         .iter()
-                        .map(|obs_hash| unwrap!(observations_map.get(obs_hash)))
+                        .map(|obs_key| unwrap!(observations_map.get(obs_key.hash())))
                         .collect::<Vec<_>>();
                     attr.label = format!(
                         "{}<tr><td colspan=\"6\">{:?}</td></tr>",

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ use std::result;
 pub enum Error {
     /// Payload of a `Vote` doesn't match the payload of a `Block`.
     MismatchedPayload,
+    /// Attempt to create a block with no votes.
+    MissingVotes,
     /// Failed to verify signature.
     SignatureFailure,
     /// Peer is not known to our node.
@@ -52,6 +54,7 @@ impl Display for Error {
                 f,
                 "The payload of the vote doesn't match the payload of targeted block."
             ),
+            Error::MissingVotes => write!(f, "Block cannot be created with no votes"),
             Error::SignatureFailure => write!(
                 f,
                 "The message or signature might be corrupted, or the signer is wrong."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,8 +119,8 @@ pub use error::{Error, Result};
 pub use gossip::{EventHash, PackedEvent, Request, Response};
 pub use id::{Proof, PublicId, SecretId};
 pub use network_event::NetworkEvent;
-pub use observation::{Malice, Observation};
-pub use parsec::{ConsensusMode, Parsec};
+pub use observation::{ConsensusMode, Malice, Observation};
+pub use parsec::Parsec;
 pub use vote::Vote;
 
 use maidsafe_utilities::serialisation;

--- a/src/meta_voting/meta_event.rs
+++ b/src/meta_voting/meta_event.rs
@@ -11,7 +11,7 @@ use super::meta_vote::{MetaVote, MetaVotes};
 use gossip::IndexedEventRef;
 use id::PublicId;
 use network_event::NetworkEvent;
-use observation::ObservationHash;
+use observation::ObservationKey;
 use std::collections::BTreeSet;
 
 #[serde(bound = "")]
@@ -21,7 +21,7 @@ pub(crate) struct MetaEvent<P: PublicId> {
     // valid block.  If there are a supermajority of peers here, this event is an "observer".
     pub observees: BTreeSet<P>,
     // Hashes of payloads of all the votes deemed interesting by this event.
-    pub interesting_content: Vec<ObservationHash>,
+    pub interesting_content: Vec<ObservationKey<P>>,
     pub meta_votes: MetaVotes<P>,
 }
 
@@ -69,8 +69,8 @@ impl<'a, T: NetworkEvent + 'a, P: PublicId + 'a> MetaEventBuilder<'a, T, P> {
         self.meta_event.observees = observees;
     }
 
-    pub fn set_interesting_content(&mut self, content_hash: Vec<ObservationHash>) {
-        self.meta_event.interesting_content = content_hash;
+    pub fn set_interesting_content(&mut self, content: Vec<ObservationKey<P>>) {
+        self.meta_event.interesting_content = content;
     }
 
     pub fn add_meta_votes(&mut self, peer_id: P, votes: Vec<MetaVote>) {

--- a/src/meta_voting/meta_vote_counts.rs
+++ b/src/meta_voting/meta_vote_counts.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::meta_vote::MetaVote;
-use parsec::is_more_than_two_thirds;
+use observation::is_more_than_two_thirds;
 use std::iter;
 
 // This is used to collect the meta votes of other events relating to a single (binary) meta vote at

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -48,22 +48,13 @@ pub enum Observation<T: NetworkEvent, P: PublicId> {
     OpaquePayload(T),
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub(crate) struct ObservationHash(pub(crate) Hash);
-
-impl ObservationHash {
-    pub const ZERO: Self = ObservationHash(Hash::ZERO);
-}
-
-impl<'a, T: NetworkEvent, P: PublicId> From<&'a Observation<T, P>> for ObservationHash {
-    fn from(observation: &'a Observation<T, P>) -> Self {
-        ObservationHash(Hash::from(serialise(observation).as_slice()))
-    }
-}
-
-impl Debug for ObservationHash {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "{:?}", self.0)
+impl<T: NetworkEvent, P: PublicId> Observation<T, P> {
+    pub(crate) fn is_opaque(&self) -> bool {
+        if let Observation::OpaquePayload(_) = *self {
+            true
+        } else {
+            false
+        }
     }
 }
 
@@ -192,6 +183,25 @@ impl<'a> Visitor<'a> for UnprovableMaliceVisitor {
 
     fn visit_unit<E: Error>(self) -> Result<Self::Value, E> {
         Ok(UnprovableMalice::Unspecified)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub(crate) struct ObservationHash(pub(crate) Hash);
+
+impl ObservationHash {
+    pub const ZERO: Self = ObservationHash(Hash::ZERO);
+}
+
+impl<'a, T: NetworkEvent, P: PublicId> From<&'a Observation<T, P>> for ObservationHash {
+    fn from(observation: &'a Observation<T, P>) -> Self {
+        ObservationHash(Hash::from(serialise(observation).as_slice()))
+    }
+}
+
+impl Debug for ObservationHash {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "{:?}", self.0)
     }
 }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -1670,7 +1670,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         event: &'a Event<T, S::PublicId>,
     ) -> Option<ObservationWithKey<'a, T, S::PublicId>> {
         let (payload, hash) = event.payload_with_hash()?;
-        let mode = if let Observation::OpaquePayload(_) = payload {
+        let mode = if payload.is_opaque() {
             self.consensus_mode
         } else {
             ConsensusMode::Supermajority


### PR DESCRIPTION
This PR implements one part of MAID-3266: it makes it so that when we are in the `ConsensusMode::Single`, each voted opaque payload is outputted in its own block signed only by the single voter. 