### PR TITLE
Fix bug in set_interesting_content

### DIFF
--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -526,7 +526,11 @@ mod detail {
         fn write_peers(&mut self) -> io::Result<()> {
             self.writeln(format_args!("  {{"))?;
             self.writeln(format_args!("    rank=same"))?;
-            let mut peer_ids = self.peer_list.all_ids().collect::<Vec<_>>();
+            let mut peer_ids = self
+                .peer_list
+                .all_ids()
+                .map(|(_, id)| id)
+                .collect::<Vec<_>>();
             for peer_id in &peer_ids {
                 self.writeln(format_args!(
                     "    \"{:?}\" [style=filled, color=white]",

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -972,6 +972,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         let mut payloads: Vec<_> = self
             .unconsensused_events(builder.election())
             .map(|event| event.inner())
+            .filter(|event| builder.event().sees(event))
             .filter_map(|event| event.payload_key().map(|key| (event, key)))
             .filter(|(_, payload_key)| {
                 !self.meta_elections.is_already_interesting_content(


### PR DESCRIPTION
We need to consider only events seen by the current event, otherwise we might collect more payloads than we should which would result in the set of interesting content being inconsistent between peers.