### PR TITLE
MAID-3264: Use human readable peer names in basic example

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -434,6 +434,7 @@ struct Environment {
     current_remove_peers: Vec<PeerId>,
     current_new_peer: Option<PeerId>,
     current_round: usize,
+    pretty_id_count: usize,
 }
 
 impl Environment {
@@ -456,6 +457,7 @@ impl Environment {
             current_remove_peers: vec![],
             current_new_peer: None,
             current_round: 0,
+            pretty_id_count: 0,
         };
 
         // Set up the requested number of peers and random network events.
@@ -478,13 +480,17 @@ impl Environment {
 
     // Returns a randomly created new `PeerId`.
     fn new_peer_id(&mut self) -> PeerId {
-        PeerId::new_with_random_keypair(
-            self.rng
-                .gen_ascii_chars()
-                .take(6)
-                .collect::<String>()
-                .as_str(),
-        )
+        let peer = PeerId::from_index(self.pretty_id_count).unwrap_or_else(|| {
+            PeerId::new_with_random_keypair(
+                self.rng
+                    .gen_ascii_chars()
+                    .take(6)
+                    .collect::<String>()
+                    .as_str(),
+            )
+        });
+        self.pretty_id_count += 1;
+        peer
     }
 
     // Returns a random number of peers which can be dropped so that we don't lose consensus, and so

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -17,7 +17,8 @@ use std::hash::{Hash, Hasher};
 
 pub const NAMES: &[&str] = &[
     "Alice", "Bob", "Carol", "Dave", "Eric", "Fred", "Gina", "Hank", "Iris", "Judy", "Kent",
-    "Lucy", "Mike", "Nina", "Oran", "Paul", "Quin", "Rose", "Stan", "Tina",
+    "Lucy", "Mike", "Nina", "Oran", "Paul", "Quin", "Rose", "Stan", "Tina", "Ulf", "Vera", "Will",
+    "Xaviera", "Yakov", "Zaida",
 ];
 
 lazy_static! {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -78,6 +78,10 @@ impl PeerId {
             initial, NAMES
         );
     }
+
+    pub fn from_index(peer_index: usize) -> Option<Self> {
+        NAMES.get(peer_index).map(|name| PeerId::new(name))
+    }
 }
 
 impl Debug for PeerId {


### PR DESCRIPTION
Random names for the peers can cause issues when visualising the generated dot file. Pick human readable names if available to mitigate it.

Also pads `NAMES` with a few more entries. Wasn't sure which names to use, so I just checked a baby name website!