### PR TITLE
MAID-3280: fix duplicate Accomplice accusations

### DIFF
--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -309,7 +309,6 @@ impl<P: PublicId> Event<P> {
         &self.cache.last_ancestors
     }
 
-    #[cfg(feature = "testing")]
     pub fn is_request(&self) -> bool {
         if let Cause::Request { .. } = self.content.cause {
             true

--- a/src/gossip/packed_event.rs
+++ b/src/gossip/packed_event.rs
@@ -41,14 +41,3 @@ impl<T: NetworkEvent, P: PublicId> PackedEvent<T, P> {
         EventHash(Hash::from(serialise(&self.content).as_slice()))
     }
 }
-
-#[cfg(feature = "malice-detection")]
-impl<T: NetworkEvent, P: PublicId> PackedEvent<T, P> {
-    pub(crate) fn self_parent(&self) -> Option<&EventHash> {
-        self.content.self_parent()
-    }
-
-    pub(crate) fn creator(&self) -> &P {
-        &self.content.creator
-    }
-}

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -128,6 +128,24 @@ impl<T: NetworkEvent, P: PublicId> Malice<T, P> {
             _ => true,
         }
     }
+
+    #[cfg(feature = "malice-detection")]
+    // If the malice specifies a single event as its source, return it.
+    pub(crate) fn single_hash(&self) -> Option<&EventHash> {
+        match self {
+            Malice::UnexpectedGenesis(hash)
+            | Malice::MissingGenesis(hash)
+            | Malice::IncorrectGenesis(hash)
+            | Malice::Fork(hash)
+            | Malice::InvalidAccusation(hash)
+            | Malice::InvalidGossipCreator(hash)
+            | Malice::Accomplice(hash, _) => Some(hash),
+            Malice::DuplicateVote(_, _)
+            | Malice::OtherParentBySameCreator(_)
+            | Malice::SelfParentByDifferentCreator(_)
+            | Malice::Unprovable(_) => None,
+        }
+    }
 }
 
 // For internal diagnostics only. The value is ignored in comparison, ordering or hashing.

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -116,7 +116,7 @@ pub enum Malice<T: NetworkEvent, P: PublicId> {
     /// Detectable but unprovable malice. Relies on consensus.
     Unprovable(UnprovableMalice),
     /// A node is not reporting malice when it should
-    Accomplice(EventHash),
+    Accomplice(EventHash, Box<Malice<T, P>>),
     // TODO: add other malice variants
 }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -2297,12 +2297,6 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
     ) -> Result<()> {
         let (event_hash, creator, starting_index) = {
             let event = self.get_known_event(event)?;
-
-            if self.unprovable_offenders.contains(event.creator()) {
-                // Can only accuse the peer once anyway
-                return Ok(());
-            }
-
             let creator_id = self.event_creator_id(&*event)?;
             let starting_index = first_event_by_peer_in_packed_event
                 .get(creator_id)

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -2209,7 +2209,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             | Malice::IncorrectGenesis(hash)
             | Malice::InvalidAccusation(hash)
             | Malice::InvalidGossipCreator(hash)
-            | Malice::Accomplice(hash) => self
+            | Malice::Accomplice(hash, _) => self
                 .graph
                 .get_index(hash)
                 .and_then(|index| self.graph.get(index))
@@ -2281,7 +2281,10 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             if can_still_detect_accomplice {
                 // Repoint the malice event to the event where we're actually certain
                 let current = *self.get_known_event(current)?.hash();
-                self.accuse(accomplice.creator, Malice::Accomplice(current));
+                self.accuse(
+                    accomplice.creator,
+                    Malice::Accomplice(current, Box::new(accomplice.against.clone())),
+                );
             }
             let _ = self
                 .candidate_accomplice_accusations
@@ -2311,7 +2314,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
                 event,
                 CandidateAccompliceAccusation {
                     creator,
-                    accusation: Malice::Accomplice(event_hash),
+                    accusation: Malice::Accomplice(event_hash, Box::new(malice.clone())),
                     against: malice,
                     starting_index,
                 },

--- a/src/peer_list/peer.rs
+++ b/src/peer_list/peer.rs
@@ -22,6 +22,10 @@ pub(crate) struct Peer<P: PublicId> {
     pub(super) state: PeerState,
     pub(super) events: Events,
     pub(super) last_gossiped_event: Option<EventIndex>,
+    // As a performance optimisation we keep track of which events we've cleared for Accomplice
+    // accusations.
+    #[cfg(feature = "malice-detection")]
+    pub accomplice_event_checkpoint: Option<EventIndex>,
     membership_list: PeerIndexSet,
     membership_list_changes: Vec<(usize, MembershipListChange)>,
 }
@@ -36,6 +40,8 @@ impl<P: PublicId> Peer<P> {
             state,
             events: Events::new(),
             last_gossiped_event: None,
+            #[cfg(feature = "malice-detection")]
+            accomplice_event_checkpoint: None,
             membership_list: PeerIndexSet::default(),
             membership_list_changes: Vec::new(),
         }


### PR DESCRIPTION
The initial raison d'être for having the `CandidateAccompliceAccusation` buffer was that the `Accomplice` malice was detected at a different event than when we could act on it. However since it was decided to repoint the accusations anyway to the event where we're actually certain we don't really need it anymore.

As a nice side effect, this should get rid of duplicate accusations being generated in certain scenarios.