### PR TITLE
fix/test: update testing dot files

### DIFF
--- a/input_graphs/consensus_with_forks/alice.dot
+++ b/input_graphs/consensus_with_forks/alice.dot
@@ -1272,7 +1272,7 @@ digraph GossipGraph {
 /// }
 /// all_voters: {Alice, Bob, Carol, Dave, Eric}
 /// undecided_voters: {Alice, Bob, Carol, Dave, Eric}
-/// start_index: 131
+/// unconsensused_events: {}
 /// meta_events: {
 ///   A_37 -> {
 ///     observees: {}

--- a/input_graphs/consensus_with_forks/bob.dot
+++ b/input_graphs/consensus_with_forks/bob.dot
@@ -1296,7 +1296,7 @@ digraph GossipGraph {
 /// }
 /// all_voters: {Alice, Bob, Carol, Dave, Eric}
 /// undecided_voters: {Alice, Bob, Carol, Dave, Eric}
-/// start_index: 131
+/// unconsensused_events: {}
 /// meta_events: {
 ///   A_37 -> {
 ///     observees: {}

--- a/input_graphs/consensus_with_forks/carol.dot
+++ b/input_graphs/consensus_with_forks/carol.dot
@@ -1280,7 +1280,7 @@ digraph GossipGraph {
 /// }
 /// all_voters: {Alice, Bob, Carol, Dave, Eric}
 /// undecided_voters: {Alice, Bob, Carol, Dave, Eric}
-/// start_index: 131
+/// unconsensused_events: {}
 /// meta_events: {
 ///   A_37 -> {
 ///     observees: {}

--- a/input_graphs/consensus_with_forks/dave.dot
+++ b/input_graphs/consensus_with_forks/dave.dot
@@ -1288,7 +1288,7 @@ digraph GossipGraph {
 /// }
 /// all_voters: {Alice, Bob, Carol, Dave, Eric}
 /// undecided_voters: {Alice, Bob, Carol, Dave, Eric}
-/// start_index: 131
+/// unconsensused_events: {}
 /// meta_events: {
 ///   A_37 -> {
 ///     observees: {}

--- a/input_graphs/consensus_with_forks/eric.dot
+++ b/input_graphs/consensus_with_forks/eric.dot
@@ -1240,7 +1240,7 @@ digraph GossipGraph {
 /// }
 /// all_voters: {Alice, Bob, Carol, Dave, Eric}
 /// undecided_voters: {Alice, Bob, Carol, Dave, Eric}
-/// start_index: 131
+/// unconsensused_events: {}
 /// meta_events: {
 ///   A_37 -> {
 ///     observees: {}


### PR DESCRIPTION
PR 212 changed dot file's format. With `start_index` removed and introduced `unconsensused_events`.
However, the `consensus_with_fork` test is disabled, hence there is no error exposed and left the dot files forgot to be updated at that time.