### PR TITLE
MAID-3080/3083: Detect invalid self/other parent

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,8 +37,10 @@ pub enum Error {
     },
     /// The given event is invalid or malformed.
     InvalidEvent,
-    /// This event's self-parent or other-parent is unknown to our node.
-    UnknownParent,
+    /// The event's self-parent is unknwon to our node.
+    UnknownSelfParent,
+    /// The event's other-parent is unknown to our node.
+    UnknownOtherParent,
     /// Our node has already voted for this network event.
     DuplicateVote,
     /// The peer sent a message to us before knowing we could handle it.
@@ -71,10 +73,12 @@ impl Display for Error {
                 required, actual
             ),
             Error::InvalidEvent => write!(f, "The given event is invalid or malformed."),
-            Error::UnknownParent => write!(
-                f,
-                "This event's self-parent or other-parent is unknown to this node."
-            ),
+            Error::UnknownSelfParent => {
+                write!(f, "The event's self-parent is unknown to this node.")
+            }
+            Error::UnknownOtherParent => {
+                write!(f, "The event's other-parent is unknown to this node.")
+            }
             Error::DuplicateVote => write!(f, "Our node has already voted for this network event."),
             Error::PrematureGossip => write!(
                 f,

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -519,7 +519,7 @@ fn get_parent<'a, T: NetworkEvent, P: PublicId>(
                 .and_then(|index| graph.get(index))
                 .ok_or_else(|| {
                     debug!("{:?} missing {} parent for {:?}", our_id, parent, content);
-                    Error::UnknownParent
+                    parent.to_unknown_error()
                 })?,
         ))
     } else {
@@ -541,6 +541,13 @@ impl Parent {
         match self {
             Parent::Self_ => content.self_parent(),
             Parent::Other => content.other_parent(),
+        }
+    }
+
+    fn to_unknown_error(self) -> Error {
+        match self {
+            Parent::Self_ => Error::UnknownSelfParent,
+            Parent::Other => Error::UnknownOtherParent,
         }
     }
 }


### PR DESCRIPTION
When the hash of the other_parent doesn’t point to any known gossip event, `handle_request` and `handle_response` should return `Error<UnknownOtherParent>` or `Error<UnknownSelfParent>`.

Note in the original task `InvalidOtherParent`/`InvalidSelfParent` was specified.