### PR TITLE
Fix and optimize the test framework + fix subtle bug in Parsec

### DIFF
--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -939,7 +939,7 @@ mod tests {
         let options = ScheduleOptions {
             genesis_size: 4,
             opaque_to_add: 5,
-            gossip_prob: 0.8,
+            prob_gossip: 0.1,
             ..Default::default()
         };
         let schedule = Schedule::new(&mut env, &options);

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -97,11 +97,16 @@ impl Peer {
         }
     }
 
-    pub fn poll(&mut self) {
+    /// Returns the index of the first new block.
+    pub fn poll(&mut self) -> usize {
+        let first = self.blocks.len();
+
         while let Some(block) = self.parsec.poll() {
             self.make_active_if_added(&block);
             self.blocks.push(block);
         }
+
+        first
     }
 
     /// Returns self.blocks

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -919,7 +919,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         let prev_meta_event = self
             .meta_elections
             .meta_event(prev_election, event.event_index())?;
-        let payloads = prev_meta_event
+        let payloads: Vec<_> = prev_meta_event
             .interesting_content
             .iter()
             .filter(|payload| {
@@ -932,7 +932,15 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             }).cloned()
             .collect();
 
-        Some(payloads)
+        if payloads.is_empty() {
+            // The previous election has no interesting content on this event that is still
+            // interesting for the current election. We can't return empty vec, because there can
+            // be some content that wasn't interesting for the previous election but might be
+            // interesting for the current one.
+            None
+        } else {
+            Some(payloads)
+        }
     }
 
     // Returns true if `builder.event()` has an ancestor by a different creator that has `payload`

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -511,7 +511,6 @@ proptest! {
         opts: ScheduleOptionsStrategy {
             num_peers: (4..=10).into(),
             num_observations: (1..=10).into(),
-            local_step: (0.01..=1.0).into(),
             recv_trans: (0.001..0.5).into(),
             failure: (0.0..1.0).into(),
             vote_duplication: (0.0..0.5).into(),


### PR DESCRIPTION
1. Fix the `Parsec::previous_interesting_content` function to return `None` in case the previous interesting content is empty. In that case we must perform the full computation, because there can be new interesting content that wasn't present in the previous meta-election.
2. Make `PeerRemovalGuard` more robust to handle edge cases.
3. Lower the gossip probability to speed the tests up, but increase the `adjustment_coeff` correspondingly, to make sure they still pass. Overall significant test performance increase.
4. Remove `prob_local_step` as it wasn't really used anymore (local step now happens on every step).
5. Some minor refactoring of the test framework