### PR TITLE
Perf optimization: cache unconsensused events in meta-election

### DIFF
--- a/dot_gen/src/main.rs
+++ b/dot_gen/src/main.rs
@@ -145,7 +145,8 @@ fn main() {
 
                 Schedule::from_observation_schedule(env, &ScheduleOptions::default(), obs)
             },
-        ).seed([848_911_612, 2_362_592_349, 3_178_199_135, 2_458_552_022]);
+        )
+        .seed([848_911_612, 2_362_592_349, 3_178_199_135, 2_458_552_022]);
 
     let _ = scenarios
         .add(

--- a/dot_gen/src/main.rs
+++ b/dot_gen/src/main.rs
@@ -134,17 +134,18 @@ fn main() {
         },
     );
 
-    let _ = scenarios.add(
-        "functional_tests::handle_malice_genesis_event_creator_not_genesis_member",
-        |env| {
-            let obs = ObservationSchedule {
-                genesis: peer_ids!("Alice", "Bob", "Carol", "Dave"),
-                schedule: vec![(0, AddPeer(PeerId::new("Eric")))],
-            };
+    let _ = scenarios
+        .add(
+            "functional_tests::handle_malice_genesis_event_creator_not_genesis_member",
+            |env| {
+                let obs = ObservationSchedule {
+                    genesis: peer_ids!("Alice", "Bob", "Carol", "Dave"),
+                    schedule: vec![(0, AddPeer(PeerId::new("Eric")))],
+                };
 
-            Schedule::from_observation_schedule(env, &ScheduleOptions::default(), obs)
-        },
-    );
+                Schedule::from_observation_schedule(env, &ScheduleOptions::default(), obs)
+            },
+        ).seed([848_911_612, 2_362_592_349, 3_178_199_135, 2_458_552_022]);
 
     let _ = scenarios
         .add(
@@ -246,9 +247,13 @@ impl Scenario {
     }
 
     fn matches(&self, pattern: &str) -> bool {
-        self.files
-            .values()
-            .any(|file| format!("{}/{}", self.name, file).contains(pattern))
+        if self.files.is_empty() {
+            self.name.contains(pattern)
+        } else {
+            self.files
+                .values()
+                .any(|file| format!("{}/{}", self.name, file).contains(pattern))
+        }
     }
 
     fn run(&mut self, mode: Mode) {
@@ -432,11 +437,17 @@ fn run(mut scenarios: Scenarios) {
     }
 
     if let Some(name) = matches.value_of("name") {
+        let mut matched = false;
         for scenario in scenarios
             .iter_mut()
             .filter(|scenario| scenario.matches(name))
         {
+            matched = true;
             scenario.run(mode);
+        }
+
+        if !matched {
+            println!("No scenario matching {:?} found", name);
         }
     }
 }

--- a/input_graphs/functional_tests_handle_malice_genesis_event_creator_not_genesis_member/alice.dot
+++ b/input_graphs/functional_tests_handle_malice_genesis_event_creator_not_genesis_member/alice.dot
@@ -11,267 +11,167 @@ digraph GossipGraph {
 
   style=invis
   subgraph cluster_Alice {
-    label=Alice
-    Alice [style=invis]
+    label="Alice"
+    "Alice" [style=invis]
     "Alice" -> "A_0" [style=invis]
     "A_0" -> "A_1" [minlen=1]
-    "A_1" -> "A_2" [minlen=3]
+    "A_1" -> "A_2" [minlen=2]
     "A_2" -> "A_3" [minlen=1]
     "A_3" -> "A_4" [minlen=1]
-    "A_4" -> "A_5" [minlen=2]
-    "A_5" -> "A_6" [minlen=4]
+    "A_4" -> "A_5" [minlen=1]
+    "A_5" -> "A_6" [minlen=2]
     "A_6" -> "A_7" [minlen=1]
-    "A_7" -> "A_8" [minlen=1]
+    "A_7" -> "A_8" [minlen=2]
     "A_8" -> "A_9" [minlen=1]
-    "A_9" -> "A_10" [minlen=3]
-    "A_10" -> "A_11" [minlen=1]
+    "A_9" -> "A_10" [minlen=5]
+    "A_10" -> "A_11" [minlen=3]
     "A_11" -> "A_12" [minlen=1]
-    "A_12" -> "A_13" [minlen=6]
+    "A_12" -> "A_13" [minlen=2]
     "A_13" -> "A_14" [minlen=1]
-    "A_14" -> "A_15" [minlen=1]
-    "A_15" -> "A_16" [minlen=2]
-    "A_16" -> "A_17" [minlen=1]
+    "A_14" -> "A_15" [minlen=2]
+    "A_15" -> "A_16" [minlen=3]
+    "A_16" -> "A_17" [minlen=3]
     "A_17" -> "A_18" [minlen=1]
-    "A_18" -> "A_19" [minlen=2]
-    "A_19" -> "A_20" [minlen=8]
-    "A_20" -> "A_21" [minlen=1]
+    "A_18" -> "A_19" [minlen=3]
   }
-  "D_3" -> "A_2" [constraint=false]
-  "D_3" -> "A_3" [constraint=false]
-  "C_6" -> "A_5" [constraint=false]
-  "D_9" -> "A_6" [constraint=false]
-  "B_7" -> "A_7" [constraint=false]
-  "C_8" -> "A_8" [constraint=false]
-  "D_11" -> "A_9" [constraint=false]
-  "B_13" -> "A_10" [constraint=false]
-  "C_12" -> "A_11" [constraint=false]
-  "C_13" -> "A_12" [constraint=false]
-  "B_18" -> "A_13" [constraint=false]
-  "B_19" -> "A_14" [constraint=false]
-  "B_20" -> "A_15" [constraint=false]
-  "D_18" -> "A_16" [constraint=false]
-  "C_22" -> "A_17" [constraint=false]
-  "D_20" -> "A_18" [constraint=false]
-  "B_23" -> "A_19" [constraint=false]
-  "B_30" -> "A_20" [constraint=false]
-  "D_28" -> "A_21" [constraint=false]
+  "C_2" -> "A_2" [constraint=false]
+  "B_1" -> "A_3" [constraint=false]
+  "D_1" -> "A_5" [constraint=false]
+  "B_5" -> "A_6" [constraint=false]
+  "D_3" -> "A_7" [constraint=false]
+  "D_4" -> "A_8" [constraint=false]
+  "C_6" -> "A_9" [constraint=false]
+  "C_8" -> "A_10" [constraint=false]
+  "C_10" -> "A_11" [constraint=false]
+  "C_10" -> "A_12" [constraint=false]
+  "C_11" -> "A_13" [constraint=false]
+  "B_8" -> "A_14" [constraint=false]
+  "C_13" -> "A_15" [constraint=false]
+  "C_16" -> "A_16" [constraint=false]
+  "B_12" -> "A_17" [constraint=false]
+  "C_16" -> "A_18" [constraint=false]
+  "C_19" -> "A_19" [constraint=false]
 
   style=invis
   subgraph cluster_Bob {
-    label=Bob
-    Bob [style=invis]
+    label="Bob"
+    "Bob" [style=invis]
     "Bob" -> "B_0" [style=invis]
     "B_0" -> "B_1" [minlen=1]
-    "B_1" -> "B_2" [minlen=1]
+    "B_1" -> "B_2" [minlen=3]
     "B_2" -> "B_3" [minlen=1]
     "B_3" -> "B_4" [minlen=1]
     "B_4" -> "B_5" [minlen=1]
-    "B_5" -> "B_6" [minlen=3]
-    "B_6" -> "B_7" [minlen=1]
+    "B_5" -> "B_6" [minlen=1]
+    "B_6" -> "B_7" [minlen=7]
     "B_7" -> "B_8" [minlen=2]
-    "B_8" -> "B_9" [minlen=1]
-    "B_9" -> "B_10" [minlen=1]
-    "B_10" -> "B_11" [minlen=2]
+    "B_8" -> "B_9" [minlen=8]
+    "B_9" -> "B_10" [minlen=4]
+    "B_10" -> "B_11" [minlen=1]
     "B_11" -> "B_12" [minlen=1]
     "B_12" -> "B_13" [minlen=1]
-    "B_13" -> "B_14" [minlen=1]
-    "B_14" -> "B_15" [minlen=2]
-    "B_15" -> "B_16" [minlen=2]
-    "B_16" -> "B_17" [minlen=2]
-    "B_17" -> "B_18" [minlen=1]
-    "B_18" -> "B_19" [minlen=1]
-    "B_19" -> "B_20" [minlen=1]
-    "B_20" -> "B_21" [minlen=4]
-    "B_21" -> "B_22" [minlen=1]
-    "B_22" -> "B_23" [minlen=1]
-    "B_23" -> "B_24" [minlen=1]
-    "B_24" -> "B_25" [minlen=1]
-    "B_25" -> "B_26" [minlen=1]
-    "B_26" -> "B_27" [minlen=1]
-    "B_27" -> "B_28" [minlen=1]
-    "B_28" -> "B_29" [minlen=1]
-    "B_29" -> "B_30" [minlen=2]
-    "B_30" -> "B_31" [minlen=3]
-    "B_31" -> "B_32" [minlen=2]
-    "B_32" -> "B_33" [minlen=1]
   }
-  "C_1" -> "B_2" [constraint=false]
-  "D_2" -> "B_3" [constraint=false]
-  "C_2" -> "B_4" [constraint=false]
-  "D_5" -> "B_6" [constraint=false]
-  "A_4" -> "B_7" [constraint=false]
+  "C_3" -> "B_2" [constraint=false]
+  "A_3" -> "B_3" [constraint=false]
+  "A_5" -> "B_5" [constraint=false]
+  "C_4" -> "B_6" [constraint=false]
+  "D_6" -> "B_7" [constraint=false]
   "D_8" -> "B_8" [constraint=false]
-  "C_7" -> "B_9" [constraint=false]
-  "C_9" -> "B_10" [constraint=false]
-  "D_11" -> "B_11" [constraint=false]
-  "C_10" -> "B_12" [constraint=false]
-  "A_9" -> "B_13" [constraint=false]
-  "C_12" -> "B_14" [constraint=false]
-  "C_15" -> "B_15" [constraint=false]
-  "D_14" -> "B_16" [constraint=false]
-  "C_18" -> "B_17" [constraint=false]
-  "A_12" -> "B_18" [constraint=false]
-  "A_12" -> "B_19" [constraint=false]
-  "A_12" -> "B_20" [constraint=false]
-  "D_19" -> "B_21" [constraint=false]
-  "D_19" -> "B_22" [constraint=false]
-  "C_24" -> "B_23" [constraint=false]
-  "D_20" -> "B_24" [constraint=false]
-  "A_19" -> "B_25" [constraint=false]
-  "C_24" -> "B_26" [constraint=false]
-  "D_24" -> "B_27" [constraint=false]
-  "C_25" -> "B_28" [constraint=false]
-  "D_27" -> "B_29" [constraint=false]
-  "C_29" -> "B_30" [constraint=false]
-  "D_32" -> "B_31" [constraint=false]
-  "D_33" -> "B_32" [constraint=false]
-  "A_21" -> "B_33" [constraint=false]
+  "A_14" -> "B_9" [constraint=false]
+  "D_11" -> "B_10" [constraint=false]
+  "D_12" -> "B_11" [constraint=false]
+  "A_16" -> "B_12" [constraint=false]
+  "C_16" -> "B_13" [constraint=false]
 
   style=invis
   subgraph cluster_Carol {
-    label=Carol
-    Carol [style=invis]
+    label="Carol"
+    "Carol" [style=invis]
     "Carol" -> "C_0" [style=invis]
     "C_0" -> "C_1" [minlen=1]
     "C_1" -> "C_2" [minlen=1]
     "C_2" -> "C_3" [minlen=1]
     "C_3" -> "C_4" [minlen=1]
-    "C_4" -> "C_5" [minlen=1]
-    "C_5" -> "C_6" [minlen=2]
-    "C_6" -> "C_7" [minlen=2]
-    "C_7" -> "C_8" [minlen=1]
+    "C_4" -> "C_5" [minlen=5]
+    "C_5" -> "C_6" [minlen=1]
+    "C_6" -> "C_7" [minlen=3]
+    "C_7" -> "C_8" [minlen=3]
     "C_8" -> "C_9" [minlen=2]
     "C_9" -> "C_10" [minlen=1]
-    "C_10" -> "C_11" [minlen=1]
-    "C_11" -> "C_12" [minlen=1]
+    "C_10" -> "C_11" [minlen=3]
+    "C_11" -> "C_12" [minlen=2]
     "C_12" -> "C_13" [minlen=1]
-    "C_13" -> "C_14" [minlen=2]
+    "C_13" -> "C_14" [minlen=1]
     "C_14" -> "C_15" [minlen=1]
     "C_15" -> "C_16" [minlen=1]
-    "C_16" -> "C_17" [minlen=2]
+    "C_16" -> "C_17" [minlen=5]
     "C_17" -> "C_18" [minlen=1]
-    "C_18" -> "C_19" [minlen=2]
-    "C_19" -> "C_20" [minlen=2]
-    "C_20" -> "C_21" [minlen=1]
-    "C_21" -> "C_22" [minlen=1]
-    "C_22" -> "C_23" [minlen=1]
-    "C_23" -> "C_24" [minlen=1]
-    "C_24" -> "C_25" [minlen=5]
-    "C_25" -> "C_26" [minlen=1]
-    "C_26" -> "C_27" [minlen=1]
-    "C_27" -> "C_28" [minlen=1]
-    "C_28" -> "C_29" [minlen=1]
+    "C_18" -> "C_19" [minlen=1]
   }
-  "B_1" -> "C_2" [constraint=false]
-  "D_3" -> "C_4" [constraint=false]
-  "B_2" -> "C_5" [constraint=false]
-  "A_4" -> "C_6" [constraint=false]
-  "B_6" -> "C_7" [constraint=false]
-  "A_5" -> "C_8" [constraint=false]
-  "D_9" -> "C_9" [constraint=false]
-  "B_8" -> "C_10" [constraint=false]
-  "B_10" -> "C_11" [constraint=false]
-  "B_10" -> "C_12" [constraint=false]
-  "A_9" -> "C_13" [constraint=false]
-  "D_13" -> "C_14" [constraint=false]
-  "B_14" -> "C_15" [constraint=false]
-  "A_11" -> "C_16" [constraint=false]
-  "D_14" -> "C_17" [constraint=false]
-  "D_14" -> "C_18" [constraint=false]
-  "D_15" -> "C_19" [constraint=false]
-  "D_16" -> "C_20" [constraint=false]
-  "B_17" -> "C_21" [constraint=false]
-  "A_15" -> "C_22" [constraint=false]
-  "D_18" -> "C_23" [constraint=false]
-  "B_20" -> "C_24" [constraint=false]
-  "B_25" -> "C_25" [constraint=false]
-  "D_22" -> "C_26" [constraint=false]
-  "D_26" -> "C_27" [constraint=false]
-  "B_26" -> "C_28" [constraint=false]
-  "B_27" -> "C_29" [constraint=false]
+  "A_1" -> "C_2" [constraint=false]
+  "B_1" -> "C_3" [constraint=false]
+  "B_6" -> "C_5" [constraint=false]
+  "A_7" -> "C_6" [constraint=false]
+  "D_5" -> "C_7" [constraint=false]
+  "D_7" -> "C_8" [constraint=false]
+  "A_10" -> "C_9" [constraint=false]
+  "A_10" -> "C_10" [constraint=false]
+  "A_12" -> "C_11" [constraint=false]
+  "A_13" -> "C_12" [constraint=false]
+  "A_14" -> "C_13" [constraint=false]
+  "D_9" -> "C_14" [constraint=false]
+  "D_9" -> "C_15" [constraint=false]
+  "A_15" -> "C_16" [constraint=false]
+  "B_13" -> "C_17" [constraint=false]
+  "A_18" -> "C_18" [constraint=false]
+  "A_18" -> "C_19" [constraint=false]
 
   style=invis
   subgraph cluster_Dave {
-    label=Dave
-    Dave [style=invis]
+    label="Dave"
+    "Dave" [style=invis]
     "Dave" -> "D_0" [style=invis]
     "D_0" -> "D_1" [minlen=1]
     "D_1" -> "D_2" [minlen=1]
-    "D_2" -> "D_3" [minlen=1]
+    "D_2" -> "D_3" [minlen=5]
     "D_3" -> "D_4" [minlen=3]
-    "D_4" -> "D_5" [minlen=1]
-    "D_5" -> "D_6" [minlen=1]
+    "D_4" -> "D_5" [minlen=2]
+    "D_5" -> "D_6" [minlen=2]
     "D_6" -> "D_7" [minlen=1]
     "D_7" -> "D_8" [minlen=1]
     "D_8" -> "D_9" [minlen=1]
-    "D_9" -> "D_10" [minlen=2]
+    "D_9" -> "D_10" [minlen=10]
     "D_10" -> "D_11" [minlen=1]
-    "D_11" -> "D_12" [minlen=2]
-    "D_12" -> "D_13" [minlen=1]
-    "D_13" -> "D_14" [minlen=4]
-    "D_14" -> "D_15" [minlen=3]
-    "D_15" -> "D_16" [minlen=2]
-    "D_16" -> "D_17" [minlen=2]
-    "D_17" -> "D_18" [minlen=1]
-    "D_18" -> "D_19" [minlen=1]
-    "D_19" -> "D_20" [minlen=1]
-    "D_20" -> "D_21" [minlen=1]
-    "D_21" -> "D_22" [minlen=1]
-    "D_22" -> "D_23" [minlen=1]
-    "D_23" -> "D_24" [minlen=1]
-    "D_24" -> "D_25" [minlen=1]
-    "D_25" -> "D_26" [minlen=1]
-    "D_26" -> "D_27" [minlen=1]
-    "D_27" -> "D_28" [minlen=1]
-    "D_28" -> "D_29" [minlen=1]
-    "D_29" -> "D_30" [minlen=1]
-    "D_30" -> "D_31" [minlen=1]
-    "D_31" -> "D_32" [minlen=1]
-    "D_32" -> "D_33" [minlen=2]
+    "D_11" -> "D_12" [minlen=1]
+    "D_12" -> "D_13" [minlen=2]
+    "D_13" -> "D_14" [minlen=2]
+    "D_14" -> "D_15" [minlen=4]
   }
-  "B_1" -> "D_2" [constraint=false]
-  "A_1" -> "D_3" [constraint=false]
-  "A_3" -> "D_4" [constraint=false]
-  "B_4" -> "D_5" [constraint=false]
-  "C_4" -> "D_7" [constraint=false]
+  "A_5" -> "D_3" [constraint=false]
+  "A_7" -> "D_4" [constraint=false]
+  "A_8" -> "D_5" [constraint=false]
+  "C_7" -> "D_6" [constraint=false]
+  "C_7" -> "D_7" [constraint=false]
   "B_6" -> "D_8" [constraint=false]
-  "C_6" -> "D_9" [constraint=false]
-  "A_6" -> "D_10" [constraint=false]
-  "B_10" -> "D_11" [constraint=false]
-  "A_9" -> "D_12" [constraint=false]
-  "C_12" -> "D_13" [constraint=false]
-  "C_16" -> "D_14" [constraint=false]
-  "C_18" -> "D_15" [constraint=false]
-  "C_19" -> "D_16" [constraint=false]
-  "C_20" -> "D_17" [constraint=false]
-  "B_16" -> "D_18" [constraint=false]
-  "B_20" -> "D_19" [constraint=false]
-  "A_16" -> "D_20" [constraint=false]
-  "C_23" -> "D_21" [constraint=false]
-  "C_24" -> "D_22" [constraint=false]
-  "B_22" -> "D_23" [constraint=false]
-  "B_22" -> "D_24" [constraint=false]
-  "B_24" -> "D_25" [constraint=false]
-  "A_18" -> "D_26" [constraint=false]
-  "C_25" -> "D_27" [constraint=false]
-  "A_19" -> "D_28" [constraint=false]
-  "C_27" -> "D_29" [constraint=false]
-  "C_29" -> "D_30" [constraint=false]
-  "B_29" -> "D_31" [constraint=false]
-  "B_30" -> "D_32" [constraint=false]
-  "B_31" -> "D_33" [constraint=false]
+  "B_7" -> "D_9" [constraint=false]
+  "C_14" -> "D_10" [constraint=false]
+  "B_9" -> "D_11" [constraint=false]
+  "C_15" -> "D_12" [constraint=false]
+  "B_11" -> "D_13" [constraint=false]
+  "B_13" -> "D_14" [constraint=false]
+  "A_19" -> "D_15" [constraint=false]
 
   {
     rank=same
-    Alice [style=filled, color=white]
-    Bob [style=filled, color=white]
-    Carol [style=filled, color=white]
-    Dave [style=filled, color=white]
+    "Alice" [style=filled, color=white]
+    "Bob" [style=filled, color=white]
+    "Carol" [style=filled, color=white]
+    "Dave" [style=filled, color=white]
   }
-  Alice -> Bob -> Carol -> Dave [style=invis]
+  "Alice" -> "Bob" -> "Carol" -> "Dave" [style=invis]
 
 /// ===== details of events =====
-  "A_0" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_0</td></tr>
 </table>>]
 /// cause: Initial
@@ -284,195 +184,159 @@ digraph GossipGraph {
 /// cause: Observation(Genesis({Alice, Bob, Carol, Dave}))
 /// last_ancestors: {Alice: 1}
 
-  "A_2" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_2</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 2, Bob: 1, Dave: 3}
+/// last_ancestors: {Alice: 2, Carol: 2}
 
-  "A_3" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_3" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_3</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 3, Bob: 1, Dave: 3}
+/// last_ancestors: {Alice: 3, Bob: 1, Carol: 2}
 
   "A_4" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_4</td></tr>
 <tr><td colspan="6">Add(Eric)</td></tr>
 </table>>]
 /// cause: Observation(Add(Eric))
-/// last_ancestors: {Alice: 4, Bob: 1, Dave: 3}
+/// last_ancestors: {Alice: 4, Bob: 1, Carol: 2}
 
   "A_5" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_5</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 5, Bob: 2, Carol: 6, Dave: 3}
-
-  "A_6" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_6</td></tr>
-<tr><td colspan="6">[Add(Eric)]</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 6, Bob: 6, Carol: 6, Dave: 9}
+/// last_ancestors: {Alice: 5, Bob: 1, Carol: 2, Dave: 1}
 
-  "A_7" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_7</td></tr>
+  "A_6" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_6</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 7, Bob: 7, Carol: 6, Dave: 9}
+/// last_ancestors: {Alice: 6, Bob: 5, Carol: 3, Dave: 1}
+
+  "A_7" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_7</td></tr>
+<tr><td colspan="6">[Add(Eric)]</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 7, Bob: 5, Carol: 3, Dave: 3}
 
   "A_8" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_8</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 8, Bob: 7, Carol: 8, Dave: 9}
+/// cause: Request
+/// last_ancestors: {Alice: 8, Bob: 5, Carol: 3, Dave: 4}
 
   "A_9" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_9</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 9, Bob: 10, Carol: 9, Dave: 11}
+</table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 9, Bob: 6, Carol: 6, Dave: 4}
 
   "A_10" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_10</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 10, Bob: 13, Carol: 10, Dave: 11}
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 10, Bob: 6, Carol: 8, Dave: 7}
 
   "A_11" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_11</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 11, Bob: 13, Carol: 12, Dave: 11}
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 11, Bob: 6, Carol: 10, Dave: 7}
 
   "A_12" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_12</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
 <tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 12, Bob: 13, Carol: 13, Dave: 11}
+/// cause: Request
+/// last_ancestors: {Alice: 12, Bob: 6, Carol: 10, Dave: 7}
 
   "A_13" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_13</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 13, Bob: 18, Carol: 18, Dave: 14}
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 13, Bob: 6, Carol: 11, Dave: 7}
 
   "A_14" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_14</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 14, Bob: 19, Carol: 18, Dave: 14}
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 14, Bob: 8, Carol: 11, Dave: 8}
 
   "A_15" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_15</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 15, Bob: 20, Carol: 18, Dave: 14}
+/// last_ancestors: {Alice: 15, Bob: 8, Carol: 13, Dave: 8}
 
   "A_16" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_16</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 16, Bob: 20, Carol: 20, Dave: 18}
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 16, Bob: 8, Carol: 16, Dave: 9}
 
   "A_17" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_17</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
 <tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
 <tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 17, Bob: 20, Carol: 22, Dave: 18}
+/// last_ancestors: {Alice: 17, Bob: 12, Carol: 16, Dave: 12}
 
   "A_18" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_18</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
 <tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
 <tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 18, Bob: 20, Carol: 22, Dave: 20}
+/// last_ancestors: {Alice: 18, Bob: 12, Carol: 16, Dave: 12}
 
   "A_19" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_19</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
 <tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 19, Bob: 23, Carol: 24, Dave: 20}
-
-  "A_20" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_20</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>1/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 20, Bob: 30, Carol: 29, Dave: 27}
-
-  "A_21" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_21</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>1/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
 <tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 21, Bob: 30, Carol: 29, Dave: 28}
+/// last_ancestors: {Alice: 19, Bob: 13, Carol: 19, Dave: 12}
 
-  "B_0" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_0</td></tr>
 </table>>]
 /// cause: Initial
@@ -488,321 +352,110 @@ digraph GossipGraph {
   "B_2" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_2</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Bob: 2, Carol: 1}
+/// cause: Response
+/// last_ancestors: {Alice: 1, Bob: 2, Carol: 3}
 
   "B_3" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_3</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Bob: 3, Carol: 1, Dave: 2}
+/// last_ancestors: {Alice: 3, Bob: 3, Carol: 3}
 
-  "B_4" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_4" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_4</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Bob: 4, Carol: 2, Dave: 2}
-
-  "B_5" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_5</td></tr>
 <tr><td colspan="6">Add(Eric)</td></tr>
 </table>>]
 /// cause: Observation(Add(Eric))
-/// last_ancestors: {Bob: 5, Carol: 2, Dave: 2}
+/// last_ancestors: {Alice: 3, Bob: 4, Carol: 3}
 
-  "B_6" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_6</td></tr>
+  "B_5" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_5</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 3, Bob: 6, Carol: 2, Dave: 5}
+/// cause: Request
+/// last_ancestors: {Alice: 5, Bob: 5, Carol: 3, Dave: 1}
+
+  "B_6" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_6</td></tr>
+<tr><td colspan="6">[Add(Eric)]</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 5, Bob: 6, Carol: 4, Dave: 1}
 
   "B_7" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_7</td></tr>
-</table>>]
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 4, Bob: 7, Carol: 2, Dave: 5}
+/// last_ancestors: {Alice: 8, Bob: 7, Carol: 7, Dave: 6}
 
-  "B_8" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_8" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_8</td></tr>
-<tr><td colspan="6">[Add(Eric)]</td></tr></table>>]
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 4, Bob: 8, Carol: 4, Dave: 8}
+/// last_ancestors: {Alice: 8, Bob: 8, Carol: 7, Dave: 8}
 
   "B_9" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_9</td></tr>
-</table>>]
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 4, Bob: 9, Carol: 7, Dave: 8}
+/// last_ancestors: {Alice: 14, Bob: 9, Carol: 11, Dave: 8}
 
   "B_10" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_10</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 5, Bob: 10, Carol: 9, Dave: 9}
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 14, Bob: 10, Carol: 14, Dave: 11}
 
   "B_11" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_11</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 6, Bob: 11, Carol: 9, Dave: 11}
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 14, Bob: 11, Carol: 15, Dave: 12}
 
   "B_12" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_12</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 6, Bob: 12, Carol: 10, Dave: 11}
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 16, Bob: 12, Carol: 16, Dave: 12}
 
   "B_13" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_13</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 9, Bob: 13, Carol: 10, Dave: 11}
-
-  "B_14" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_14</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 9, Bob: 14, Carol: 12, Dave: 11}
-
-  "B_15" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_15</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>b</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 9, Bob: 15, Carol: 15, Dave: 13}
-
-  "B_16" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_16</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
 <tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
 <tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 11, Bob: 16, Carol: 16, Dave: 14}
+/// last_ancestors: {Alice: 16, Bob: 13, Carol: 16, Dave: 12}
 
-  "B_17" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_17</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 11, Bob: 17, Carol: 18, Dave: 14}
-
-  "B_18" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_18</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 12, Bob: 18, Carol: 18, Dave: 14}
-
-  "B_19" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_19</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 12, Bob: 19, Carol: 18, Dave: 14}
-
-  "B_20" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_20</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 12, Bob: 20, Carol: 18, Dave: 14}
-
-  "B_21" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_21</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 12, Bob: 21, Carol: 20, Dave: 19}
-
-  "B_22" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_22</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 12, Bob: 22, Carol: 20, Dave: 19}
-
-  "B_23" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_23</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 15, Bob: 23, Carol: 24, Dave: 19}
-
-  "B_24" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_24</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 16, Bob: 24, Carol: 24, Dave: 20}
-
-  "B_25" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_25</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 19, Bob: 25, Carol: 24, Dave: 20}
-
-  "B_26" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_26</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 19, Bob: 26, Carol: 24, Dave: 20}
-
-  "B_27" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_27</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 19, Bob: 27, Carol: 24, Dave: 24}
-
-  "B_28" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_28</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 19, Bob: 28, Carol: 25, Dave: 24}
-
-  "B_29" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_29</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 19, Bob: 29, Carol: 25, Dave: 27}
-
-  "B_30" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_30</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>1/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 19, Bob: 30, Carol: 29, Dave: 27}
-
-  "B_31" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_31</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>1/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 19, Bob: 31, Carol: 29, Dave: 32}
-
-  "B_32" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_32</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>1/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 19, Bob: 32, Carol: 29, Dave: 33}
-
-  "B_33" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_33</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>1/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 21, Bob: 33, Carol: 29, Dave: 33}
-
-  "C_0" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_0</td></tr>
 </table>>]
 /// cause: Initial
@@ -815,257 +468,165 @@ digraph GossipGraph {
 /// cause: Observation(Genesis({Alice, Bob, Carol, Dave}))
 /// last_ancestors: {Carol: 1}
 
-  "C_2" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_2</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Bob: 1, Carol: 2}
+/// last_ancestors: {Alice: 1, Carol: 2}
 
-  "C_3" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_3" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_3</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 1, Bob: 1, Carol: 3}
+
+  "C_4" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_4</td></tr>
 <tr><td colspan="6">Add(Eric)</td></tr>
 </table>>]
 /// cause: Observation(Add(Eric))
-/// last_ancestors: {Bob: 1, Carol: 3}
+/// last_ancestors: {Alice: 1, Bob: 1, Carol: 4}
 
-  "C_4" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_4</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 1, Bob: 1, Carol: 4, Dave: 3}
-
-  "C_5" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_5" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_5</td></tr>
-</table>>]
+<tr><td colspan="6">[Add(Eric)]</td></tr></table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 1, Bob: 2, Carol: 5, Dave: 3}
+/// last_ancestors: {Alice: 5, Bob: 6, Carol: 5, Dave: 1}
 
   "C_6" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_6</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 4, Bob: 2, Carol: 6, Dave: 3}
+/// last_ancestors: {Alice: 7, Bob: 6, Carol: 6, Dave: 3}
 
-  "C_7" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_7" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_7</td></tr>
-<tr><td colspan="6">[Add(Eric)]</td></tr></table>>]
+</table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 4, Bob: 6, Carol: 7, Dave: 5}
+/// last_ancestors: {Alice: 8, Bob: 6, Carol: 7, Dave: 5}
 
   "C_8" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_8</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 5, Bob: 6, Carol: 8, Dave: 5}
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 8, Bob: 6, Carol: 8, Dave: 7}
 
   "C_9" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_9</td></tr>
-</table>>]
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 5, Bob: 6, Carol: 9, Dave: 9}
+/// last_ancestors: {Alice: 10, Bob: 6, Carol: 9, Dave: 7}
 
   "C_10" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_10</td></tr>
-</table>>]
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 5, Bob: 8, Carol: 10, Dave: 9}
+/// last_ancestors: {Alice: 10, Bob: 6, Carol: 10, Dave: 7}
 
   "C_11" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_11</td></tr>
-</table>>]
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 5, Bob: 10, Carol: 11, Dave: 9}
+/// last_ancestors: {Alice: 12, Bob: 6, Carol: 11, Dave: 7}
 
   "C_12" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_12</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 5, Bob: 10, Carol: 12, Dave: 9}
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 13, Bob: 6, Carol: 12, Dave: 7}
 
   "C_13" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_13</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 9, Bob: 10, Carol: 13, Dave: 11}
+/// last_ancestors: {Alice: 14, Bob: 8, Carol: 13, Dave: 8}
 
   "C_14" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_14</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
 <tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
 <tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 9, Bob: 10, Carol: 14, Dave: 13}
+/// cause: Request
+/// last_ancestors: {Alice: 14, Bob: 8, Carol: 14, Dave: 9}
 
   "C_15" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_15</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
 <tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
 <tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 9, Bob: 14, Carol: 15, Dave: 13}
+/// last_ancestors: {Alice: 14, Bob: 8, Carol: 15, Dave: 9}
 
   "C_16" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_16</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
 <tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
 <tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 11, Bob: 14, Carol: 16, Dave: 13}
+/// cause: Request
+/// last_ancestors: {Alice: 15, Bob: 8, Carol: 16, Dave: 9}
 
   "C_17" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_17</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 11, Bob: 14, Carol: 17, Dave: 14}
+/// last_ancestors: {Alice: 16, Bob: 13, Carol: 17, Dave: 12}
 
   "C_18" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_18</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 11, Bob: 14, Carol: 18, Dave: 14}
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 18, Bob: 13, Carol: 18, Dave: 12}
 
   "C_19" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_19</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 11, Bob: 14, Carol: 19, Dave: 15}
-
-  "C_20" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_20</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 11, Bob: 14, Carol: 20, Dave: 16}
-
-  "C_21" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_21</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
 <tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 11, Bob: 17, Carol: 21, Dave: 16}
-
-  "C_22" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_22</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
 <tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 15, Bob: 20, Carol: 22, Dave: 16}
-
-  "C_23" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_23</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 15, Bob: 20, Carol: 23, Dave: 18}
-
-  "C_24" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_24</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 15, Bob: 20, Carol: 24, Dave: 18}
-
-  "C_25" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_25</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 19, Bob: 25, Carol: 25, Dave: 20}
-
-  "C_26" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_26</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 19, Bob: 25, Carol: 26, Dave: 22}
-
-  "C_27" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_27</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 19, Bob: 25, Carol: 27, Dave: 26}
-
-  "C_28" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_28</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 19, Bob: 26, Carol: 28, Dave: 26}
-
-  "C_29" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_29</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>f</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>1/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 19, Bob: 27, Carol: 29, Dave: 26}
+/// last_ancestors: {Alice: 18, Bob: 13, Carol: 19, Dave: 12}
 
   "D_0" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_0</td></tr>
@@ -1080,319 +641,136 @@ digraph GossipGraph {
 /// cause: Observation(Genesis({Alice, Bob, Carol, Dave}))
 /// last_ancestors: {Dave: 1}
 
-  "D_2" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "D_2" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_2</td></tr>
+<tr><td colspan="6">Add(Eric)</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Bob: 1, Dave: 2}
+/// cause: Observation(Add(Eric))
+/// last_ancestors: {Dave: 2}
 
   "D_3" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_3</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 1, Bob: 1, Dave: 3}
-
-  "D_4" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_4</td></tr>
-</table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 3, Bob: 1, Dave: 4}
+/// last_ancestors: {Alice: 5, Bob: 1, Carol: 2, Dave: 3}
+
+  "D_4" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_4</td></tr>
+<tr><td colspan="6">[Add(Eric)]</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 7, Bob: 5, Carol: 3, Dave: 4}
 
   "D_5" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_5</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 3, Bob: 4, Carol: 2, Dave: 5}
+/// cause: Response
+/// last_ancestors: {Alice: 8, Bob: 5, Carol: 3, Dave: 5}
 
-  "D_6" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "D_6" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_6</td></tr>
-<tr><td colspan="6">Add(Eric)</td></tr>
-</table>>]
-/// cause: Observation(Add(Eric))
-/// last_ancestors: {Alice: 3, Bob: 4, Carol: 2, Dave: 6}
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 8, Bob: 6, Carol: 7, Dave: 6}
 
   "D_7" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_7</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 3, Bob: 4, Carol: 4, Dave: 7}
-
-  "D_8" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_8</td></tr>
-<tr><td colspan="6">[Add(Eric)]</td></tr></table>>]
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 3, Bob: 6, Carol: 4, Dave: 8}
+/// last_ancestors: {Alice: 8, Bob: 6, Carol: 7, Dave: 7}
+
+  "D_8" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_8</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 8, Bob: 6, Carol: 7, Dave: 8}
 
   "D_9" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_9</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 4, Bob: 6, Carol: 6, Dave: 9}
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 8, Bob: 7, Carol: 7, Dave: 9}
 
   "D_10" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_10</td></tr>
-</table>>]
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 6, Bob: 6, Carol: 6, Dave: 10}
+/// last_ancestors: {Alice: 14, Bob: 8, Carol: 14, Dave: 10}
 
   "D_11" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_11</td></tr>
-</table>>]
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 6, Bob: 10, Carol: 9, Dave: 11}
+/// last_ancestors: {Alice: 14, Bob: 9, Carol: 14, Dave: 11}
 
   "D_12" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_12</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 9, Bob: 10, Carol: 9, Dave: 12}
+/// last_ancestors: {Alice: 14, Bob: 9, Carol: 15, Dave: 12}
 
   "D_13" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_13</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 9, Bob: 10, Carol: 12, Dave: 13}
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 14, Bob: 11, Carol: 15, Dave: 13}
 
   "D_14" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_14</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 11, Bob: 14, Carol: 16, Dave: 14}
+/// last_ancestors: {Alice: 16, Bob: 13, Carol: 16, Dave: 14}
 
   "D_15" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_15</td></tr>
 <tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 11, Bob: 14, Carol: 18, Dave: 15}
-
-  "D_16" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_16</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 11, Bob: 14, Carol: 19, Dave: 16}
-
-  "D_17" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_17</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 11, Bob: 14, Carol: 20, Dave: 17}
-
-  "D_18" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_18</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
 <tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 11, Bob: 16, Carol: 20, Dave: 18}
-
-  "D_19" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_19</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>f</td><td>f</td><td>f</td></tr>
 <tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 12, Bob: 20, Carol: 20, Dave: 19}
-
-  "D_20" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_20</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 16, Bob: 20, Carol: 20, Dave: 20}
-
-  "D_21" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_21</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 16, Bob: 20, Carol: 23, Dave: 21}
-
-  "D_22" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_22</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 16, Bob: 20, Carol: 24, Dave: 22}
-
-  "D_23" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_23</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 16, Bob: 22, Carol: 24, Dave: 23}
-
-  "D_24" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_24</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 16, Bob: 22, Carol: 24, Dave: 24}
-
-  "D_25" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_25</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 16, Bob: 24, Carol: 24, Dave: 25}
-
-  "D_26" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_26</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 18, Bob: 24, Carol: 24, Dave: 26}
-
-  "D_27" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_27</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 19, Bob: 25, Carol: 25, Dave: 27}
-
-  "D_28" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_28</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 19, Bob: 25, Carol: 25, Dave: 28}
-
-  "D_29" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_29</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 19, Bob: 25, Carol: 27, Dave: 29}
-
-  "D_30" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_30</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>1/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 19, Bob: 27, Carol: 29, Dave: 30}
-
-  "D_31" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_31</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>1/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 19, Bob: 29, Carol: 29, Dave: 31}
-
-  "D_32" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_32</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>1/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 19, Bob: 30, Carol: 29, Dave: 32}
-
-  "D_33" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_33</td></tr>
-<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
-<tr><td>A: </td><td>0/0</td><td>b</td><td>b</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/1</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>0/2</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>   </td><td>1/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
-<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
-<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 19, Bob: 31, Carol: 29, Dave: 33}
+/// last_ancestors: {Alice: 19, Bob: 13, Carol: 19, Dave: 15}
 
 }
 
@@ -1405,7 +783,6 @@ digraph GossipGraph {
 /// round_hashes: {
 ///   Alice -> [
 ///     RoundHash { round: 0, latest_block_hash: a137c1b54c5895b13a1e204869f650636920286bd5b903e0576a9a15a2f58c2c }
-///     RoundHash { round: 1, latest_block_hash: a137c1b54c5895b13a1e204869f650636920286bd5b903e0576a9a15a2f58c2c }
 ///   ]
 ///   Bob -> [
 ///     RoundHash { round: 0, latest_block_hash: a137c1b54c5895b13a1e204869f650636920286bd5b903e0576a9a15a2f58c2c }
@@ -1418,30 +795,15 @@ digraph GossipGraph {
 ///   ]
 /// }
 /// interesting_events: {
-///   Alice -> ["A_6"]
-///   Bob -> ["B_8"]
-///   Carol -> ["C_7"]
-///   Dave -> ["D_8"]
+///   Alice -> ["A_7"]
+///   Bob -> ["B_6"]
+///   Carol -> ["C_5"]
+///   Dave -> ["D_4"]
 /// }
 /// all_voters: {Alice, Bob, Carol, Dave}
 /// undecided_voters: {Alice, Bob, Carol, Dave}
+/// unconsensused_events: {"A_4", "B_4", "C_4", "D_2"}
 /// meta_events: {
-///   A_0 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   A_1 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   A_2 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   A_3 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
 ///   A_4 -> {
 ///     observees: {}
 ///     interesting_content: []
@@ -1452,36 +814,29 @@ digraph GossipGraph {
 ///   }
 ///   A_6 -> {
 ///     observees: {}
-///     interesting_content: [Add(Eric)]
+///     interesting_content: []
 ///   }
 ///   A_7 -> {
 ///     observees: {}
-///     interesting_content: []
+///     interesting_content: [Add(Eric)]
 ///   }
 ///   A_8 -> {
 ///     observees: {}
 ///     interesting_content: []
 ///   }
 ///   A_9 -> {
-///     observees: {Bob, Carol, Dave}
+///     observees: {Alice, Bob}
 ///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   f   -   -   - 
-///       B: 0/0   t   -   -   - 
-///       C: 0/0   t   -   -   - 
-///       D: 0/0   t   -   -   - 
-///     }
 ///   }
 ///   A_10 -> {
 ///     observees: {Alice, Bob, Carol, Dave}
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   f   -   -   - 
-///       B: 0/0   t   -   -   - 
-///       C: 0/0   t   -   -   - 
-///       D: 0/0   t   -   -   - 
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   b   f   f   - 
+///       D: 0/0   t   t   t   - 
 ///     }
 ///   }
 ///   A_11 -> {
@@ -1489,10 +844,10 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   f   -   -   - 
-///       B: 0/0   t   -   -   - 
-///       C: 0/0   t   -   -   - 
-///       D: 0/0   t   -   -   - 
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   b   f   f   - 
+///       D: 0/0   t   t   t   - 
 ///     }
 ///   }
 ///   A_12 -> {
@@ -1500,9 +855,9 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   t   t   - 
-///       B: 0/0   t   -   -   - 
-///       C: 0/0   t   t   t   - 
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   b   f   f   - 
 ///       D: 0/0   t   t   t   - 
 ///     }
 ///   }
@@ -1511,11 +866,10 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   b   f   f   - 
+///       D: 0/0   t   t   t   - 
 ///     }
 ///   }
 ///   A_14 -> {
@@ -1523,11 +877,10 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   b   f   f   - 
+///       D: 0/0   t   t   t   - 
 ///     }
 ///   }
 ///   A_15 -> {
@@ -1535,11 +888,10 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   b   b   f   - 
+///       D: 0/0   t   t   t   - 
 ///     }
 ///   }
 ///   A_16 -> {
@@ -1547,11 +899,10 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   b   b   f   - 
+///       D: 0/0   t   t   t   - 
 ///     }
 ///   }
 ///   A_17 -> {
@@ -1559,10 +910,10 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
+///       A: 0/0   t   t   t   t 
 ///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
+///       C: 0/0   b   b   f   - 
+///          0/1   f   -   -   - 
 ///       D: 0/0   t   t   t   t 
 ///     }
 ///   }
@@ -1571,11 +922,10 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   -   -   - 
+///       A: 0/0   t   t   t   t 
 ///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
+///       C: 0/0   b   b   f   - 
+///          0/1   f   -   -   - 
 ///       D: 0/0   t   t   t   t 
 ///     }
 ///   }
@@ -1584,49 +934,12 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   -   -   - 
+///       A: 0/0   t   t   t   t 
 ///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
+///       C: 0/0   b   b   f   - 
+///          0/1   f   f   f   - 
 ///       D: 0/0   t   t   t   t 
 ///     }
-///   }
-///   A_20 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///          1/0   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   A_21 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///          1/0   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_0 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   B_1 -> {
-///     observees: {}
-///     interesting_content: []
 ///   }
 ///   B_2 -> {
 ///     observees: {}
@@ -1646,33 +959,64 @@ digraph GossipGraph {
 ///   }
 ///   B_6 -> {
 ///     observees: {}
-///     interesting_content: []
-///   }
-///   B_7 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   B_8 -> {
-///     observees: {}
 ///     interesting_content: [Add(Eric)]
 ///   }
-///   B_9 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   B_10 -> {
-///     observees: {Dave}
-///     interesting_content: []
-///   }
-///   B_11 -> {
-///     observees: {Alice, Carol, Dave}
+///   B_7 -> {
+///     observees: {Alice, Bob, Carol, Dave}
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
 ///       A: 0/0   t   -   -   - 
-///       B: 0/0   f   -   -   - 
+///       B: 0/0   t   -   -   - 
 ///       C: 0/0   t   -   -   - 
 ///       D: 0/0   t   -   -   - 
+///     }
+///   }
+///   B_8 -> {
+///     observees: {Alice, Bob, Carol, Dave}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///       D: 0/0   t   -   -   - 
+///     }
+///   }
+///   B_9 -> {
+///     observees: {Alice, Bob, Carol, Dave}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   t 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   b   f   f   - 
+///          0/1   f   -   -   - 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   B_10 -> {
+///     observees: {Alice, Bob, Carol, Dave}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   t 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   b   b   f   - 
+///          0/1   f   -   -   - 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   B_11 -> {
+///     observees: {Alice, Bob, Carol, Dave}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   t 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   b   b   f   - 
+///          0/1   f   -   -   - 
+///       D: 0/0   t   t   t   t 
 ///     }
 ///   }
 ///   B_12 -> {
@@ -1680,10 +1024,11 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   t   -   -   - 
-///       B: 0/0   f   -   -   - 
-///       C: 0/0   t   -   -   - 
-///       D: 0/0   t   -   -   - 
+///       A: 0/0   t   t   t   t 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   b   b   f   - 
+///          0/1   f   -   -   - 
+///       D: 0/0   t   t   t   t 
 ///     }
 ///   }
 ///   B_13 -> {
@@ -1691,275 +1036,12 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   t   -   -   - 
-///       B: 0/0   f   -   -   - 
-///       C: 0/0   t   -   -   - 
-///       D: 0/0   t   -   -   - 
-///     }
-///   }
-///   B_14 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   t   -   -   - 
-///       B: 0/0   f   -   -   - 
-///       C: 0/0   t   -   -   - 
-///       D: 0/0   t   -   -   - 
-///     }
-///   }
-///   B_15 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   f   f   - 
-///       B: 0/0   b   t   t   - 
-///       C: 0/0   t   t   t   - 
-///       D: 0/0   t   t   t   - 
-///     }
-///   }
-///   B_16 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   -   -   - 
+///       A: 0/0   t   t   t   t 
 ///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
+///       C: 0/0   b   b   f   - 
+///          0/1   f   -   -   - 
 ///       D: 0/0   t   t   t   t 
 ///     }
-///   }
-///   B_17 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_18 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_19 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_20 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_21 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_22 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_23 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_24 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_25 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_26 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_27 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_28 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_29 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_30 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///          1/0   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_31 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///          1/0   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_32 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///          1/0   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   B_33 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///          1/0   t   t   t   t 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   C_0 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   C_1 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   C_2 -> {
-///     observees: {}
-///     interesting_content: []
 ///   }
 ///   C_3 -> {
 ///     observees: {}
@@ -1971,45 +1053,80 @@ digraph GossipGraph {
 ///   }
 ///   C_5 -> {
 ///     observees: {}
-///     interesting_content: []
+///     interesting_content: [Add(Eric)]
 ///   }
 ///   C_6 -> {
 ///     observees: {}
 ///     interesting_content: []
 ///   }
 ///   C_7 -> {
-///     observees: {}
-///     interesting_content: [Add(Eric)]
+///     observees: {Alice, Dave}
+///     interesting_content: []
 ///   }
 ///   C_8 -> {
-///     observees: {}
+///     observees: {Alice, Bob, Dave}
 ///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   f   -   -   - 
+///       D: 0/0   t   -   -   - 
+///     }
 ///   }
 ///   C_9 -> {
-///     observees: {}
+///     observees: {Alice, Bob, Carol, Dave}
 ///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   f   f   f   - 
+///       D: 0/0   t   t   t   - 
+///     }
 ///   }
 ///   C_10 -> {
-///     observees: {Dave}
+///     observees: {Alice, Bob, Carol, Dave}
 ///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   f   f   f   - 
+///       D: 0/0   t   t   t   - 
+///     }
 ///   }
 ///   C_11 -> {
-///     observees: {Dave}
+///     observees: {Alice, Bob, Carol, Dave}
 ///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   f   f   f   - 
+///       D: 0/0   t   t   t   - 
+///     }
 ///   }
 ///   C_12 -> {
-///     observees: {Dave}
+///     observees: {Alice, Bob, Carol, Dave}
 ///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   f   f   f   - 
+///       D: 0/0   t   t   t   - 
+///     }
 ///   }
 ///   C_13 -> {
 ///     observees: {Alice, Bob, Carol, Dave}
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   t   -   -   - 
-///       B: 0/0   t   -   -   - 
-///       C: 0/0   t   -   -   - 
-///       D: 0/0   t   -   -   - 
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   b   b   f   - 
+///       D: 0/0   t   t   t   - 
 ///     }
 ///   }
 ///   C_14 -> {
@@ -2017,9 +1134,9 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   f   f   - 
+///       A: 0/0   t   t   t   - 
 ///       B: 0/0   t   t   t   - 
-///       C: 0/0   t   t   t   - 
+///       C: 0/0   b   b   f   - 
 ///       D: 0/0   t   t   t   - 
 ///     }
 ///   }
@@ -2028,9 +1145,9 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   f   f   - 
+///       A: 0/0   t   t   t   - 
 ///       B: 0/0   t   t   t   - 
-///       C: 0/0   t   t   t   - 
+///       C: 0/0   b   b   f   - 
 ///       D: 0/0   t   t   t   - 
 ///     }
 ///   }
@@ -2039,9 +1156,9 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   f   f   - 
+///       A: 0/0   t   t   t   - 
 ///       B: 0/0   t   t   t   - 
-///       C: 0/0   t   t   t   - 
+///       C: 0/0   b   b   f   - 
 ///       D: 0/0   t   t   t   - 
 ///     }
 ///   }
@@ -2050,10 +1167,11 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///       B: 0/0   t   t   t   - 
-///       C: 0/0   t   t   t   - 
-///       D: 0/0   t   t   t   - 
+///       A: 0/0   t   t   t   t 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   b   b   f   - 
+///          0/1   f   -   -   - 
+///       D: 0/0   t   t   t   t 
 ///     }
 ///   }
 ///   C_18 -> {
@@ -2061,10 +1179,11 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///       B: 0/0   t   t   t   - 
-///       C: 0/0   t   t   t   - 
-///       D: 0/0   t   t   t   - 
+///       A: 0/0   t   t   t   t 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   b   b   f   - 
+///          0/1   f   f   f   - 
+///       D: 0/0   t   t   t   t 
 ///     }
 ///   }
 ///   C_19 -> {
@@ -2072,134 +1191,10 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///       B: 0/0   t   t   t   - 
-///       C: 0/0   t   t   t   - 
-///       D: 0/0   t   t   t   - 
-///     }
-///   }
-///   C_20 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///       B: 0/0   t   t   t   - 
-///       C: 0/0   t   t   t   - 
-///       D: 0/0   t   t   t   - 
-///     }
-///   }
-///   C_21 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   -   -   - 
+///       A: 0/0   t   t   t   t 
 ///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   C_22 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   C_23 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   C_24 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   C_25 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   C_26 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   C_27 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   C_28 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   C_29 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   f   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///          1/0   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
+///       C: 0/0   b   b   f   - 
+///          0/1   f   f   f   - 
 ///       D: 0/0   t   t   t   t 
 ///     }
 ///   }
@@ -2221,56 +1216,102 @@ digraph GossipGraph {
 ///   }
 ///   D_4 -> {
 ///     observees: {}
-///     interesting_content: []
+///     interesting_content: [Add(Eric)]
 ///   }
 ///   D_5 -> {
 ///     observees: {}
 ///     interesting_content: []
 ///   }
 ///   D_6 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   D_7 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   D_8 -> {
-///     observees: {}
-///     interesting_content: [Add(Eric)]
-///   }
-///   D_9 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   D_10 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   D_11 -> {
-///     observees: {Carol, Dave}
-///     interesting_content: []
-///   }
-///   D_12 -> {
-///     observees: {Bob, Carol, Dave}
+///     observees: {Alice, Bob, Dave}
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   f   -   -   - 
+///       A: 0/0   t   -   -   - 
 ///       B: 0/0   t   -   -   - 
-///       C: 0/0   t   -   -   - 
+///       C: 0/0   f   -   -   - 
 ///       D: 0/0   t   -   -   - 
 ///     }
 ///   }
-///   D_13 -> {
-///     observees: {Bob, Carol, Dave}
+///   D_7 -> {
+///     observees: {Alice, Bob, Dave}
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   f   -   -   - 
+///       A: 0/0   t   -   -   - 
 ///       B: 0/0   t   -   -   - 
-///       C: 0/0   t   -   -   - 
+///       C: 0/0   f   -   -   - 
 ///       D: 0/0   t   -   -   - 
+///     }
+///   }
+///   D_8 -> {
+///     observees: {Alice, Bob, Dave}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   f   -   -   - 
+///       D: 0/0   t   -   -   - 
+///     }
+///   }
+///   D_9 -> {
+///     observees: {Alice, Bob, Carol, Dave}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   f   -   -   - 
+///       D: 0/0   t   -   -   - 
+///     }
+///   }
+///   D_10 -> {
+///     observees: {Alice, Bob, Carol, Dave}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   t 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   b   b   t   - 
+///          0/1   t   -   -   - 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   D_11 -> {
+///     observees: {Alice, Bob, Carol, Dave}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   t 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   b   b   t   - 
+///          0/1   t   -   -   - 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   D_12 -> {
+///     observees: {Alice, Bob, Carol, Dave}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   t 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   b   b   t   - 
+///          0/1   t   -   -   - 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   D_13 -> {
+///     observees: {Alice, Bob, Carol, Dave}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   t 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   b   b   t   - 
+///          0/1   t   -   -   - 
+///       D: 0/0   t   t   t   t 
 ///     }
 ///   }
 ///   D_14 -> {
@@ -2278,10 +1319,11 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///       B: 0/0   t   t   t   - 
-///       C: 0/0   t   t   t   - 
-///       D: 0/0   t   t   t   - 
+///       A: 0/0   t   t   t   t 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   b   b   t   - 
+///          0/1   t   -   -   - 
+///       D: 0/0   t   t   t   t 
 ///     }
 ///   }
 ///   D_15 -> {
@@ -2289,240 +1331,10 @@ digraph GossipGraph {
 ///     interesting_content: []
 ///     meta_votes: {
 ///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///       B: 0/0   t   t   t   - 
-///       C: 0/0   t   t   t   - 
-///       D: 0/0   t   t   t   - 
-///     }
-///   }
-///   D_16 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///       B: 0/0   t   t   t   - 
-///       C: 0/0   t   t   t   - 
-///       D: 0/0   t   t   t   - 
-///     }
-///   }
-///   D_17 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///       B: 0/0   t   t   t   - 
-///       C: 0/0   t   t   t   - 
-///       D: 0/0   t   t   t   - 
-///     }
-///   }
-///   D_18 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   -   -   - 
+///       A: 0/0   t   t   t   t 
 ///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_19 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_20 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_21 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_22 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_23 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_24 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_25 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_26 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_27 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_28 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_29 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_30 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///          1/0   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_31 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///          1/0   t   -   -   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_32 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///          1/0   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
-///       D: 0/0   t   t   t   t 
-///     }
-///   }
-///   D_33 -> {
-///     observees: {Alice, Bob, Carol, Dave}
-///     interesting_content: []
-///     meta_votes: {
-///         stage est bin aux dec
-///       A: 0/0   b   b   t   - 
-///          0/1   t   t   t   - 
-///          0/2   t   t   t   - 
-///          1/0   t   t   t   - 
-///       B: 0/0   t   t   t   t 
-///       C: 0/0   t   t   t   t 
+///       C: 0/0   b   b   t   - 
+///          0/1   f   f   f   f 
 ///       D: 0/0   t   t   t   t 
 ///     }
 ///   }

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -70,7 +70,7 @@ mod detail {
     use serialise;
     use std::cell::RefCell;
     use std::cmp;
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
     use std::env;
     use std::fmt::{self, Debug};
     use std::fs::{self, File};
@@ -674,12 +674,18 @@ mod detail {
                     }
                 }
 
-                // write start index
+                // write unconsensused events
+                let unconsensused_events: BTreeSet<_> = election
+                    .unconsensused_events
+                    .iter()
+                    .filter_map(|index| self.gossip_graph.get(*index))
+                    .map(|event| event.short_name())
+                    .collect();
                 lines.push(format!(
-                    "{}{}start_index: {}",
+                    "{}{}unconsensused_events: {:?}",
                     Self::COMMENT,
                     self.indentation(),
-                    election.start_index
+                    unconsensused_events
                 ));
 
                 // write meta-events

--- a/src/meta_voting/meta_elections.rs
+++ b/src/meta_voting/meta_elections.rs
@@ -302,7 +302,8 @@ impl<P: PublicId> MetaElections<P> {
         self.get(handle)
             .map(|election| {
                 self.consensus_history()[..election.consensus_len].contains(payload_key)
-            }).unwrap_or(false)
+            })
+            .unwrap_or(false)
     }
 
     /// Topological index of the first unconsensused payload-carying event for the given election.

--- a/src/meta_voting/meta_elections.rs
+++ b/src/meta_voting/meta_elections.rs
@@ -306,9 +306,9 @@ impl<P: PublicId> MetaElections<P> {
             .unwrap_or(false)
     }
 
-    /// Topological index of the first unconsensused payload-carying event for the given election.
+    /// Topological index of the first unconsensused payload-carrying event for the given election.
     pub fn start_index(&self, handle: MetaElectionHandle) -> usize {
-        // `unconsensused_events` are already sorted topologically, so just returnt the first one.
+        // `unconsensused_events` are already sorted topologically, so just return the first one.
         self.get(handle)
             .and_then(|election| election.unconsensused_events.iter().next())
             .map(|event_index| event_index.topological_index())

--- a/src/meta_voting/meta_elections.rs
+++ b/src/meta_voting/meta_elections.rs
@@ -307,12 +307,11 @@ impl<P: PublicId> MetaElections<P> {
     }
 
     /// Topological index of the first unconsensused payload-carrying event for the given election.
-    pub fn start_index(&self, handle: MetaElectionHandle) -> usize {
+    pub fn start_index(&self, handle: MetaElectionHandle) -> Option<usize> {
         // `unconsensused_events` are already sorted topologically, so just return the first one.
         self.get(handle)
             .and_then(|election| election.unconsensused_events.iter().next())
             .map(|event_index| event_index.topological_index())
-            .unwrap_or(0)
     }
 
     /// Creates new election and returns handle of the previous election.


### PR DESCRIPTION
This PR trying to improve performance by reducing the number of events we need to traverse when calculating interesting content. It does so by caching all events that carry unconsensused payloads in the meta-election.

It also fixes two subtle bugs in the `previous_interesting_content` optimization. Details are explained in the corresponding commit message.