### PR TITLE
bugfix/tests: fix various issues in tests

### DIFF
--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -180,7 +180,7 @@ impl PeerStatuses {
         (*unwrap!(rng.choose(&names))).clone()
     }
 
-    /// Returns an iterator thorugh all the peers
+    /// Returns an iterator through all the peers
     pub fn all_peers(&self) -> impl Iterator<Item = &PeerId> {
         self.statuses.keys()
     }
@@ -197,7 +197,7 @@ impl PeerStatuses {
 
     /// Returns an iterator through the list of present peers (active or pending)
     pub fn present_peers(&self) -> impl Iterator<Item = &PeerId> {
-        self.peers_by_status(|s| *s == PeerStatus::Active || *s == PeerStatus::Failed)
+        self.peers_by_status(|s| *s == PeerStatus::Active || *s == PeerStatus::Pending)
             .map(|(id, _)| id)
     }
 
@@ -216,7 +216,7 @@ impl PeerStatuses {
         let _ = self.statuses.insert(p, PeerStatus::Active);
     }
 
-    // Randomly chooses a peer to remove.
+    /// Randomly chooses a peer to remove.
     pub fn remove_random_peer<R: Rng>(&mut self, rng: &mut R, min_active: usize) -> Option<PeerId> {
         let name = self.choose_name_to_remove(rng);
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -796,7 +796,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         info!(
             "{:?} got consensus on block {} with payload {:?} and payload hash {:?}",
             self.our_pub_id(),
-            self.meta_elections.consensus_history().len() - 1,
+            self.meta_elections.consensus_history().len(),
             payload,
             payload_key.hash()
         )


### PR DESCRIPTION
This change avoids the blocks handled by non-active test nodes as counting towards the voting quorum.  It also fixes a minor bug in the test code whereby failed peers were treated as running, and a logging statement which triggers a subtraction with overflow.