### PR TITLE
MAID-3271 investigate issue of new peer's event_1 cannot reach consensus

### DIFF
--- a/src/meta_voting/meta_vote.rs
+++ b/src/meta_voting/meta_vote.rs
@@ -140,7 +140,11 @@ impl MetaVote {
                 let coin_toss = coin_tosses.get(&parent.round);
                 let mut next = parent.clone();
                 Self::increase_step(&mut next, &counts, coin_toss.cloned());
-                Some(next)
+
+                let new_counts = MetaVoteCounts::new(&next, others, total_peers);
+                let updated = Self::update_meta_vote(&next, new_counts, &coin_tosses);
+
+                Some(updated)
             } else {
                 None
             }


### PR DESCRIPTION
The colouring work from Bart exposed an `one event late` issue:
that is for new peer's event_1, although it already sees other voters' meta decisions, it will only be at event_2 that the new peer will reached the same perspective.

This PR contains a fix resolving this issue.