### PR TITLE
Fix several issues in the test framework

### DIFF
--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -526,7 +526,7 @@ fn parse_add_or_remove_without_related_info() -> Parser<u8, (PeerId, Vec<u8>)> {
 
 fn parse_opaque() -> Parser<u8, Observation<Transaction, PeerId>> {
     (seq(b"OpaquePayload(") * parse_transaction() - seq(b")"))
-        .map(|s| Transaction::new(&s))
+        .map(Transaction::new)
         .map(Observation::OpaquePayload)
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -140,8 +140,8 @@ impl SecretId for PeerId {
 pub struct Transaction(String);
 
 impl Transaction {
-    pub fn new(id: &str) -> Self {
-        Transaction(id.to_string())
+    pub fn new<T: Into<String>>(id: T) -> Self {
+        Transaction(id.into())
     }
 }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -1109,7 +1109,6 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
                 }
             }).cloned()
             .collect();
-
         builder.set_observees(observees);
     }
 


### PR DESCRIPTION
1. During schedule generation, votes are now cast by all peers, not just by the active ones. This is because the status of a peer during schedule generation might not necessarily match its status during execution (because of `PeerRemovalGuard`). Removed and failed peers are skipped when actually casting votes durging execution.

2. In single-vote mode, any votes cast by peers that are scheduled for removal or fail anywhere in the schedule are not guaranteed to be consensused. The framework is updated to reflect this.

3. Re-queueing of schedule events that failed to be executed is changed to prevent single failed event to be tried over and over until the schedule is exhausted.