### PR TITLE
Upgrade to rust 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
   - osx
 language: rust
 rust:
-  - 1.31.0
+  - stable
 sudo: false
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ before_script:
 script:
   - set -x;
     cargo fmt -- --check &&
-    cargo test --verbose --release --features=testing &&
-    cargo test --verbose --release --features=testing,malice-detection &&
-    cargo test --verbose --release --features=dump-graphs dot_parser &&
     cargo clippy --verbose --all-targets &&
     cargo clippy --verbose --all-targets --features=dump-graphs &&
     cargo clippy --verbose --all-targets --features=testing &&
@@ -33,6 +30,9 @@ script:
     cargo clippy --verbose --all-targets --features=mock &&
     cargo clippy --verbose --all-targets --features=mock,dump-graphs &&
     cargo clippy --verbose --all-targets --features=mock,dump-graphs,malice-detection &&
-    cargo clippy --verbose --manifest-path=dot_gen/Cargo.toml
+    cargo clippy --verbose --manifest-path=dot_gen/Cargo.toml &&
+    cargo test --verbose --release --features=testing &&
+    cargo test --verbose --release --features=testing,malice-detection &&
+    cargo test --verbose --release --features=dump-graphs dot_parser
 before_cache:
  - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ cache:
 before_script:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune;
-  - rustup component add rustfmt
-  - rustup component add clippy
+  - rustup component add rustfmt clippy
 script:
   - set -x;
     cargo fmt -- --check &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Implementation of Protocol for Asynchronous, Reliable, Secure and Efficient Consensus"
 documentation = "https://docs.rs/parsec"
+edition = "2018"
 exclude = ["input_graphs/*"]
 homepage = "https://maidsafe.net"
 license = "GPL-3.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     RUST_BACKTRACE: 1
   matrix:
-    - RUST_TOOLCHAIN: 1.31.0
+    - RUST_TOOLCHAIN: stable
 
 branches:
   only:

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -55,8 +55,6 @@
 #[macro_use]
 extern crate criterion;
 #[cfg(feature = "testing")]
-extern crate parsec;
-#[cfg(feature = "testing")]
 #[macro_use]
 extern crate unwrap;
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -52,9 +52,7 @@
 
 #[macro_use]
 extern crate clap;
-extern crate maidsafe_utilities;
-extern crate parsec;
-extern crate rand;
+use parsec;
 #[macro_use]
 extern crate unwrap;
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -6,12 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use error::Error;
-use id::{Proof, PublicId};
-use network_event::NetworkEvent;
-use observation::Observation;
+use crate::error::Error;
+use crate::id::{Proof, PublicId};
+use crate::network_event::NetworkEvent;
+use crate::observation::Observation;
+use crate::vote::Vote;
 use std::collections::{BTreeMap, BTreeSet};
-use vote::Vote;
 
 /// A struct representing a collection of votes by peers for an `Observation`.
 #[serde(bound = "")]

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -6,32 +6,32 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use gossip::{CauseInput, Event, EventIndex, Graph, IndexedEventRef};
+use crate::gossip::{CauseInput, Event, EventIndex, Graph, IndexedEventRef};
 #[cfg(any(
     all(test, feature = "malice-detection", feature = "mock"),
     feature = "testing"
 ))]
-use gossip::{EventContextMut, EventContextRef};
-use hash::Hash;
-use hash::HASH_LEN;
-use meta_voting::{
+use crate::gossip::{EventContextMut, EventContextRef};
+use crate::hash::Hash;
+use crate::hash::HASH_LEN;
+use crate::meta_voting::{
     BoolSet, MetaElection, MetaElectionHandle, MetaElections, MetaEvent, MetaVote, Step,
 };
-use mock::{PeerId, Transaction};
+use crate::mock::{PeerId, Transaction};
 #[cfg(any(
     all(test, feature = "malice-detection", feature = "mock"),
     feature = "testing"
 ))]
-use observation::ConsensusMode;
-use observation::{
+use crate::observation::ConsensusMode;
+use crate::observation::{
     Observation, ObservationHash, ObservationInfo, ObservationKey, ObservationStore,
 };
-use peer_list::{PeerIndexMap, PeerIndexSet, PeerList, PeerState};
+use crate::peer_list::{PeerIndexMap, PeerIndexSet, PeerList, PeerState};
+use crate::round_hash::RoundHash;
 use pom::char_class::{alphanum, digit, hex_digit, multispace, space};
 use pom::parser::*;
 use pom::Result as PomResult;
 use pom::{DataInput, Parser};
-use round_hash::RoundHash;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::{self, Read};
@@ -1037,12 +1037,12 @@ fn next_topological_event(
 #[cfg(all(test, feature = "dump-graphs"))]
 mod tests {
     use super::*;
-    use dev_utils::{Environment, RngChoice, Schedule, ScheduleOptions};
-    use dump_graph::DIR;
-    use gossip::GraphSnapshot;
-    use maidsafe_utilities::serialisation::deserialise;
-    use meta_voting::MetaElectionsSnapshot;
-    use mock::PeerId;
+    use crate::dev_utils::{Environment, RngChoice, Schedule, ScheduleOptions};
+    use crate::dump_graph::DIR;
+    use crate::gossip::GraphSnapshot;
+    use crate::maidsafe_utilities::serialisation::deserialise;
+    use crate::meta_voting::MetaElectionsSnapshot;
+    use crate::mock::PeerId;
     use std::fs;
 
     type Snapshot = (GraphSnapshot, MetaElectionsSnapshot<PeerId>);

--- a/src/dev_utils/environment.rs
+++ b/src/dev_utils/environment.rs
@@ -6,9 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use dev_utils::network::Network;
+use crate::dev_utils::network::Network;
+use crate::observation::ConsensusMode;
 use maidsafe_utilities::SeededRng;
-use observation::ConsensusMode;
 use rand::{Rng, SeedableRng, XorShiftRng};
 use std::fmt;
 

--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -11,11 +11,11 @@ use super::parse_test_dot_file;
 use super::peer::{Peer, PeerStatus};
 use super::schedule::{Schedule, ScheduleEvent, ScheduleOptions};
 use super::Observation;
-use block::Block;
-use error::Error;
-use gossip::{Request, Response};
-use mock::{PeerId, Transaction};
-use observation::{
+use crate::block::Block;
+use crate::error::Error;
+use crate::gossip::{Request, Response};
+use crate::mock::{PeerId, Transaction};
+use crate::observation::{
     is_more_than_two_thirds, ConsensusMode, Malice, Observation as ParsecObservation,
 };
 use rand::Rng;

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -9,10 +9,10 @@
 use super::Observation;
 #[cfg(feature = "testing")]
 use super::ParsedContents;
-use block::Block;
-use mock::{PeerId, Transaction};
-use observation::{ConsensusMode, Malice, Observation as ParsecObservation};
-use parsec::Parsec;
+use crate::block::Block;
+use crate::mock::{PeerId, Transaction};
+use crate::observation::{ConsensusMode, Malice, Observation as ParsecObservation};
+use crate::parsec::Parsec;
 use rand::Rng;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug, Formatter};

--- a/src/dev_utils/proptest/schedule.rs
+++ b/src/dev_utils/proptest/schedule.rs
@@ -7,8 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{Bounded, BoundedBoxedStrategy};
-use dev_utils::environment::{Environment, RngChoice};
-use dev_utils::schedule::{DelayDistribution, Schedule, ScheduleOptions};
+use crate::dev_utils::environment::{Environment, RngChoice};
+use crate::dev_utils::schedule::{DelayDistribution, Schedule, ScheduleOptions};
 use proptest_crate::prelude::{Just, RngCore};
 use proptest_crate::strategy::{NewTree, Strategy, ValueTree};
 use proptest_crate::test_runner::TestRunner;

--- a/src/dev_utils/record.rs
+++ b/src/dev_utils/record.rs
@@ -7,11 +7,11 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::dot_parser::{parse_dot_file, ParsedContents};
-use gossip::{Event, Request, Response};
-use mock::{PeerId, Transaction};
-use observation::{ConsensusMode, Observation, ObservationStore};
-use parsec::Parsec;
-use peer_list::PeerIndex;
+use crate::gossip::{Event, Request, Response};
+use crate::mock::{PeerId, Transaction};
+use crate::observation::{ConsensusMode, Observation, ObservationStore};
+use crate::parsec::Parsec;
+use crate::peer_list::PeerIndex;
 use std::collections::BTreeSet;
 use std::io;
 use std::path::Path;
@@ -194,7 +194,7 @@ fn extract_genesis_group<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use parsec::assert_same_events;
+    use crate::parsec::assert_same_events;
 
     #[test]
     fn smoke() {

--- a/src/dev_utils/schedule.rs
+++ b/src/dev_utils/schedule.rs
@@ -10,9 +10,9 @@ use super::Environment;
 use super::Observation;
 use super::{PeerStatus, PeerStatuses};
 #[cfg(feature = "dump-graphs")]
-use dump_graph::DIR;
-use mock::{PeerId, Transaction, NAMES};
-use observation::{ConsensusMode, Observation as ParsecObservation};
+use crate::dump_graph::DIR;
+use crate::mock::{PeerId, Transaction, NAMES};
+use crate::observation::{ConsensusMode, Observation as ParsecObservation};
 use rand::seq;
 use rand::Rng;
 use std::collections::{BTreeMap, BTreeSet};

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -6,12 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use gossip::Graph;
-use id::SecretId;
-use meta_voting::MetaElections;
-use network_event::NetworkEvent;
-use observation::ObservationStore;
-use peer_list::PeerList;
+use crate::gossip::Graph;
+use crate::id::SecretId;
+use crate::meta_voting::MetaElections;
+use crate::network_event::NetworkEvent;
+use crate::observation::ObservationStore;
+use crate::peer_list::PeerList;
 
 /// Use this to initialise the folder into which the dot files will be dumped.  This allows the
 /// folder's path to be displayed at the start of a run, rather than at the arbitrary point when
@@ -59,14 +59,14 @@ pub use self::detail::DIR;
 
 #[cfg(feature = "dump-graphs")]
 mod detail {
-    use gossip::{Event, EventHash, EventIndex, Graph, GraphSnapshot, IndexedEventRef};
-    use id::{PublicId, SecretId};
-    use meta_voting::{MetaElections, MetaElectionsSnapshot, MetaEvent, MetaVote};
-    use network_event::NetworkEvent;
-    use observation::ObservationStore;
-    use peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet, PeerList};
+    use crate::gossip::{Event, EventHash, EventIndex, Graph, GraphSnapshot, IndexedEventRef};
+    use crate::id::{PublicId, SecretId};
+    use crate::meta_voting::{MetaElections, MetaElectionsSnapshot, MetaEvent, MetaVote};
+    use crate::network_event::NetworkEvent;
+    use crate::observation::ObservationStore;
+    use crate::peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet, PeerList};
+    use crate::serialise;
     use rand::{self, Rng};
-    use serialise;
     use std::cell::RefCell;
     use std::cmp;
     use std::collections::{BTreeMap, BTreeSet};

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use peer_list::PeerState;
+use crate::peer_list::PeerState;
 use std::fmt::{self, Display, Formatter};
 use std::result;
 

--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -6,16 +6,16 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use block::Block;
-use dev_utils::parse_test_dot_file;
-use error::Error;
-use gossip::{Event, Graph, GraphSnapshot};
-use id::PublicId;
-use meta_voting::MetaElectionsSnapshot;
-use mock::{self, PeerId, Transaction};
-use observation::Observation;
-use parsec::TestParsec;
-use peer_list::{MembershipListChange, PeerIndexSet, PeerListSnapshot, PeerState};
+use crate::block::Block;
+use crate::dev_utils::parse_test_dot_file;
+use crate::error::Error;
+use crate::gossip::{Event, Graph, GraphSnapshot};
+use crate::id::PublicId;
+use crate::meta_voting::MetaElectionsSnapshot;
+use crate::mock::{self, PeerId, Transaction};
+use crate::observation::Observation;
+use crate::parsec::TestParsec;
+use crate::peer_list::{MembershipListChange, PeerIndexSet, PeerListSnapshot, PeerState};
 use std::collections::BTreeSet;
 
 macro_rules! assert_err {
@@ -507,13 +507,13 @@ fn gossip_after_fork() {
 #[cfg(feature = "malice-detection")]
 mod handle_malice {
     use super::*;
-    use dev_utils::{parse_dot_file_with_test_name, parse_test_dot_file, ParsedContents};
-    use gossip::{find_event_by_short_name, Event, EventHash};
-    use id::SecretId;
-    use mock::Transaction;
-    use network_event::NetworkEvent;
-    use observation::Malice;
-    use peer_list::{PeerIndex, PeerList, PeerState};
+    use crate::dev_utils::{parse_dot_file_with_test_name, parse_test_dot_file, ParsedContents};
+    use crate::gossip::{find_event_by_short_name, Event, EventHash};
+    use crate::id::SecretId;
+    use crate::mock::Transaction;
+    use crate::network_event::NetworkEvent;
+    use crate::observation::Malice;
+    use crate::peer_list::{PeerIndex, PeerList, PeerState};
     use std::collections::BTreeMap;
 
     // Returns iterator over all votes cast by the given node.

--- a/src/gossip/cause.rs
+++ b/src/gossip/cause.rs
@@ -13,21 +13,21 @@ use super::{
     event_hash::EventHash,
     graph::{EventIndex, Graph},
 };
-use error::Error;
-use id::{PublicId, SecretId};
+use crate::error::Error;
+use crate::id::{PublicId, SecretId};
 #[cfg(any(test, feature = "testing"))]
-use mock::{PeerId, Transaction};
-use network_event::NetworkEvent;
+use crate::mock::{PeerId, Transaction};
+use crate::network_event::NetworkEvent;
 #[cfg(any(test, feature = "testing"))]
-use observation::ConsensusMode;
-use observation::ObservationInfo;
+use crate::observation::ConsensusMode;
+use crate::observation::ObservationInfo;
 #[cfg(any(test, feature = "dump-graphs", feature = "testing"))]
-use observation::ObservationStore;
-use peer_list::PeerIndex;
+use crate::observation::ObservationStore;
+use crate::peer_list::PeerIndex;
+use crate::vote::{Vote, VoteKey};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "dump-graphs")]
 use std::fmt::{self, Display, Formatter};
-use vote::{Vote, VoteKey};
 
 #[serde(bound(
     serialize = "V: Serialize, E: Serialize",

--- a/src/gossip/content.rs
+++ b/src/gossip/content.rs
@@ -12,12 +12,12 @@ use super::{
     event_hash::EventHash,
     graph::EventIndex,
 };
-use error::Error;
-use id::{PublicId, SecretId};
-use network_event::NetworkEvent;
-use peer_list::PeerIndex;
+use crate::error::Error;
+use crate::id::{PublicId, SecretId};
+use crate::network_event::NetworkEvent;
+use crate::peer_list::PeerIndex;
+use crate::vote::{Vote, VoteKey};
 use serde::{Deserialize, Serialize};
-use vote::{Vote, VoteKey};
 
 #[serde(bound(
     serialize = "V: Serialize, E: Serialize, P: Serialize",

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -16,22 +16,22 @@ use super::{
     graph::{EventIndex, Graph},
     packed_event::PackedEvent,
 };
-use error::Error;
-use hash::Hash;
-use id::{PublicId, SecretId};
+use crate::error::Error;
+use crate::hash::Hash;
+use crate::id::{PublicId, SecretId};
 #[cfg(any(test, feature = "testing"))]
-use mock::{PeerId, Transaction};
-use network_event::NetworkEvent;
-use observation::{Observation, ObservationKey, ObservationStore};
-use peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet, PeerList};
-use serialise;
+use crate::mock::{PeerId, Transaction};
+use crate::network_event::NetworkEvent;
+use crate::observation::{Observation, ObservationKey, ObservationStore};
+use crate::peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet, PeerList};
+use crate::serialise;
+use crate::vote::{Vote, VoteKey};
 use std::cmp;
 #[cfg(any(test, feature = "testing"))]
 use std::collections::BTreeMap;
 use std::fmt::{self, Debug, Display, Formatter};
 #[cfg(feature = "dump-graphs")]
 use std::io::{self, Write};
-use vote::{Vote, VoteKey};
 
 pub(crate) struct Event<P: PublicId> {
     content: Content<VoteKey<P>, EventIndex, PeerIndex>,
@@ -660,18 +660,18 @@ impl Debug for ShortName {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use error::Error;
-    use gossip::{
+    use crate::error::Error;
+    use crate::gossip::{
         cause::Cause,
         event::Event,
         event_hash::EventHash,
         graph::{EventIndex, Graph},
     };
-    use id::SecretId;
-    use mock::{PeerId, Transaction};
-    use observation::ConsensusMode;
-    use observation::Observation;
-    use peer_list::{PeerList, PeerState};
+    use crate::id::SecretId;
+    use crate::mock::{PeerId, Transaction};
+    use crate::observation::ConsensusMode;
+    use crate::observation::Observation;
+    use crate::peer_list::{PeerList, PeerState};
 
     struct Context {
         graph: Graph<PeerId>,

--- a/src/gossip/event_context.rs
+++ b/src/gossip/event_context.rs
@@ -7,10 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::graph::Graph;
-use id::SecretId;
-use network_event::NetworkEvent;
-use observation::{ConsensusMode, ObservationStore};
-use peer_list::PeerList;
+use crate::id::SecretId;
+use crate::network_event::NetworkEvent;
+use crate::observation::{ConsensusMode, ObservationStore};
+use crate::peer_list::PeerList;
 
 pub(crate) struct EventContextRef<'a, T: NetworkEvent, S: SecretId> {
     pub(crate) graph: &'a Graph<S::PublicId>,

--- a/src/gossip/event_hash.rs
+++ b/src/gossip/event_hash.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use hash::Hash;
+use crate::hash::Hash;
 use std::fmt::{self, Debug, Formatter};
 
 /// Hash of the event contents.

--- a/src/gossip/graph/ancestors.rs
+++ b/src/gossip/graph/ancestors.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{Graph, IndexedEventRef};
-use id::PublicId;
+use crate::id::PublicId;
 use std::collections::BTreeSet;
 
 pub(crate) struct Ancestors<'a, P: PublicId + 'a> {

--- a/src/gossip/graph/event_ref.rs
+++ b/src/gossip/graph/event_ref.rs
@@ -8,7 +8,7 @@
 
 use super::super::event::Event;
 use super::event_index::EventIndex;
-use id::PublicId;
+use crate::id::PublicId;
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::ops::Deref;
 

--- a/src/gossip/graph/mod.rs
+++ b/src/gossip/graph/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use self::event_index::EventIndex;
 pub(crate) use self::event_ref::IndexedEventRef;
 
 use super::{event::Event, event_hash::EventHash};
-use id::PublicId;
+use crate::id::PublicId;
 use std::collections::btree_map::{BTreeMap, Entry};
 use std::collections::BTreeSet;
 
@@ -234,7 +234,7 @@ pub(crate) mod snapshot {
 #[cfg(test)]
 mod tests {
     use super::super::find_event_by_short_name;
-    use dev_utils::parse_test_dot_file;
+    use crate::dev_utils::parse_test_dot_file;
 
     #[test]
     fn ancestors_iterator() {

--- a/src/gossip/messages.rs
+++ b/src/gossip/messages.rs
@@ -6,11 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use error::{Error, Result};
-use gossip::event_hash::EventHash;
-use gossip::packed_event::PackedEvent;
-use id::PublicId;
-use network_event::NetworkEvent;
+use crate::error::{Error, Result};
+use crate::gossip::event_hash::EventHash;
+use crate::gossip::packed_event::PackedEvent;
+use crate::id::PublicId;
+use crate::network_event::NetworkEvent;
 
 /// A gossip request message.
 #[serde(bound = "")]

--- a/src/gossip/packed_event.rs
+++ b/src/gossip/packed_event.rs
@@ -8,12 +8,12 @@
 
 use super::content::Content;
 use super::event_hash::EventHash;
-use hash::Hash;
-use id::PublicId;
-use network_event::NetworkEvent;
-use serialise;
+use crate::hash::Hash;
+use crate::id::PublicId;
+use crate::network_event::NetworkEvent;
+use crate::serialise;
+use crate::vote::Vote;
 use std::fmt::{self, Debug, Formatter};
-use vote::Vote;
 
 /// Packed event contains only content and signature.
 #[serde(bound = "")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,6 @@
     clippy::new_ret_no_self
 )]
 
-extern crate fnv;
 #[cfg(any(test, feature = "dump-graphs", feature = "mock"))]
 #[macro_use]
 extern crate lazy_static;
@@ -165,22 +164,14 @@ extern crate lazy_static;
 extern crate log;
 #[macro_use]
 extern crate maidsafe_utilities;
-#[cfg(any(test, feature = "testing"))]
-extern crate pom;
 #[cfg(feature = "testing")]
 #[macro_use]
 extern crate proptest as proptest_crate;
-#[cfg(any(test, feature = "dump-graphs", feature = "mock"))]
-extern crate rand;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate tiny_keccak;
 #[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
 #[macro_use]
 extern crate unwrap;
-#[cfg(any(test, feature = "mock"))]
-extern crate safe_crypto;
 
 mod block;
 mod dump_graph;
@@ -212,16 +203,16 @@ pub mod dev_utils;
 #[cfg(any(test, feature = "mock"))]
 pub mod mock;
 
-pub use block::Block;
+pub use crate::block::Block;
 #[cfg(feature = "dump-graphs")]
-pub use dump_graph::DIR;
-pub use error::{Error, Result};
-pub use gossip::{EventHash, PackedEvent, Request, Response};
-pub use id::{Proof, PublicId, SecretId};
-pub use network_event::NetworkEvent;
-pub use observation::{ConsensusMode, Malice, Observation};
-pub use parsec::Parsec;
-pub use vote::Vote;
+pub use crate::dump_graph::DIR;
+pub use crate::error::{Error, Result};
+pub use crate::gossip::{EventHash, PackedEvent, Request, Response};
+pub use crate::id::{Proof, PublicId, SecretId};
+pub use crate::network_event::NetworkEvent;
+pub use crate::observation::{ConsensusMode, Malice, Observation};
+pub use crate::parsec::Parsec;
+pub use crate::vote::Vote;
 
 use maidsafe_utilities::serialisation;
 use serde::ser::Serialize;

--- a/src/meta_voting/meta_elections.rs
+++ b/src/meta_voting/meta_elections.rs
@@ -8,12 +8,12 @@
 
 use super::meta_event::MetaEvent;
 use super::meta_vote::MetaVote;
+use crate::gossip::EventIndex;
+use crate::id::PublicId;
+use crate::observation::{ObservationHash, ObservationKey};
+use crate::peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet};
+use crate::round_hash::RoundHash;
 use fnv::FnvHashMap;
-use gossip::EventIndex;
-use id::PublicId;
-use observation::{ObservationHash, ObservationKey};
-use peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet};
-use round_hash::RoundHash;
 use std::collections::{btree_map::Entry, BTreeMap, BTreeSet, VecDeque};
 use std::fmt::{self, Debug};
 use std::{iter, mem, usize};
@@ -476,10 +476,10 @@ impl MetaElections {
 pub(crate) mod snapshot {
     use super::super::meta_event::snapshot::MetaEventSnapshot;
     use super::*;
-    use gossip::{EventHash, Graph};
-    use id::SecretId;
-    use observation::snapshot::ObservationKeySnapshot;
-    use peer_list::PeerList;
+    use crate::gossip::{EventHash, Graph};
+    use crate::id::SecretId;
+    use crate::observation::snapshot::ObservationKeySnapshot;
+    use crate::peer_list::PeerList;
 
     #[serde(bound = "")]
     #[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]

--- a/src/meta_voting/meta_event.rs
+++ b/src/meta_voting/meta_event.rs
@@ -8,10 +8,10 @@
 
 use super::meta_elections::MetaElectionHandle;
 use super::meta_vote::MetaVote;
-use gossip::IndexedEventRef;
-use id::PublicId;
-use observation::ObservationKey;
-use peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet};
+use crate::gossip::IndexedEventRef;
+use crate::id::PublicId;
+use crate::observation::ObservationKey;
+use crate::peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet};
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub(crate) struct MetaEvent {
@@ -83,9 +83,9 @@ impl<'a, P: PublicId + 'a> MetaEventBuilder<'a, P> {
 #[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
 pub(crate) mod snapshot {
     use super::*;
-    use id::SecretId;
-    use observation::snapshot::ObservationKeySnapshot;
-    use peer_list::PeerList;
+    use crate::id::SecretId;
+    use crate::observation::snapshot::ObservationKeySnapshot;
+    use crate::peer_list::PeerList;
     use std::collections::{BTreeMap, BTreeSet};
 
     #[serde(bound = "")]

--- a/src/meta_voting/meta_vote_counts.rs
+++ b/src/meta_voting/meta_vote_counts.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::meta_vote::MetaVote;
-use observation::is_more_than_two_thirds;
+use crate::observation::is_more_than_two_thirds;
 use std::iter;
 
 // This is used to collect the meta votes of other events relating to a single (binary) meta vote at

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use id::{PublicId, SecretId};
-use network_event::NetworkEvent;
+use crate::id::{PublicId, SecretId};
+use crate::network_event::NetworkEvent;
 use rand::{Rand, Rng};
 use safe_crypto::Signature as SafeSignature;
 use safe_crypto::{gen_sign_keypair, PublicSignKey, SecretSignKey};

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -6,13 +6,13 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use gossip::{EventHash, PackedEvent};
-use hash::Hash;
-use id::PublicId;
-use network_event::NetworkEvent;
-use peer_list::PeerIndex;
+use crate::gossip::{EventHash, PackedEvent};
+use crate::hash::Hash;
+use crate::id::PublicId;
+use crate::network_event::NetworkEvent;
+use crate::peer_list::PeerIndex;
+use crate::serialise;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
-use serialise;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
@@ -291,8 +291,8 @@ pub fn is_more_than_two_thirds(small: usize, large: usize) -> bool {
 #[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
 pub(crate) mod snapshot {
     use super::*;
-    use id::SecretId;
-    use peer_list::PeerList;
+    use crate::id::SecretId;
+    use crate::peer_list::PeerList;
 
     #[serde(bound = "")]
     #[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
@@ -322,8 +322,8 @@ pub(crate) mod snapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mock::{PeerId, Transaction};
     use maidsafe_utilities::serialisation::deserialise;
-    use mock::{PeerId, Transaction};
 
     #[test]
     fn malice_comparison_and_hashing_ignores_unprovable_value() {

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -6,31 +6,33 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use block::Block;
+use crate::block::Block;
 #[cfg(any(feature = "testing", all(test, feature = "mock")))]
-use dev_utils::ParsedContents;
-use dump_graph;
-use error::{Error, Result};
+use crate::dev_utils::ParsedContents;
+use crate::dump_graph;
+use crate::error::{Error, Result};
 #[cfg(any(all(test, feature = "mock"), feature = "malice-detection"))]
-use gossip::EventHash;
-use gossip::{
+use crate::gossip::EventHash;
+use crate::gossip::{
     Event, EventContextMut, EventContextRef, EventIndex, Graph, IndexedEventRef, PackedEvent,
     Request, Response, UnpackedEvent,
 };
 #[cfg(feature = "malice-detection")]
-use id::PublicId;
-use id::SecretId;
-use meta_voting::{MetaElectionHandle, MetaElections, MetaEvent, MetaEventBuilder, MetaVote, Step};
+use crate::id::PublicId;
+use crate::id::SecretId;
+use crate::meta_voting::{
+    MetaElectionHandle, MetaElections, MetaEvent, MetaEventBuilder, MetaVote, Step,
+};
 #[cfg(any(feature = "testing", all(test, feature = "mock")))]
-use mock::{PeerId, Transaction};
-use network_event::NetworkEvent;
+use crate::mock::{PeerId, Transaction};
+use crate::network_event::NetworkEvent;
 #[cfg(feature = "malice-detection")]
-use observation::UnprovableMalice;
-use observation::{
+use crate::observation::UnprovableMalice;
+use crate::observation::{
     is_more_than_two_thirds, ConsensusMode, Malice, Observation, ObservationHash, ObservationKey,
     ObservationStore,
 };
-use peer_list::{PeerIndex, PeerIndexSet, PeerList, PeerState};
+use crate::peer_list::{PeerIndex, PeerIndexSet, PeerList, PeerState};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::mem;
 #[cfg(all(test, feature = "mock"))]
@@ -2362,7 +2364,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         event: IndexedEventRef<'a, S::PublicId>,
         creator: PeerIndex,
     ) -> Option<IndexedEventRef<'a, S::PublicId>> {
-        use gossip::LastAncestor;
+        use crate::gossip::LastAncestor;
 
         match event.last_ancestor_by(creator) {
             LastAncestor::Some(index) => self
@@ -2623,7 +2625,7 @@ impl<T: NetworkEvent, S: SecretId> DerefMut for TestParsec<T, S> {
 /// Assert that the two parsec instances have the same events modulo their insertion order.
 #[cfg(all(test, feature = "testing"))]
 pub(crate) fn assert_same_events<T: NetworkEvent, S: SecretId>(a: &Parsec<T, S>, b: &Parsec<T, S>) {
-    use gossip::GraphSnapshot;
+    use crate::gossip::GraphSnapshot;
 
     let a = GraphSnapshot::new(&a.graph);
     let b = GraphSnapshot::new(&b.graph);

--- a/src/peer_list/membership_list.rs
+++ b/src/peer_list/membership_list.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use peer_list::{PeerIndex, PeerIndexSet};
+use crate::peer_list::{PeerIndex, PeerIndexSet};
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub(crate) enum MembershipListChange {

--- a/src/peer_list/mod.rs
+++ b/src/peer_list/mod.rs
@@ -20,14 +20,14 @@ pub(crate) use self::snapshot::PeerListSnapshot;
 #[cfg(feature = "malice-detection")]
 use self::membership_list::MembershipListWithChanges;
 use self::peer::Peer;
-use error::Error;
+use crate::error::Error;
 #[cfg(any(test, feature = "testing"))]
-use gossip::Graph;
-use gossip::{Event, EventIndex, IndexedEventRef};
-use hash::Hash;
-use id::SecretId;
+use crate::gossip::Graph;
+use crate::gossip::{Event, EventIndex, IndexedEventRef};
+use crate::hash::Hash;
+use crate::id::SecretId;
 #[cfg(any(test, feature = "testing"))]
-use mock::PeerId;
+use crate::mock::PeerId;
 use std::collections::btree_map::{BTreeMap, Entry};
 #[cfg(any(test, feature = "testing"))]
 use std::collections::BTreeSet;
@@ -545,8 +545,8 @@ impl Builder {
 #[cfg(test)]
 pub(crate) mod snapshot {
     use super::*;
-    use gossip::EventHash;
-    use id::PublicId;
+    use crate::gossip::EventHash;
+    use crate::id::PublicId;
 
     #[derive(Eq, PartialEq, Debug)]
     pub(crate) struct PeerListSnapshot<P: PublicId>(

--- a/src/peer_list/peer.rs
+++ b/src/peer_list/peer.rs
@@ -9,10 +9,10 @@
 use super::membership_list::MembershipListChange;
 use super::peer_index::PeerIndexSet;
 use super::peer_state::PeerState;
-use gossip::{EventIndex, IndexedEventRef};
-use hash::Hash;
-use id::PublicId;
-use serialise;
+use crate::gossip::{EventIndex, IndexedEventRef};
+use crate::hash::Hash;
+use crate::id::PublicId;
+use crate::serialise;
 use std::iter::{self, FromIterator};
 
 #[derive(Debug)]

--- a/src/round_hash.rs
+++ b/src/round_hash.rs
@@ -6,10 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use hash::Hash;
-use id::PublicId;
-use observation::ObservationHash;
-use serialise;
+use crate::hash::Hash;
+use crate::id::PublicId;
+use crate::observation::ObservationHash;
+use crate::serialise;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
 pub(crate) struct RoundHash {

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -6,13 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use error::Error;
-use id::{Proof, PublicId, SecretId};
-use network_event::NetworkEvent;
-use observation::{ConsensusMode, Observation, ObservationHash, ObservationKey, ObservationStore};
-use peer_list::PeerIndex;
+use crate::error::Error;
+use crate::id::{Proof, PublicId, SecretId};
+use crate::network_event::NetworkEvent;
+use crate::observation::{
+    ConsensusMode, Observation, ObservationHash, ObservationKey, ObservationStore,
+};
+use crate::peer_list::PeerIndex;
+use crate::serialise;
 use serde::de::DeserializeOwned;
-use serialise;
 use std::fmt::{self, Debug, Formatter};
 
 /// A helper struct carrying an `Observation` and a signature of this `Observation`.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -53,11 +53,8 @@
     variant_size_differences
 )]
 
-extern crate maidsafe_utilities;
-extern crate parsec;
 #[macro_use]
 extern crate proptest;
-extern crate rand;
 #[macro_use]
 extern crate unwrap;
 


### PR DESCRIPTION
* Upgrade compiler
* Switch to 2018 edition
* Fix compilation, fmt and clippy warnings
