### PR TITLE
MAID-3276: remove redundant fields from Event

### DIFF
--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -1081,6 +1081,7 @@ mod tests {
 
             let mut dot_file_path = entry.path();
             assert!(dot_file_path.set_extension("dot"));
+
             let parsed = unwrap!(parse_dot_file(&dot_file_path));
             let actual_snapshot = (
                 GraphSnapshot::new(&parsed.graph),

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -7,13 +7,25 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use gossip::{CauseInput, Event, EventIndex, Graph, IndexedEventRef};
+#[cfg(any(
+    all(test, feature = "malice-detection", feature = "mock"),
+    feature = "testing"
+))]
+use gossip::{EventContextMut, EventContextRef};
 use hash::Hash;
 use hash::HASH_LEN;
 use meta_voting::{
     BoolSet, MetaElection, MetaElectionHandle, MetaElections, MetaEvent, MetaVote, Step,
 };
 use mock::{PeerId, Transaction};
-use observation::{Observation, ObservationHash, ObservationKey};
+#[cfg(any(
+    all(test, feature = "malice-detection", feature = "mock"),
+    feature = "testing"
+))]
+use observation::ConsensusMode;
+use observation::{
+    Observation, ObservationHash, ObservationInfo, ObservationKey, ObservationStore,
+};
 use peer_list::{PeerIndexMap, PeerIndexSet, PeerList, PeerState};
 use pom::char_class::{alphanum, digit, hex_digit, multispace, space};
 use pom::parser::*;
@@ -581,7 +593,7 @@ fn parse_single_meta_event() -> Parser<u8, (String, (ObservationMap, ParsedMetaE
 fn parse_meta_event_content() -> Parser<u8, (ObservationMap, ParsedMetaEvent)> {
     (parse_observees() + parse_interesting_content() + parse_meta_votes().opt()).map(
         |((observees, observation_map), meta_votes)| {
-            let interesting_content = observation_map.iter().map(|(key, _)| key.clone()).collect();
+            let interesting_content = observation_map.iter().map(|(key, _)| *key).collect();
             (
                 observation_map,
                 ParsedMetaEvent {
@@ -678,10 +690,10 @@ fn parse_end() -> Parser<u8, ()> {
 /// The event graph and associated info that were parsed from the dumped dot file.
 pub(crate) struct ParsedContents {
     pub our_id: PeerId,
-    pub graph: Graph<Transaction, PeerId>,
+    pub graph: Graph<PeerId>,
     pub meta_elections: MetaElections,
     pub peer_list: PeerList<PeerId>,
-    pub observation_map: BTreeMap<ObservationKey, Observation<Transaction, PeerId>>,
+    pub observations: ObservationStore<Transaction, PeerId>,
 }
 
 impl ParsedContents {
@@ -695,15 +707,15 @@ impl ParsedContents {
             graph: Graph::new(),
             meta_elections,
             peer_list,
-            observation_map: BTreeMap::new(),
+            observations: ObservationStore::new(),
         }
     }
 }
 
-#[cfg(all(test, feature = "mock"))]
 impl ParsedContents {
     /// Remove and return the last (newest) event from the `ParsedContents`, if any.
-    pub fn remove_last_event(&mut self) -> Option<Event<Transaction, PeerId>> {
+    #[cfg(all(test, feature = "mock"))]
+    pub fn remove_last_event(&mut self) -> Option<Event<PeerId>> {
         let (index_0, event) = self.graph.remove_last()?;
         let index_1 = self.peer_list.remove_last_event(event.creator());
         assert_eq!(Some(index_0), index_1);
@@ -711,12 +723,38 @@ impl ParsedContents {
         Some(event)
     }
 
-    #[cfg(feature = "malice-detection")]
+    #[cfg(all(feature = "malice-detection", feature = "mock"))]
     /// Insert event into the `ParsedContents`. Note this does not perform any validations whatsoever,
     /// so this is useful for simulating all kinds of invalid or malicious situations.
-    pub fn add_event(&mut self, event: Event<Transaction, PeerId>) {
+    pub fn add_event(&mut self, event: Event<PeerId>) -> EventIndex {
         let indexed_event = self.graph.insert(event);
         self.peer_list.add_event(indexed_event);
+        indexed_event.event_index()
+    }
+
+    #[cfg(any(
+        all(test, feature = "malice-detection", feature = "mock"),
+        feature = "testing"
+    ))]
+    pub fn event_context(&self) -> EventContextRef<Transaction, PeerId> {
+        EventContextRef {
+            graph: &self.graph,
+            peer_list: &self.peer_list,
+            observations: &self.observations,
+        }
+    }
+
+    #[cfg(any(
+        all(test, feature = "malice-detection", feature = "mock"),
+        feature = "testing"
+    ))]
+    pub fn event_context_mut(&mut self) -> EventContextMut<Transaction, PeerId> {
+        EventContextMut {
+            graph: &self.graph,
+            peer_list: &self.peer_list,
+            observations: &mut self.observations,
+            consensus_mode: ConsensusMode::Supermajority,
+        }
     }
 }
 
@@ -728,7 +766,6 @@ pub(crate) fn parse_dot_file<P: AsRef<Path>>(full_path: P) -> io::Result<ParsedC
 
 /// For use by functional/unit tests which provide a dot file for the test setup.  This put the test
 /// name as part of the path automatically.
-#[cfg(any(test, feature = "testing"))]
 pub(crate) fn parse_test_dot_file(filename: &str) -> ParsedContents {
     use std::thread;
 
@@ -740,7 +777,7 @@ pub(crate) fn parse_test_dot_file(filename: &str) -> ParsedContents {
 
 /// For use by functional/unit tests which provide a dot file for the test setup.  This reads and
 /// parses the dot file as per `parse_dot_file()` above, with test name being part of the path.
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "mock"))]
 pub(crate) fn parse_dot_file_with_test_name(filename: &str, test_name: &str) -> ParsedContents {
     use std::path::PathBuf;
 
@@ -800,20 +837,22 @@ fn convert_into_parsed_contents(result: ParsedFile) -> ParsedContents {
 
     let peer_list = peer_list_builder.finish(&parsed_contents.graph);
 
-    let observation_map = meta_elections
-        .meta_elections
-        .values()
-        .flat_map(|meta_election| {
-            meta_election
-                .observation_map
-                .iter()
-                .map(|(key, obs)| (key.clone(), obs.clone()))
-        })
-        .collect();
+    parsed_contents
+        .observations
+        .extend(
+            meta_elections
+                .meta_elections
+                .values()
+                .flat_map(|meta_election| {
+                    meta_election
+                        .observation_map
+                        .iter()
+                        .map(|(key, obs)| (*key, ObservationInfo::new(obs.clone())))
+                }),
+        );
     let meta_elections = convert_to_meta_elections(meta_elections, &mut event_hashes, &peer_list);
 
     parsed_contents.peer_list = peer_list;
-    parsed_contents.observation_map = observation_map;
     parsed_contents.meta_elections = meta_elections;
     parsed_contents
 }
@@ -954,6 +993,7 @@ fn create_events(
             index_by_creator,
             next_event_details.last_ancestors.clone(),
             peer_list,
+            &mut parsed_contents.observations,
         );
 
         let index = parsed_contents.graph.insert(next_event).event_index();
@@ -964,10 +1004,10 @@ fn create_events(
 }
 
 fn get_event_by_id<'a>(
-    graph: &'a Graph<Transaction, PeerId>,
+    graph: &'a Graph<PeerId>,
     indices: &BTreeMap<String, EventIndex>,
     id: &str,
-) -> Option<IndexedEventRef<'a, Transaction, PeerId>> {
+) -> Option<IndexedEventRef<'a, PeerId>> {
     indices.get(id).cloned().and_then(|index| graph.get(index))
 }
 

--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(any(all(test, feature = "mock"), feature = "testing"))]
+#[cfg(feature = "testing")]
 use super::parse_test_dot_file;
 use super::peer::{Peer, PeerStatus};
 use super::schedule::{Schedule, ScheduleEvent, ScheduleOptions};
@@ -109,7 +109,7 @@ impl Network {
         }
     }
 
-    #[cfg(any(all(test, feature = "mock"), feature = "testing"))]
+    #[cfg(feature = "testing")]
     pub fn from_graphs<I: IntoIterator<Item = &'static str>>(
         consensus_mode: ConsensusMode,
         genesis: BTreeSet<PeerId>,

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Observation;
-#[cfg(any(all(test, feature = "mock"), feature = "testing"))]
+#[cfg(feature = "testing")]
 use super::ParsedContents;
 use block::Block;
 use mock::{PeerId, Transaction};
@@ -64,7 +64,7 @@ impl Peer {
         }
     }
 
-    #[cfg(any(all(test, feature = "mock"), feature = "testing"))]
+    #[cfg(feature = "testing")]
     pub(crate) fn from_parsed_contents(contents: ParsedContents) -> Self {
         let id = contents.our_id.clone();
         let parsec = Parsec::from_parsed_contents(contents);

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ use std::result;
 pub enum Error {
     /// Payload of a `Vote` doesn't match the payload of a `Block`.
     MismatchedPayload,
+    /// Payload hash doesn't correspond to any payload known to us.
+    UnknownPayload,
     /// Attempt to create a block with no votes.
     MissingVotes,
     /// Failed to verify signature.
@@ -58,6 +60,10 @@ impl Display for Error {
             Error::MismatchedPayload => write!(
                 f,
                 "The payload of the vote doesn't match the payload of targeted block."
+            ),
+            Error::UnknownPayload => write!(
+                f,
+                "The payload hash doesn't correspond to any payload known to our node."
             ),
             Error::MissingVotes => write!(f, "Block cannot be created with no votes"),
             Error::SignatureFailure => write!(

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -6,11 +6,14 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#[cfg(test)]
+use super::graph::IndexedEventRef;
 use super::{
-    cause::Cause,
+    cause::{other_parent_hash, self_parent_hash, Cause},
     content::Content,
+    event_context::{EventContextMut, EventContextRef},
     event_hash::EventHash,
-    graph::{EventIndex, Graph, IndexedEventRef},
+    graph::{EventIndex, Graph},
     packed_event::PackedEvent,
 };
 use error::Error;
@@ -19,88 +22,163 @@ use id::{PublicId, SecretId};
 #[cfg(any(test, feature = "testing"))]
 use mock::{PeerId, Transaction};
 use network_event::NetworkEvent;
-use observation::Observation;
-use observation::ObservationHash;
+use observation::{Observation, ObservationKey, ObservationStore};
 use peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet, PeerList};
 use serialise;
 use std::cmp;
 #[cfg(any(test, feature = "testing"))]
 use std::collections::BTreeMap;
-use std::fmt::{self, Debug, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 #[cfg(feature = "dump-graphs")]
 use std::io::{self, Write};
-use vote::Vote;
+use vote::{Vote, VoteKey};
 
-pub(crate) struct Event<T: NetworkEvent, P: PublicId> {
-    content: Content<T, P>,
+pub(crate) struct Event<P: PublicId> {
+    content: Content<VoteKey<P>, EventIndex, PeerIndex>,
     // Creator's signature of `content`.
     signature: P::Signature,
     cache: Cache,
 }
 
-impl<T: NetworkEvent, P: PublicId> Event<T, P> {
+impl<P: PublicId> Event<P> {
     // Creates a new event as the result of receiving a gossip request message.
-    pub fn new_from_request<S: SecretId<PublicId = P>>(
-        self_parent: EventHash,
-        other_parent: EventHash,
-        graph: &Graph<T, P>,
-        peer_list: &PeerList<S>,
+    pub fn new_from_request<T: NetworkEvent, S: SecretId<PublicId = P>>(
+        self_parent: EventIndex,
+        other_parent: EventIndex,
         forking_peers: &PeerIndexSet,
-    ) -> Self {
-        Self::new(
-            Cause::Request {
+        ctx: EventContextRef<T, S>,
+    ) -> Result<Self, Error> {
+        let content: Content<Vote<T, _>, _, _> = Content {
+            creator: ctx.peer_list.our_pub_id().clone(),
+            cause: Cause::Request {
+                self_parent: self_parent_hash(ctx.graph, self_parent)?,
+                other_parent: other_parent_hash(ctx.graph, other_parent)?,
+            },
+        };
+        let (hash, signature) = compute_event_hash_and_signature(&content, ctx.peer_list.our_id());
+
+        let content = Content {
+            creator: PeerIndex::OUR,
+            cause: Cause::Request {
                 self_parent,
                 other_parent,
             },
-            graph,
-            peer_list,
+        };
+
+        Ok(Self::new(
+            hash,
+            signature,
+            content,
+            ctx.graph,
+            ctx.peer_list,
             forking_peers,
-        )
+        ))
     }
 
     // Creates a new event as the result of receiving a gossip response message.
-    pub fn new_from_response<S: SecretId<PublicId = P>>(
-        self_parent: EventHash,
-        other_parent: EventHash,
-        graph: &Graph<T, P>,
-        peer_list: &PeerList<S>,
+    pub fn new_from_response<T: NetworkEvent, S: SecretId<PublicId = P>>(
+        self_parent: EventIndex,
+        other_parent: EventIndex,
         forking_peers: &PeerIndexSet,
-    ) -> Self {
-        Self::new(
-            Cause::Response {
+        ctx: EventContextRef<T, S>,
+    ) -> Result<Self, Error> {
+        let content: Content<Vote<T, _>, _, _> = Content {
+            creator: ctx.peer_list.our_pub_id().clone(),
+            cause: Cause::Response {
+                self_parent: self_parent_hash(ctx.graph, self_parent)?,
+                other_parent: other_parent_hash(ctx.graph, other_parent)?,
+            },
+        };
+        let (hash, signature) = compute_event_hash_and_signature(&content, ctx.peer_list.our_id());
+
+        let content = Content {
+            creator: PeerIndex::OUR,
+            cause: Cause::Response {
                 self_parent,
                 other_parent,
             },
-            graph,
-            peer_list,
+        };
+
+        Ok(Self::new(
+            hash,
+            signature,
+            content,
+            ctx.graph,
+            ctx.peer_list,
             forking_peers,
-        )
+        ))
     }
 
     // Creates a new event as the result of observing a network event.
-    pub fn new_from_observation<S: SecretId<PublicId = P>>(
-        self_parent: EventHash,
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn new_from_observation<T: NetworkEvent, S: SecretId<PublicId = P>>(
+        self_parent: EventIndex,
         observation: Observation<T, P>,
-        graph: &Graph<T, P>,
-        peer_list: &PeerList<S>,
-    ) -> Self {
-        let vote = Vote::new(peer_list.our_id(), observation);
-        Self::new(
-            Cause::Observation { self_parent, vote },
+        ctx: EventContextMut<T, S>,
+    ) -> Result<Self, Error> {
+        // Compute event hash + signature.
+        let vote = Vote::new(ctx.peer_list.our_id(), observation);
+        let content = Content {
+            creator: ctx.peer_list.our_pub_id().clone(),
+            cause: Cause::Observation {
+                self_parent: self_parent_hash(ctx.graph, self_parent)?,
+                vote,
+            },
+        };
+        let (hash, signature) = compute_event_hash_and_signature(&content, ctx.peer_list.our_id());
+        let graph = ctx.graph;
+        let peer_list = ctx.peer_list;
+        let content = Content::unpack(content, ctx)?;
+
+        Ok(Self::new(
+            hash,
+            signature,
+            content,
             graph,
             peer_list,
+            &PeerIndexSet::default(),
+        ))
+    }
+
+    // Creates an initial event.  This is the first event by its creator in the graph.
+    pub fn new_initial<T: NetworkEvent, S: SecretId<PublicId = P>>(
+        ctx: EventContextRef<T, S>,
+    ) -> Self {
+        let content: Content<Vote<T, _>, _, _> = Content {
+            creator: ctx.peer_list.our_pub_id().clone(),
+            cause: Cause::Initial,
+        };
+        let (hash, signature) = compute_event_hash_and_signature(&content, ctx.peer_list.our_id());
+
+        let content = Content {
+            creator: PeerIndex::OUR,
+            cause: Cause::Initial,
+        };
+
+        Self::new(
+            hash,
+            signature,
+            content,
+            ctx.graph,
+            ctx.peer_list,
             &PeerIndexSet::default(),
         )
     }
 
-    // Creates an initial event.  This is the first event by its creator in the graph.
-    pub fn new_initial<S: SecretId<PublicId = P>>(peer_list: &PeerList<S>) -> Self {
-        Self::new(
-            Cause::Initial,
-            &Graph::new(),
-            peer_list,
-            &PeerIndexSet::default(),
-        )
+    fn new<S: SecretId<PublicId = P>>(
+        hash: EventHash,
+        signature: P::Signature,
+        content: Content<VoteKey<P>, EventIndex, PeerIndex>,
+        graph: &Graph<P>,
+        peer_list: &PeerList<S>,
+        forking_peers: &PeerIndexSet,
+    ) -> Self {
+        let cache = Cache::new(hash, &content, graph, peer_list, forking_peers);
+        Self {
+            content,
+            signature,
+            cache,
+        }
     }
 
     // Creates an event from a `PackedEvent`.
@@ -110,55 +188,48 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
     //   - `Err(Error::SignatureFailure)` if signature validation fails
     //   - `Err(Error::UnknownParent)` if the event indicates it should have an ancestor, but the
     //     ancestor isn't in `events`.
-    pub(crate) fn unpack<S: SecretId<PublicId = P>>(
+    #[allow(clippy::needless_pass_by_value)]
+    pub(crate) fn unpack<T: NetworkEvent, S: SecretId<PublicId = P>>(
         packed_event: PackedEvent<T, P>,
-        graph: &Graph<T, P>,
-        peer_list: &PeerList<S>,
         forking_peers: &PeerIndexSet,
-    ) -> Result<UnpackedEvent<T, P>, Error> {
+        ctx: EventContextMut<T, S>,
+    ) -> Result<UnpackedEvent<P>, Error> {
         let hash = compute_event_hash_and_verify_signature(
             &packed_event.content,
             &packed_event.signature,
         )?;
 
-        if let Some(index) = graph.get_index(&hash) {
+        if let Some(index) = ctx.graph.get_index(&hash) {
             return Ok(UnpackedEvent::Known(index));
         }
 
-        let creator = peer_list
-            .get_index(&packed_event.content.creator)
-            .ok_or(Error::UnknownPeer)?;
-        let (self_parent, other_parent) =
-            get_parents(&packed_event.content, graph, peer_list.our_pub_id())?;
-        let cache = Cache::new(
-            hash,
-            &packed_event.content,
-            self_parent,
-            other_parent,
-            creator,
-            forking_peers,
-            peer_list,
-        );
+        let graph = ctx.graph;
+        let peer_list = ctx.peer_list;
+        let content = Content::unpack(packed_event.content, ctx)?;
+        let cache = Cache::new(hash, &content, graph, peer_list, forking_peers);
 
         Ok(UnpackedEvent::New(Self {
-            content: packed_event.content,
+            content,
             signature: packed_event.signature,
             cache,
         }))
     }
 
     // Creates a `PackedEvent` from this `Event`.
-    pub(crate) fn pack(&self) -> PackedEvent<T, P> {
-        PackedEvent {
-            content: self.content.clone(),
+    pub(crate) fn pack<T: NetworkEvent, S: SecretId<PublicId = P>>(
+        &self,
+        ctx: EventContextRef<T, S>,
+    ) -> Result<PackedEvent<T, P>, Error> {
+        Ok(PackedEvent {
+            content: self.content.pack(ctx)?,
             signature: self.signature.clone(),
-        }
+        })
     }
 
     // Returns whether this event can see `other`, i.e. whether there's a directed path from `other`
     // to `self` in the graph, and no two events created by `other`'s creator are ancestors to
     // `self` (fork).
-    pub fn sees<E: AsRef<Event<T, P>>>(&self, other: E) -> bool {
+    pub fn sees<E: AsRef<Event<P>>>(&self, other: E) -> bool {
         self.is_descendant_of(other).unwrap_or(false)
     }
 
@@ -166,7 +237,7 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
     // and `other` the answer cannot be determined from the events themselves and graph traversal
     // is required. `None` is returned in that case. Otherwise returns `Some` with the correct
     // answer.
-    pub fn is_descendant_of<E: AsRef<Event<T, P>>>(&self, other: E) -> Option<bool> {
+    pub fn is_descendant_of<E: AsRef<Event<P>>>(&self, other: E) -> Option<bool> {
         match self.last_ancestor_by(other.as_ref().creator()) {
             LastAncestor::Some(last_index) => Some(last_index >= other.as_ref().index_by_creator()),
             LastAncestor::None => Some(false),
@@ -191,62 +262,38 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
         self.cache.forking_peers.contains(&peer_index)
     }
 
-    /// Returns `Some(vote)` if the event is for a vote of network event, otherwise returns `None`.
-    pub fn vote(&self) -> Option<&Vote<T, P>> {
-        if let Cause::Observation { ref vote, .. } = self.content.cause {
-            Some(vote)
-        } else {
-            None
+    pub fn payload_key(&self) -> Option<&ObservationKey> {
+        match self.content.cause {
+            Cause::Observation { ref vote, .. } => Some(vote.payload_key()),
+            _ => None,
         }
     }
 
-    pub fn vote_with_payload_hash(&self) -> Option<(&Vote<T, P>, &ObservationHash)> {
-        self.vote().and_then(|vote| match self.cache.payload_hash {
-            Some(ref hash) => Some((vote, hash)),
-            None => {
-                log_or_panic!("Event has payload but no payload hash: {:?}", self);
-                None
+    pub fn vote_and_payload_key<T: NetworkEvent>(
+        &self,
+        observations: &ObservationStore<T, P>,
+    ) -> Option<(Vote<T, P>, ObservationKey)> {
+        match self.content.cause {
+            Cause::Observation { ref vote, .. } => {
+                let key = *vote.payload_key();
+                let vote = vote.resolve(observations).ok()?;
+
+                Some((vote, key))
             }
-        })
-    }
-
-    pub fn payload(&self) -> Option<&Observation<T, P>> {
-        self.vote().map(Vote::payload)
-    }
-
-    pub fn payload_hash(&self) -> Option<&ObservationHash> {
-        self.vote().and_then(|_| self.cache.payload_hash.as_ref())
-    }
-
-    pub fn payload_with_hash(&self) -> Option<(&Observation<T, P>, &ObservationHash)> {
-        self.vote_with_payload_hash()
-            .map(|(vote, hash)| (vote.payload(), hash))
+            _ => None,
+        }
     }
 
     pub fn creator(&self) -> PeerIndex {
-        self.cache.creator
-    }
-
-    pub fn creator_id(&self) -> &P {
-        &self.content.creator
+        self.content.creator
     }
 
     pub fn self_parent(&self) -> Option<EventIndex> {
-        self.cache.self_parent
+        self.content.self_parent().cloned()
     }
 
     pub fn other_parent(&self) -> Option<EventIndex> {
-        self.cache.other_parent
-    }
-
-    #[cfg(test)]
-    pub fn self_parent_hash(&self) -> Option<&EventHash> {
-        self.content.self_parent()
-    }
-
-    #[cfg(test)]
-    pub fn other_parent_hash(&self) -> Option<&EventHash> {
-        self.content.other_parent()
+        self.content.other_parent().cloned()
     }
 
     pub fn hash(&self) -> &EventHash {
@@ -292,49 +339,11 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
     }
 
     /// Returns the first char of the creator's ID, followed by an underscore and the event's index.
-    pub fn short_name(&self) -> String {
-        format!(
-            "{:.1}_{}",
-            format!("{:?}", self.content.creator),
-            self.cache.index_by_creator
-        )
-    }
-
-    fn new<S: SecretId<PublicId = P>>(
-        cause: Cause<T, P>,
-        graph: &Graph<T, P>,
-        peer_list: &PeerList<S>,
-        forking_peers: &PeerIndexSet,
-    ) -> Self {
-        let content = Content {
-            creator: peer_list.our_id().public_id().clone(),
-            cause,
-        };
-
-        let (hash, signature) = compute_event_hash_and_signature(&content, peer_list.our_id());
-        let (self_parent, other_parent) = get_parents(&content, graph, peer_list.our_pub_id())
-            .unwrap_or_else(|error| {
-                log_or_panic!(
-                    "{:?} constructed an invalid event: {:?}.",
-                    peer_list.our_pub_id(),
-                    error
-                );
-                (None, None)
-            });
-        let cache = Cache::new(
-            hash,
-            &content,
-            self_parent,
-            other_parent,
-            PeerIndex::OUR,
-            forking_peers,
-            peer_list,
-        );
-
-        Self {
-            content,
-            signature,
-            cache,
+    #[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
+    pub fn short_name(&self) -> ShortName {
+        ShortName {
+            creator_initial: self.cache.creator_initial,
+            index_by_creator: self.cache.index_by_creator,
         }
     }
 
@@ -344,27 +353,23 @@ impl<T: NetworkEvent, P: PublicId> Event<T, P> {
     }
 }
 
-impl<T: NetworkEvent, P: PublicId> PartialEq for Event<T, P> {
+impl<P: PublicId> PartialEq for Event<P> {
     fn eq(&self, other: &Self) -> bool {
         self.content == other.content && self.signature == other.signature
     }
 }
 
-impl<T: NetworkEvent, P: PublicId> Eq for Event<T, P> {}
+impl<P: PublicId> Eq for Event<P> {}
 
-impl<T: NetworkEvent, P: PublicId> Debug for Event<T, P> {
+impl<P: PublicId> Debug for Event<P> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "Event{{ {} {:?}", self.short_name(), self.hash(),)?;
-        write!(
-            formatter,
-            ", {}",
-            match &self.content.cause {
-                Cause::Request { .. } => "Request".to_string(),
-                Cause::Response { .. } => "Response".to_string(),
-                Cause::Observation { vote, .. } => format!("Observation({:?})", vote.payload()),
-                Cause::Initial => "Initial".to_string(),
-            }
-        )?;
+        write!(formatter, "Event{{")?;
+
+        #[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
+        write!(formatter, " {}", self.short_name())?;
+
+        write!(formatter, " {:?}", self.hash())?;
+        write!(formatter, ", {}", self.content.cause)?;
         write!(
             formatter,
             ", self_parent: {:?}, other_parent: {:?}",
@@ -380,15 +385,16 @@ impl<T: NetworkEvent, P: PublicId> Debug for Event<T, P> {
     }
 }
 
-impl<T: NetworkEvent, P: PublicId> AsRef<Self> for Event<T, P> {
+impl<P: PublicId> AsRef<Self> for Event<P> {
     fn as_ref(&self) -> &Self {
         self
     }
 }
 
 #[cfg(any(test, feature = "testing"))]
-impl Event<Transaction, PeerId> {
+impl Event<PeerId> {
     // Creates a new event using the input parameters directly.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_from_dot_input(
         creator: &PeerId,
         cause: CauseInput,
@@ -397,14 +403,14 @@ impl Event<Transaction, PeerId> {
         index_by_creator: usize,
         last_ancestors: BTreeMap<PeerId, usize>,
         peer_list: &PeerList<PeerId>,
+        observations: &mut ObservationStore<Transaction, PeerId>,
     ) -> Self {
         let cause = Cause::new_from_dot_input(
             cause,
             creator,
-            self_parent.map(|p| p.1),
-            other_parent.map(|p| p.1),
+            self_parent.map(|(_, h)| h),
+            other_parent.map(|(_, h)| h),
         );
-        let payload_hash = compute_payload_hash(&cause);
         let content = Content {
             creator: creator.clone(),
             cause,
@@ -412,6 +418,15 @@ impl Event<Transaction, PeerId> {
         let (hash, signature) = compute_event_hash_and_signature(&content, creator);
 
         let creator = unwrap!(peer_list.get_index(creator));
+        let cause = Cause::unpack_from_dot_input(
+            content.cause,
+            creator,
+            self_parent.map(|(i, _)| i),
+            other_parent.map(|(i, _)| i),
+            observations,
+        );
+        let content = Content { creator, cause };
+
         let last_ancestors = last_ancestors
             .into_iter()
             .map(|(peer_id, index_by_creator)| {
@@ -421,13 +436,10 @@ impl Event<Transaction, PeerId> {
 
         let cache = Cache {
             hash,
-            self_parent: self_parent.map(|p| p.0),
-            other_parent: other_parent.map(|p| p.0),
-            creator,
             index_by_creator,
             last_ancestors,
             forking_peers: PeerIndexSet::default(),
-            payload_hash,
+            creator_initial: get_creator_initial(peer_list, creator),
         };
 
         Self {
@@ -439,11 +451,11 @@ impl Event<Transaction, PeerId> {
 }
 
 #[derive(Debug)]
-pub(crate) enum UnpackedEvent<T: NetworkEvent, P: PublicId> {
+pub(crate) enum UnpackedEvent<P: PublicId> {
     // Event is already in our gossip graph
     Known(EventIndex),
     // Event is not yet in our gossip graph
-    New(Event<T, P>),
+    New(Event<P>),
 }
 
 pub(crate) enum LastAncestor {
@@ -468,34 +480,30 @@ pub(crate) enum CauseInput {
 struct Cache {
     // Hash of `Event`s `Content`.
     hash: EventHash,
-    // EventIndex of self-parent
-    self_parent: Option<EventIndex>,
-    // EventIndex of other-parent
-    other_parent: Option<EventIndex>,
-    // PeerIndex of the creator
-    creator: PeerIndex,
     // Index of this event relative to other events by the same creator.
     index_by_creator: usize,
     // Index of each peer's latest event that is an ancestor of this event.
     last_ancestors: PeerIndexMap<usize>,
     // Peers with a fork having both sides seen by this event.
     forking_peers: PeerIndexSet,
-    // Hash of the payload
-    payload_hash: Option<ObservationHash>,
+    // First leter of the creator name.
+    #[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
+    creator_initial: char,
 }
 
 impl Cache {
-    fn new<T: NetworkEvent, S: SecretId>(
+    fn new<S: SecretId>(
         hash: EventHash,
-        content: &Content<T, S::PublicId>,
-        self_parent: Option<IndexedEventRef<T, S::PublicId>>,
-        other_parent: Option<IndexedEventRef<T, S::PublicId>>,
-        creator: PeerIndex,
-        forking_peers: &PeerIndexSet,
+        content: &Content<VoteKey<S::PublicId>, EventIndex, PeerIndex>,
+        graph: &Graph<S::PublicId>,
         peer_list: &PeerList<S>,
+        forking_peers: &PeerIndexSet,
     ) -> Self {
+        let self_parent = content.self_parent().and_then(|index| graph.get(*index));
+        let other_parent = content.other_parent().and_then(|index| graph.get(*index));
+
         let (index_by_creator, last_ancestors) = index_by_creator_and_last_ancestors(
-            creator,
+            content.creator,
             self_parent.map(|e| e.inner()),
             other_parent.map(|e| e.inner()),
             peer_list,
@@ -505,95 +513,22 @@ impl Cache {
             other_parent.map(|e| e.inner()),
             forking_peers,
         );
-        let payload_hash = compute_payload_hash(&content.cause);
 
         Self {
             hash,
-            self_parent: self_parent.map(|e| e.event_index()),
-            other_parent: other_parent.map(|e| e.event_index()),
-            creator,
             index_by_creator,
             last_ancestors,
             forking_peers,
-            payload_hash,
+            #[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
+            creator_initial: get_creator_initial(peer_list, content.creator),
         }
     }
 }
 
-type OptionalParents<'a, T, P> = (
-    Option<IndexedEventRef<'a, T, P>>,
-    Option<IndexedEventRef<'a, T, P>>,
-);
-
-fn get_parents<'a, T: NetworkEvent, P: PublicId>(
-    content: &Content<T, P>,
-    graph: &'a Graph<T, P>,
-    our_id: &P,
-) -> Result<OptionalParents<'a, T, P>, Error> {
-    let self_parent = get_parent(Parent::Self_, content, graph, our_id)?;
-    let other_parent = get_parent(Parent::Other, content, graph, our_id)?;
-    Ok((self_parent, other_parent))
-}
-
-fn get_parent<'a, T: NetworkEvent, P: PublicId>(
-    parent: Parent,
-    content: &Content<T, P>,
-    graph: &'a Graph<T, P>,
-    our_id: &P,
-) -> Result<Option<IndexedEventRef<'a, T, P>>, Error> {
-    if let Some(hash) = parent.hash(content) {
-        Ok(Some(
-            graph
-                .get_index(hash)
-                .and_then(|index| graph.get(index))
-                .ok_or_else(|| {
-                    debug!("{:?} missing {} parent for {:?}", our_id, parent, content);
-                    parent.to_unknown_error()
-                })?,
-        ))
-    } else {
-        Ok(None)
-    }
-}
-
-#[derive(Clone, Copy)]
-enum Parent {
-    Self_, // `Self` is reserved.
-    Other,
-}
-
-impl Parent {
-    fn hash<'a, T: NetworkEvent, P: PublicId>(
-        self,
-        content: &'a Content<T, P>,
-    ) -> Option<&'a EventHash> {
-        match self {
-            Parent::Self_ => content.self_parent(),
-            Parent::Other => content.other_parent(),
-        }
-    }
-
-    fn to_unknown_error(self) -> Error {
-        match self {
-            Parent::Self_ => Error::UnknownSelfParent,
-            Parent::Other => Error::UnknownOtherParent,
-        }
-    }
-}
-
-impl fmt::Display for Parent {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        match *self {
-            Parent::Self_ => write!(formatter, "self"),
-            Parent::Other => write!(formatter, "other"),
-        }
-    }
-}
-
-fn index_by_creator_and_last_ancestors<T: NetworkEvent, S: SecretId>(
+fn index_by_creator_and_last_ancestors<S: SecretId>(
     creator: PeerIndex,
-    self_parent: Option<&Event<T, S::PublicId>>,
-    other_parent: Option<&Event<T, S::PublicId>>,
+    self_parent: Option<&Event<S::PublicId>>,
+    other_parent: Option<&Event<S::PublicId>>,
     peer_list: &PeerList<S>,
 ) -> (usize, PeerIndexMap<usize>) {
     let (index_by_creator, mut last_ancestors) = if let Some(self_parent) = self_parent {
@@ -623,9 +558,9 @@ fn index_by_creator_and_last_ancestors<T: NetworkEvent, S: SecretId>(
 // An event's forking_peers list is a union inherited from its self_parent and other_parent.
 // The event shall only put forking peer into the list when have direct path to both sides of
 // the fork.
-fn join_forking_peers<T: NetworkEvent, P: PublicId>(
-    self_parent: Option<&Event<T, P>>,
-    other_parent: Option<&Event<T, P>>,
+fn join_forking_peers<P: PublicId>(
+    self_parent: Option<&Event<P>>,
+    other_parent: Option<&Event<P>>,
     prev_forking_peers: &PeerIndexSet,
 ) -> PeerIndexSet {
     let mut forking_peers = PeerIndexSet::default();
@@ -643,18 +578,8 @@ fn join_forking_peers<T: NetworkEvent, P: PublicId>(
     forking_peers
 }
 
-fn compute_payload_hash<T: NetworkEvent, P: PublicId>(
-    cause: &Cause<T, P>,
-) -> Option<ObservationHash> {
-    if let Cause::Observation { ref vote, .. } = cause {
-        Some(ObservationHash::from(vote.payload()))
-    } else {
-        None
-    }
-}
-
 fn compute_event_hash_and_signature<T: NetworkEvent, S: SecretId>(
-    content: &Content<T, S::PublicId>,
+    content: &Content<Vote<T, S::PublicId>, EventHash, S::PublicId>,
     our_id: &S,
 ) -> (EventHash, <S::PublicId as PublicId>::Signature) {
     let serialised_content = serialise(&content);
@@ -665,7 +590,7 @@ fn compute_event_hash_and_signature<T: NetworkEvent, S: SecretId>(
 }
 
 fn compute_event_hash_and_verify_signature<T: NetworkEvent, P: PublicId>(
-    content: &Content<T, P>,
+    content: &Content<Vote<T, P>, EventHash, P>,
     signature: &P::Signature,
 ) -> Result<EventHash, Error> {
     let serialised_content = serialise(content);
@@ -681,19 +606,47 @@ fn compute_event_hash_and_verify_signature<T: NetworkEvent, P: PublicId>(
 
 /// Finds the first event which has the `short_name` provided.
 #[cfg(test)]
-pub(crate) fn find_event_by_short_name<'a, I, T, P>(
+pub(crate) fn find_event_by_short_name<'a, I, P>(
     events: I,
     short_name: &str,
-) -> Option<IndexedEventRef<'a, T, P>>
+) -> Option<IndexedEventRef<'a, P>>
 where
-    I: IntoIterator<Item = IndexedEventRef<'a, T, P>>,
-    T: NetworkEvent,
+    I: IntoIterator<Item = IndexedEventRef<'a, P>>,
     P: PublicId,
 {
     let short_name = short_name.to_uppercase();
     events
         .into_iter()
-        .find(|event| event.short_name().to_uppercase() == short_name)
+        .find(|event| event.short_name().to_string() == short_name)
+}
+
+#[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
+fn get_creator_initial<S: SecretId>(peer_list: &PeerList<S>, creator: PeerIndex) -> char {
+    peer_list
+        .get(creator)
+        .and_then(|peer| {
+            let name = format!("{:?}", peer.id());
+            name.chars().next().map(|c| c.to_ascii_uppercase())
+        })
+        .unwrap_or('?')
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub(crate) struct ShortName {
+    creator_initial: char,
+    index_by_creator: usize,
+}
+
+impl Display for ShortName {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}_{}", self.creator_initial, self.index_by_creator)
+    }
+}
+
+impl Debug for ShortName {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
 }
 
 #[cfg(test)]
@@ -708,80 +661,98 @@ mod tests {
     };
     use id::SecretId;
     use mock::{PeerId, Transaction};
+    use observation::ConsensusMode;
     use observation::Observation;
     use peer_list::{PeerList, PeerState};
 
-    struct PeerListAndEvent {
+    struct Context {
+        graph: Graph<PeerId>,
         peer_list: PeerList<PeerId>,
-        event: Event<Transaction, PeerId>,
+        observations: ObservationStore<Transaction, PeerId>,
+        consensus_mode: ConsensusMode,
     }
 
-    impl PeerListAndEvent {
-        fn new(peer_list: PeerList<PeerId>) -> Self {
+    impl Context {
+        fn new(our_id: &str) -> Self {
+            let our_id = PeerId::new(our_id);
+            let peer_list = PeerList::new(our_id);
+
             Self {
-                event: Event::<Transaction, PeerId>::new_initial(&peer_list),
+                graph: Graph::new(),
                 peer_list,
+                observations: ObservationStore::new(),
+                consensus_mode: ConsensusMode::Supermajority,
+            }
+        }
+
+        fn as_ref(&self) -> EventContextRef<Transaction, PeerId> {
+            EventContextRef {
+                graph: &self.graph,
+                peer_list: &self.peer_list,
+                observations: &self.observations,
+            }
+        }
+
+        fn as_mut(&mut self) -> EventContextMut<Transaction, PeerId> {
+            EventContextMut {
+                graph: &self.graph,
+                peer_list: &self.peer_list,
+                observations: &mut self.observations,
+                consensus_mode: self.consensus_mode,
             }
         }
     }
 
-    fn create_peer_list(id: &str) -> (PeerId, PeerList<PeerId>) {
-        let peer_id = PeerId::new(id);
-        let peer_list = PeerList::<PeerId>::new(peer_id.clone());
-        (peer_id, peer_list)
-    }
+    fn create_event_with_single_peer(id: &str) -> (Context, Event<PeerId>) {
+        let context = Context::new(id);
+        let event = Event::new_initial(context.as_ref());
 
-    fn create_event_with_single_peer(id: &str) -> PeerListAndEvent {
-        let (_, peer_list) = create_peer_list(id);
-        PeerListAndEvent::new(peer_list)
+        (context, event)
     }
 
     fn insert_into_gossip_graph(
-        initial_event: Event<Transaction, PeerId>,
-        graph: &mut Graph<Transaction, PeerId>,
+        initial_event: Event<PeerId>,
+        graph: &mut Graph<PeerId>,
     ) -> (EventIndex, EventHash) {
         let hash = *initial_event.hash();
         assert!(!graph.contains(&hash));
         (graph.insert(initial_event).event_index(), hash)
     }
 
-    fn create_two_events(id0: &str, id1: &str) -> (PeerListAndEvent, PeerListAndEvent) {
-        let (peer_id0, mut peer_id0_list) = create_peer_list(id0);
-        let (peer_id1, mut peer_id1_list) = create_peer_list(id1);
-        let _ = peer_id0_list.add_peer(
-            peer_id1,
+    fn create_two_events(id0: &str, id1: &str) -> (Context, Event<PeerId>, Context, Event<PeerId>) {
+        let mut context0 = Context::new(id0);
+        let mut context1 = Context::new(id1);
+
+        let _ = context0.peer_list.add_peer(
+            context1.peer_list.our_pub_id().clone(),
             PeerState::VOTE | PeerState::SEND | PeerState::RECV,
         );
-        let _ = peer_id1_list.add_peer(
-            peer_id0,
+        let _ = context1.peer_list.add_peer(
+            context0.peer_list.our_pub_id().clone(),
             PeerState::VOTE | PeerState::SEND | PeerState::RECV,
         );
 
-        (
-            PeerListAndEvent::new(peer_id0_list),
-            PeerListAndEvent::new(peer_id1_list),
-        )
+        let event0 = Event::new_initial(context0.as_ref());
+        let event1 = Event::new_initial(context1.as_ref());
+
+        (context0, event0, context1, event1)
     }
 
-    fn create_gossip_graph_with_two_events(
-        alice_initial: Event<Transaction, PeerId>,
-        bob_initial: Event<Transaction, PeerId>,
-    ) -> (
-        EventIndex,
-        EventHash,
-        EventIndex,
-        EventHash,
-        Graph<Transaction, PeerId>,
-    ) {
-        let mut graph = Graph::new();
-        let (alice_index, alice_hash) = insert_into_gossip_graph(alice_initial, &mut graph);
-        let (bob_index, bob_hash) = insert_into_gossip_graph(bob_initial, &mut graph);
-        (alice_index, alice_hash, bob_index, bob_hash, graph)
+    fn convert_event(
+        event: &Event<PeerId>,
+        src: EventContextRef<Transaction, PeerId>,
+        dst: EventContextMut<Transaction, PeerId>,
+    ) -> Event<PeerId> {
+        let e = unwrap!(event.pack(src));
+        match unwrap!(Event::unpack(e, &PeerIndexSet::default(), dst)) {
+            UnpackedEvent::New(e) => e,
+            UnpackedEvent::Known(_) => panic!("Unexpected known event"),
+        }
     }
 
     #[test]
     fn event_construction_initial() {
-        let initial = create_event_with_single_peer("Alice").event;
+        let initial = create_event_with_single_peer("Alice").1;
         assert!(initial.is_initial());
         assert!(!initial.is_response());
         assert!(initial.self_parent().is_none());
@@ -791,26 +762,26 @@ mod tests {
 
     #[test]
     fn event_construction_from_observation() {
-        let alice = create_event_with_single_peer("Alice");
-        let mut graph = Graph::new();
+        let (mut alice, a_0) = create_event_with_single_peer("Alice");
         let (initial_event_index, initial_event_hash) =
-            insert_into_gossip_graph(alice.event, &mut graph);
+            insert_into_gossip_graph(a_0, &mut alice.graph);
 
         // Our observation
         let net_event = Observation::OpaquePayload(Transaction::new("event_observed_by_alice"));
 
-        let event_from_observation = Event::<Transaction, PeerId>::new_from_observation(
-            initial_event_hash,
+        let event_from_observation = unwrap!(Event::new_from_observation(
+            initial_event_index,
             net_event.clone(),
-            &graph,
-            &alice.peer_list,
-        );
+            alice.as_mut(),
+        ));
+
+        let packed_event_from_observation = unwrap!(event_from_observation.pack(alice.as_ref()));
 
         assert_eq!(
-            event_from_observation.content.creator,
+            packed_event_from_observation.content.creator,
             *alice.peer_list.our_id().public_id()
         );
-        match &event_from_observation.content.cause {
+        match &packed_event_from_observation.content.cause {
             Cause::Observation { self_parent, vote } => {
                 assert_eq!(self_parent, &initial_event_hash);
                 assert_eq!(*vote.payload(), net_event);
@@ -831,143 +802,140 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Alice constructed an invalid event")]
     #[cfg(feature = "testing")]
     fn event_construction_from_observation_with_phony_self_parent() {
-        let alice = create_event_with_single_peer("Alice");
-        let self_parent_hash = EventHash::ZERO;
-        let events = Graph::new();
+        let mut alice = Context::new("Alice");
+        let self_parent_index = EventIndex::PHONY;
         let net_event = Observation::OpaquePayload(Transaction::new("event_observed_by_alice"));
-        let _ = Event::<Transaction, PeerId>::new_from_observation(
-            self_parent_hash,
-            net_event.clone(),
-            &events,
-            &alice.peer_list,
-        );
+
+        match Event::new_from_observation(self_parent_index, net_event.clone(), alice.as_mut()) {
+            Err(Error::UnknownSelfParent) => (),
+            x => panic!("Unexpected {:?}", x),
+        }
     }
 
     #[test]
     fn event_construction_from_request() {
-        let (alice, bob) = create_two_events("Alice", "Bob");
-        let (alice_initial_index, alice_initial_hash, bob_initial_index, bob_initial_hash, events) =
-            create_gossip_graph_with_two_events(alice.event, bob.event);
+        let (mut alice, a_0, bob, b_0) = create_two_events("Alice", "Bob");
+        let b_0 = convert_event(&b_0, bob.as_ref(), alice.as_mut());
+        let a_0_index = alice.graph.insert(a_0).event_index();
+        let b_0_index = alice.graph.insert(b_0).event_index();
 
         // Alice receives request from Bob
-        let event_from_request = Event::<Transaction, PeerId>::new_from_request(
-            alice_initial_hash,
-            bob_initial_hash,
-            &events,
-            &alice.peer_list,
+        let event_from_request = unwrap!(Event::new_from_request(
+            a_0_index,
+            b_0_index,
             &PeerIndexSet::default(),
-        );
+            alice.as_ref()
+        ));
+
+        let packed_event_from_request = unwrap!(event_from_request.pack(alice.as_ref()));
 
         assert_eq!(
-            event_from_request.content.creator,
+            packed_event_from_request.content.creator,
             *alice.peer_list.our_id().public_id()
         );
         assert_eq!(event_from_request.index_by_creator(), 1);
         assert!(!event_from_request.is_initial());
         assert!(!event_from_request.is_response());
-        assert_eq!(event_from_request.self_parent(), Some(alice_initial_index));
-        assert_eq!(event_from_request.other_parent(), Some(bob_initial_index));
+        assert_eq!(event_from_request.self_parent(), Some(a_0_index));
+        assert_eq!(event_from_request.other_parent(), Some(b_0_index));
     }
 
     #[test]
-    #[should_panic(expected = "Alice constructed an invalid event")]
     #[cfg(feature = "testing")]
     fn event_construction_from_request_without_self_parent_event_in_graph() {
-        let (alice, bob) = create_two_events("Alice", "Bob");
-        let mut events = Graph::new();
-        let alice_initial_hash = *alice.event.hash();
-        let (_, bob_initial_hash) = insert_into_gossip_graph(bob.event, &mut events);
-        let _ = Event::<Transaction, PeerId>::new_from_request(
-            alice_initial_hash,
-            bob_initial_hash,
-            &events,
-            &alice.peer_list,
+        let (mut alice, _, bob, b_0) = create_two_events("Alice", "Bob");
+        let b_0 = convert_event(&b_0, bob.as_ref(), alice.as_mut());
+        let b_0_index = alice.graph.insert(b_0).event_index();
+
+        match Event::new_from_request(
+            EventIndex::PHONY,
+            b_0_index,
             &PeerIndexSet::default(),
-        );
+            alice.as_ref(),
+        ) {
+            Err(Error::UnknownSelfParent) => (),
+            x => panic!("Unexpected {:?}", x),
+        }
     }
 
     #[test]
-    #[should_panic(expected = "Alice constructed an invalid event")]
     #[cfg(feature = "testing")]
     fn event_construction_from_request_without_other_parent_event_in_graph() {
-        let (alice, bob) = create_two_events("Alice", "Bob");
-        let mut events = Graph::new();
-        let (_, alice_initial_hash) = insert_into_gossip_graph(alice.event, &mut events);
-        let bob_initial_hash = *bob.event.hash();
-        let _ = Event::<Transaction, PeerId>::new_from_request(
-            alice_initial_hash,
-            bob_initial_hash,
-            &events,
-            &alice.peer_list,
+        let (mut alice, a_0, _, _) = create_two_events("Alice", "Bob");
+        let a_0_index = alice.graph.insert(a_0).event_index();
+
+        match Event::new_from_request(
+            a_0_index,
+            EventIndex::PHONY,
             &PeerIndexSet::default(),
-        );
+            alice.as_ref(),
+        ) {
+            Err(Error::UnknownOtherParent) => (),
+            x => panic!("Unexpected {:?}", x),
+        }
     }
 
     #[test]
     fn event_construction_from_response() {
-        let (alice, bob) = create_two_events("Alice", "Bob");
-        let (alice_initial_index, alice_initial_hash, bob_initial_index, bob_initial_hash, events) =
-            create_gossip_graph_with_two_events(alice.event, bob.event);
+        let (mut alice, a_0, bob, b_0) = create_two_events("Alice", "Bob");
+        let b_0 = convert_event(&b_0, bob.as_ref(), alice.as_mut());
+        let a_0_index = alice.graph.insert(a_0).event_index();
+        let b_0_index = alice.graph.insert(b_0).event_index();
 
-        let event_from_response = Event::<Transaction, PeerId>::new_from_response(
-            alice_initial_hash,
-            bob_initial_hash,
-            &events,
-            &alice.peer_list,
+        let event_from_response = unwrap!(Event::new_from_response(
+            a_0_index,
+            b_0_index,
             &PeerIndexSet::default(),
-        );
+            alice.as_ref()
+        ));
+        let packed_event_from_response = unwrap!(event_from_response.pack(alice.as_ref()));
 
         assert_eq!(
-            event_from_response.content.creator,
+            packed_event_from_response.content.creator,
             *alice.peer_list.our_id().public_id()
         );
         assert_eq!(event_from_response.index_by_creator(), 1);
         assert!(!event_from_response.is_initial());
         assert!(event_from_response.is_response());
-        assert_eq!(event_from_response.self_parent(), Some(alice_initial_index));
-        assert_eq!(event_from_response.other_parent(), Some(bob_initial_index));
+        assert_eq!(event_from_response.self_parent(), Some(a_0_index));
+        assert_eq!(event_from_response.other_parent(), Some(b_0_index));
     }
 
     #[test]
     fn event_construction_unpack() {
-        let alice = create_event_with_single_peer("Alice");
-        let mut graph = Graph::new();
-        let (_, initial_event_hash) = insert_into_gossip_graph(alice.event, &mut graph);
+        let (mut alice, a_0) = create_event_with_single_peer("Alice");
+        let a_0_index = alice.graph.insert(a_0).event_index();
 
         // Our observation
         let net_event = Observation::OpaquePayload(Transaction::new("event_observed_by_alice"));
 
-        let event_from_observation = Event::<Transaction, PeerId>::new_from_observation(
-            initial_event_hash,
+        let event_from_observation = unwrap!(Event::new_from_observation(
+            a_0_index,
             net_event,
-            &graph,
-            &alice.peer_list,
-        );
+            alice.as_mut()
+        ));
 
-        let packed_event = event_from_observation.pack();
+        let packed_event = unwrap!(event_from_observation.pack(alice.as_ref()));
         let unpacked_event = match unwrap!(Event::unpack(
             packed_event.clone(),
-            &graph,
-            &alice.peer_list,
             &PeerIndexSet::default(),
+            alice.as_mut()
         )) {
             UnpackedEvent::New(event) => event,
             UnpackedEvent::Known(_) => panic!("Unexpected known event"),
         };
 
         assert_eq!(event_from_observation, unpacked_event);
-        assert!(!graph.contains(unpacked_event.hash()));
+        assert!(!alice.graph.contains(unpacked_event.hash()));
 
-        let _ = graph.insert(unpacked_event);
+        let _ = alice.graph.insert(unpacked_event);
 
         match unwrap!(Event::unpack(
             packed_event,
-            &graph,
-            &alice.peer_list,
-            &PeerIndexSet::default()
+            &PeerIndexSet::default(),
+            alice.as_mut()
         )) {
             UnpackedEvent::New(_) => panic!("Unexpected new event"),
             UnpackedEvent::Known(_) => (),
@@ -976,28 +944,25 @@ mod tests {
 
     #[test]
     fn event_construction_unpack_fail_with_wrong_signature() {
-        let alice = create_event_with_single_peer("Alice");
-        let mut graph = Graph::new();
-        let (_, initial_event_hash) = insert_into_gossip_graph(alice.event, &mut graph);
+        let (mut alice, a_0) = create_event_with_single_peer("Alice");
+        let a_0_index = alice.graph.insert(a_0).event_index();
 
         // Our observation
         let net_event = Observation::OpaquePayload(Transaction::new("event_observed_by_alice"));
 
-        let event_from_observation = Event::<Transaction, PeerId>::new_from_observation(
-            initial_event_hash,
+        let event_from_observation = unwrap!(Event::new_from_observation(
+            a_0_index,
             net_event,
-            &graph,
-            &alice.peer_list,
-        );
+            alice.as_mut()
+        ));
 
-        let mut packed_event = event_from_observation.pack();
+        let mut packed_event = unwrap!(event_from_observation.pack(alice.as_ref()));
         packed_event.signature = alice.peer_list.our_id().sign_detached(&[123]);
 
-        let error = unwrap_err!(Event::<Transaction, PeerId>::unpack(
+        let error = unwrap_err!(Event::unpack(
             packed_event,
-            &graph,
-            &alice.peer_list,
-            &PeerIndexSet::default()
+            &PeerIndexSet::default(),
+            alice.as_mut()
         ));
         if let Error::SignatureFailure = error {
         } else {

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -348,8 +348,16 @@ impl<P: PublicId> Event<P> {
     }
 
     #[cfg(feature = "dump-graphs")]
-    pub fn write_cause_to_dot_format(&self, writer: &mut Write) -> io::Result<()> {
-        writeln!(writer, "/// cause: {}", self.content.cause)
+    pub fn write_cause_to_dot_format<T: NetworkEvent>(
+        &self,
+        writer: &mut Write,
+        observations: &ObservationStore<T, P>,
+    ) -> io::Result<()> {
+        writeln!(
+            writer,
+            "/// cause: {}",
+            self.content.cause.display(observations)
+        )
     }
 }
 
@@ -369,7 +377,7 @@ impl<P: PublicId> Debug for Event<P> {
         write!(formatter, " {}", self.short_name())?;
 
         write!(formatter, " {:?}", self.hash())?;
-        write!(formatter, ", {}", self.content.cause)?;
+        write!(formatter, ", {:?}", self.content.cause)?;
         write!(
             formatter,
             ", self_parent: {:?}, other_parent: {:?}",
@@ -645,7 +653,7 @@ impl Display for ShortName {
 
 impl Debug for ShortName {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        Display::fmt(self, f)
+        write!(f, "\"{}\"", self)
     }
 }
 

--- a/src/gossip/event_context.rs
+++ b/src/gossip/event_context.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::graph::Graph;
+use id::SecretId;
+use network_event::NetworkEvent;
+use observation::{ConsensusMode, ObservationStore};
+use peer_list::PeerList;
+
+pub(crate) struct EventContextRef<'a, T: NetworkEvent, S: SecretId> {
+    pub(crate) graph: &'a Graph<S::PublicId>,
+    pub(crate) peer_list: &'a PeerList<S>,
+    pub(crate) observations: &'a ObservationStore<T, S::PublicId>,
+}
+
+// `#[derive(Clone)]` doesn't work here for some reason...
+impl<'a, T: NetworkEvent, S: SecretId> Clone for EventContextRef<'a, T, S> {
+    fn clone(&self) -> Self {
+        Self {
+            graph: self.graph,
+            peer_list: self.peer_list,
+            observations: self.observations,
+        }
+    }
+}
+
+// ...neither does `#[derive(Copy)]`.
+impl<'a, T: NetworkEvent, S: SecretId> Copy for EventContextRef<'a, T, S> {}
+
+pub(crate) struct EventContextMut<'a, T: NetworkEvent, S: SecretId> {
+    pub(crate) graph: &'a Graph<S::PublicId>,
+    pub(crate) peer_list: &'a PeerList<S>,
+    pub(crate) observations: &'a mut ObservationStore<T, S::PublicId>,
+    pub(crate) consensus_mode: ConsensusMode,
+}

--- a/src/gossip/event_hash.rs
+++ b/src/gossip/event_hash.rs
@@ -20,5 +20,6 @@ impl Debug for EventHash {
 }
 
 impl EventHash {
+    #[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
     pub(crate) const ZERO: Self = EventHash(Hash::ZERO);
 }

--- a/src/gossip/graph/ancestors.rs
+++ b/src/gossip/graph/ancestors.rs
@@ -8,17 +8,16 @@
 
 use super::{Graph, IndexedEventRef};
 use id::PublicId;
-use network_event::NetworkEvent;
 use std::collections::BTreeSet;
 
-pub(crate) struct Ancestors<'a, T: NetworkEvent + 'a, P: PublicId + 'a> {
-    pub(super) graph: &'a Graph<T, P>,
-    pub(super) queue: BTreeSet<IndexedEventRef<'a, T, P>>,
+pub(crate) struct Ancestors<'a, P: PublicId + 'a> {
+    pub(super) graph: &'a Graph<P>,
+    pub(super) queue: BTreeSet<IndexedEventRef<'a, P>>,
     pub(super) visited: Vec<bool>, // TODO: replace with bitset, for space efficiency
 }
 
-impl<'a, T: NetworkEvent, P: PublicId> Iterator for Ancestors<'a, T, P> {
-    type Item = IndexedEventRef<'a, T, P>;
+impl<'a, P: PublicId> Iterator for Ancestors<'a, P> {
+    type Item = IndexedEventRef<'a, P>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // This is a modified breadth-first search: Instead of using a simple queue to track the

--- a/src/gossip/graph/event_ref.rs
+++ b/src/gossip/graph/event_ref.rs
@@ -9,21 +9,20 @@
 use super::super::event::Event;
 use super::event_index::EventIndex;
 use id::PublicId;
-use network_event::NetworkEvent;
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::ops::Deref;
 
 /// Reference to `Event` together with its index.
 #[derive(Clone, Debug)]
-pub(crate) struct IndexedEventRef<'a, T: NetworkEvent + 'a, P: PublicId + 'a> {
+pub(crate) struct IndexedEventRef<'a, P: PublicId + 'a> {
     pub(super) index: EventIndex,
-    pub(super) event: &'a Event<T, P>,
+    pub(super) event: &'a Event<P>,
 }
 
 // Note: for some reason #[derive(Copy)] doesn't work.
-impl<'a, T: NetworkEvent, P: PublicId> Copy for IndexedEventRef<'a, T, P> {}
+impl<'a, P: PublicId> Copy for IndexedEventRef<'a, P> {}
 
-impl<'a, T: NetworkEvent, P: PublicId> IndexedEventRef<'a, T, P> {
+impl<'a, P: PublicId> IndexedEventRef<'a, P> {
     pub fn event_index(&self) -> EventIndex {
         self.index
     }
@@ -34,40 +33,40 @@ impl<'a, T: NetworkEvent, P: PublicId> IndexedEventRef<'a, T, P> {
 
     /// Returns reference to the inner `Event`. Note this is not the same as `Deref::deref`,
     /// because the lifetime is different ('a vs 'self).
-    pub fn inner(&self) -> &'a Event<T, P> {
+    pub fn inner(&self) -> &'a Event<P> {
         self.event
     }
 }
 
-impl<'a, T: NetworkEvent, P: PublicId> Deref for IndexedEventRef<'a, T, P> {
-    type Target = Event<T, P>;
+impl<'a, P: PublicId> Deref for IndexedEventRef<'a, P> {
+    type Target = Event<P>;
 
     fn deref(&self) -> &Self::Target {
         self.event
     }
 }
 
-impl<'a, T: NetworkEvent, P: PublicId> AsRef<Event<T, P>> for IndexedEventRef<'a, T, P> {
-    fn as_ref(&self) -> &Event<T, P> {
+impl<'a, P: PublicId> AsRef<Event<P>> for IndexedEventRef<'a, P> {
+    fn as_ref(&self) -> &Event<P> {
         self.event
     }
 }
 
-impl<'a, T: NetworkEvent, P: PublicId> PartialEq for IndexedEventRef<'a, T, P> {
+impl<'a, P: PublicId> PartialEq for IndexedEventRef<'a, P> {
     fn eq(&self, other: &Self) -> bool {
         self.index == other.index
     }
 }
 
-impl<'a, T: NetworkEvent, P: PublicId> Eq for IndexedEventRef<'a, T, P> {}
+impl<'a, P: PublicId> Eq for IndexedEventRef<'a, P> {}
 
-impl<'a, T: NetworkEvent, P: PublicId> PartialOrd for IndexedEventRef<'a, T, P> {
+impl<'a, P: PublicId> PartialOrd for IndexedEventRef<'a, P> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.index.partial_cmp(&other.index)
     }
 }
 
-impl<'a, T: NetworkEvent, P: PublicId> Ord for IndexedEventRef<'a, T, P> {
+impl<'a, P: PublicId> Ord for IndexedEventRef<'a, P> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.index.cmp(&other.index)
     }

--- a/src/gossip/messages.rs
+++ b/src/gossip/messages.rs
@@ -7,7 +7,6 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use error::{Error, Result};
-use gossip::event::Event;
 use gossip::event_hash::EventHash;
 use gossip::packed_event::PackedEvent;
 use id::PublicId;
@@ -21,10 +20,8 @@ pub struct Request<T: NetworkEvent, P: PublicId> {
 }
 
 impl<T: NetworkEvent, P: PublicId> Request<T, P> {
-    pub(crate) fn new(events: Vec<&Event<T, P>>) -> Self {
-        Self {
-            packed_events: events.into_iter().map(Event::pack).collect(),
-        }
+    pub(crate) fn new(packed_events: Vec<PackedEvent<T, P>>) -> Self {
+        Self { packed_events }
     }
 
     pub(crate) fn hash_of_last_event_created_by(&self, src: &P) -> Result<Option<EventHash>> {
@@ -40,10 +37,8 @@ pub struct Response<T: NetworkEvent, P: PublicId> {
 }
 
 impl<T: NetworkEvent, P: PublicId> Response<T, P> {
-    pub(crate) fn new(events: Vec<&Event<T, P>>) -> Self {
-        Self {
-            packed_events: events.into_iter().map(Event::pack).collect(),
-        }
+    pub(crate) fn new(packed_events: Vec<PackedEvent<T, P>>) -> Self {
+        Self { packed_events }
     }
 
     pub(crate) fn hash_of_last_event_created_by(&self, src: &P) -> Result<Option<EventHash>> {

--- a/src/gossip/mod.rs
+++ b/src/gossip/mod.rs
@@ -9,6 +9,7 @@
 mod cause;
 mod content;
 mod event;
+mod event_context;
 mod event_hash;
 mod graph;
 mod messages;
@@ -21,6 +22,7 @@ pub(super) use self::event::CauseInput;
 #[cfg(feature = "malice-detection")]
 pub(super) use self::event::LastAncestor;
 pub(super) use self::event::{Event, UnpackedEvent};
+pub(super) use self::event_context::{EventContextMut, EventContextRef};
 pub use self::event_hash::EventHash;
 #[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
 pub(super) use self::graph::snapshot::GraphSnapshot;

--- a/src/gossip/packed_event.rs
+++ b/src/gossip/packed_event.rs
@@ -13,12 +13,13 @@ use id::PublicId;
 use network_event::NetworkEvent;
 use serialise;
 use std::fmt::{self, Debug, Formatter};
+use vote::Vote;
 
 /// Packed event contains only content and signature.
 #[serde(bound = "")]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct PackedEvent<T: NetworkEvent, P: PublicId> {
-    pub(super) content: Content<T, P>,
+    pub(super) content: Content<Vote<T, P>, EventHash, P>,
     pub(super) signature: P::Signature,
 }
 

--- a/src/meta_voting/meta_elections.rs
+++ b/src/meta_voting/meta_elections.rs
@@ -335,7 +335,7 @@ impl MetaElections {
         voters: PeerIndexSet,
         unconsensused_events: BTreeSet<EventIndex>,
     ) -> MetaElectionHandle {
-        self.consensus_history.push(payload_key.clone());
+        self.consensus_history.push(payload_key);
 
         let new = MetaElection::new(voters, self.consensus_history.len(), unconsensused_events);
 
@@ -395,11 +395,7 @@ impl MetaElections {
         self.current_election.initialise(peer_ids, hash);
     }
 
-    #[cfg(any(
-        all(test, feature = "mock"),
-        feature = "dump-graphs",
-        feature = "testing"
-    ))]
+    #[cfg(feature = "dump-graphs")]
     pub fn current_meta_events(&self) -> &FnvHashMap<EventIndex, MetaEvent> {
         &self.current_election.meta_events
     }
@@ -482,7 +478,6 @@ pub(crate) mod snapshot {
     use super::*;
     use gossip::{EventHash, Graph};
     use id::SecretId;
-    use network_event::NetworkEvent;
     use observation::snapshot::ObservationKeySnapshot;
     use peer_list::PeerList;
 
@@ -491,13 +486,12 @@ pub(crate) mod snapshot {
     pub(crate) struct MetaElectionsSnapshot<P: PublicId>(Vec<MetaElectionSnapshot<P>>);
 
     impl<P: PublicId> MetaElectionsSnapshot<P> {
-        pub fn new<T, S>(
+        pub fn new<S>(
             meta_elections: &MetaElections,
-            graph: &Graph<T, P>,
+            graph: &Graph<P>,
             peer_list: &PeerList<S>,
         ) -> Self
         where
-            T: NetworkEvent,
             S: SecretId<PublicId = P>,
         {
             MetaElectionsSnapshot(
@@ -522,13 +516,12 @@ pub(crate) mod snapshot {
     }
 
     impl<P: PublicId> MetaElectionSnapshot<P> {
-        pub fn new<T, S>(
+        pub fn new<S>(
             meta_election: &MetaElection,
-            graph: &Graph<T, P>,
+            graph: &Graph<P>,
             peer_list: &PeerList<S>,
         ) -> Self
         where
-            T: NetworkEvent,
             S: SecretId<PublicId = P>,
         {
             let meta_events = meta_election

--- a/src/meta_voting/meta_event.rs
+++ b/src/meta_voting/meta_event.rs
@@ -10,7 +10,6 @@ use super::meta_elections::MetaElectionHandle;
 use super::meta_vote::MetaVote;
 use gossip::IndexedEventRef;
 use id::PublicId;
-use network_event::NetworkEvent;
 use observation::ObservationKey;
 use peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet};
 
@@ -25,10 +24,10 @@ pub(crate) struct MetaEvent {
 }
 
 impl MetaEvent {
-    pub fn build<T: NetworkEvent, P: PublicId>(
+    pub fn build<P: PublicId>(
         election: MetaElectionHandle,
-        event: IndexedEventRef<T, P>,
-    ) -> MetaEventBuilder<T, P> {
+        event: IndexedEventRef<P>,
+    ) -> MetaEventBuilder<P> {
         MetaEventBuilder {
             election,
             event,
@@ -41,18 +40,18 @@ impl MetaEvent {
     }
 }
 
-pub(crate) struct MetaEventBuilder<'a, T: NetworkEvent + 'a, P: PublicId + 'a> {
+pub(crate) struct MetaEventBuilder<'a, P: PublicId + 'a> {
     election: MetaElectionHandle,
-    event: IndexedEventRef<'a, T, P>,
+    event: IndexedEventRef<'a, P>,
     meta_event: MetaEvent,
 }
 
-impl<'a, T: NetworkEvent + 'a, P: PublicId + 'a> MetaEventBuilder<'a, T, P> {
+impl<'a, P: PublicId + 'a> MetaEventBuilder<'a, P> {
     pub fn election(&self) -> MetaElectionHandle {
         self.election
     }
 
-    pub fn event(&self) -> IndexedEventRef<'a, T, P> {
+    pub fn event(&self) -> IndexedEventRef<'a, P> {
         self.event
     }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -784,10 +784,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             &self.graph,
             &self.meta_elections,
             &self.peer_list,
-            self.observations
-                .iter()
-                .map(|(key, info)| (key.hash(), &info.observation))
-                .collect(),
+            &self.observations,
         );
 
         let payload = self
@@ -2389,10 +2386,7 @@ impl<T: NetworkEvent, S: SecretId> Drop for Parsec<T, S> {
                 &self.graph,
                 &self.meta_elections,
                 &self.peer_list,
-                self.observations
-                    .iter()
-                    .map(|(key, info)| (key.hash(), &info.observation))
-                    .collect(),
+                &self.observations,
             );
         }
     }

--- a/src/peer_list/peer.rs
+++ b/src/peer_list/peer.rs
@@ -12,7 +12,6 @@ use super::peer_state::PeerState;
 use gossip::{EventIndex, IndexedEventRef};
 use hash::Hash;
 use id::PublicId;
-use network_event::NetworkEvent;
 use serialise;
 use std::iter::{self, FromIterator};
 
@@ -73,7 +72,7 @@ impl<P: PublicId> Peer<P> {
         self.events.add(index_by_creator, event_index);
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "mock"))]
     pub(super) fn remove_last_event(&mut self) -> Option<EventIndex> {
         self.events.remove_last()
     }
@@ -125,7 +124,7 @@ impl Events {
         self.0.push(Slot::new(event_index))
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "mock"))]
     fn remove_last(&mut self) -> Option<EventIndex> {
         if let Some(slot) = self.0.last_mut() {
             if let Some(index) = slot.rest.pop() {
@@ -160,14 +159,13 @@ impl Events {
     }
 }
 
-impl<'a, T, P> FromIterator<IndexedEventRef<'a, T, P>> for Events
+impl<'a, P> FromIterator<IndexedEventRef<'a, P>> for Events
 where
-    T: NetworkEvent + 'a,
     P: PublicId + 'a,
 {
     fn from_iter<I>(iter: I) -> Self
     where
-        I: IntoIterator<Item = IndexedEventRef<'a, T, P>>,
+        I: IntoIterator<Item = IndexedEventRef<'a, P>>,
     {
         let mut events = Self::new();
         for event in iter {

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -9,12 +9,15 @@
 use error::Error;
 use id::{Proof, PublicId, SecretId};
 use network_event::NetworkEvent;
-use observation::Observation;
+use observation::{ConsensusMode, Observation, ObservationHash, ObservationKey, ObservationStore};
+use peer_list::PeerIndex;
+use serde::de::DeserializeOwned;
 use serialise;
+use std::fmt::{self, Debug, Formatter};
 
 /// A helper struct carrying an `Observation` and a signature of this `Observation`.
-#[serde(bound = "")]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug)]
+#[serde(bound(deserialize = "T: DeserializeOwned"))]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Vote<T: NetworkEvent, P: PublicId> {
     payload: Observation<T, P>,
     signature: P::Signature,
@@ -52,5 +55,61 @@ impl<T: NetworkEvent, P: PublicId> Vote<T, P> {
             });
         }
         Err(Error::SignatureFailure)
+    }
+}
+
+impl<T: NetworkEvent, P: PublicId> Debug for Vote<T, P> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.payload)
+    }
+}
+
+/// Key representing a vote when stored inside the gossip graph.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct VoteKey<P: PublicId> {
+    payload_key: ObservationKey,
+    signature: P::Signature,
+}
+
+impl<P: PublicId> VoteKey<P> {
+    pub fn new<T: NetworkEvent>(
+        vote: Vote<T, P>,
+        creator: PeerIndex,
+        consensus_mode: ConsensusMode,
+    ) -> (Self, Observation<T, P>) {
+        let consensus_mode = consensus_mode.of(&vote.payload);
+        let hash = ObservationHash::from(&vote.payload);
+        let payload_key = ObservationKey::new(hash, creator, consensus_mode);
+
+        let vote_key = Self {
+            payload_key,
+            signature: vote.signature,
+        };
+
+        (vote_key, vote.payload)
+    }
+
+    /// Fetch the `Vote` corresponding to `key`.
+    pub fn resolve<T: NetworkEvent>(
+        &self,
+        observations: &ObservationStore<T, P>,
+    ) -> Result<Vote<T, P>, Error> {
+        Ok(Vote {
+            payload: observations
+                .get(&self.payload_key)
+                .map(|info| info.observation.clone())
+                .ok_or(Error::UnknownPayload)?,
+            signature: self.signature.clone(),
+        })
+    }
+
+    pub fn payload_key(&self) -> &ObservationKey {
+        &self.payload_key
+    }
+}
+
+impl<P: PublicId> Debug for VoteKey<P> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.payload_key)
     }
 }


### PR DESCRIPTION
This PR removes some fields from `Event` that weren't necessary:

- `self_parent_hash: EventHash` and `other_parent_hash: EventHash` - can be looked up by `self_parent: EventIndex` and `other_parent: EventIndex`.
- `creator_id: P` - can be looked up by `creator: PeerIndex`
- `vote: Vote<T, P>` - replaced by `VoteKey`, which can be used to look up the actual `Vote`.

In order to do this, `Content` and `Cause` are now generic over the type of vote (`Vote` or `VoteKey`), the type of event indentifier (`EventHash` or `EventIndex`) and the type of peer identifier (`PublicId` or `PeerIndex`). `Event` now contains the ones specialized with `VoteKey`, `EventIndex` and `PeerIndex`, whereas `PackedEvent` has `Vote`, `EventHash` and `PublicId`.

`Event` is no longer generic over `T: NetworkEvent` which is the cause of the majority of changes in this PR. Those changes are trivial though.

To simplify the code, two new reference-like types are introduced: `EventContextRef` and `EventContextMut`, which contain references to all the data necessary to construct, pack or unpack `Event`s. I prefer to pass `EventContextRef` and  `EventContextMut` by value, because they are conceptually references, but clippy disagrees with this idea. Thus the `#[allow: clippy::needless_pass_by_value]` attributes in few places.

