### PR TITLE
Update unconsensused events also in previous meta-elections

### DIFF
--- a/src/meta_voting/meta_elections.rs
+++ b/src/meta_voting/meta_elections.rs
@@ -405,10 +405,11 @@ impl MetaElections {
     }
 
     pub fn add_unconsensused_event(&mut self, event_index: EventIndex) {
-        let _ = self
-            .current_election
-            .unconsensused_events
-            .insert(event_index);
+        for election in
+            iter::once(&mut self.current_election).chain(self.previous_elections.values_mut())
+        {
+            let _ = election.unconsensused_events.insert(event_index);
+        }
     }
 
     pub fn unconsensused_events<'a>(


### PR DESCRIPTION
This fixes an issue with `previous_interesting_content` sometimes incorrectly returning empty collection.

Problem is that if we only update `unconsensused_events` for the current meta-election, the following situation can occur:

1. We decide the current meta-election, thus freezing it's `unconsensused_events`.
2. We keep adding new meta-events to that meta-election, because we are still evaluating it from the point of view of other peers.
3. Some time later, we add an event that carries an observation X. This event is NOT added to the `unconsensused_events` of that meta-election
4. So from that point on, no meta-event created for that meta-election will ever have X among its interesting content.
5. So `previous_interesting_content` is now broken, because it might return a vec that doesn't contain X, event though it should.
