### PR TITLE
Less reprocessing

### DIFF
--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -722,6 +722,11 @@ impl ParsedContents {
     pub fn add_event(&mut self, event: Event<PeerId>) -> EventIndex {
         let indexed_event = self.graph.insert(event);
         self.peer_list.add_event(indexed_event);
+
+        let start_index = indexed_event.event_index().topological_index() + 1;
+        self.meta_election.lower_start_index = start_index;
+        self.meta_election.upper_start_index = start_index;
+
         indexed_event.event_index()
     }
 
@@ -897,6 +902,8 @@ fn convert_to_meta_election(
             .cloned()
             .collect(),
         consensus_history: meta_election.consensus_history,
+        upper_start_index: 0,
+        lower_start_index: 0,
     }
 }
 

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -896,8 +896,6 @@ fn convert_to_meta_election(
             .filter_map(|id| event_indices.get(&id))
             .cloned()
             .collect(),
-        // TODO: parse these too:
-        observers: BTreeSet::new(),
         consensus_history: meta_election.consensus_history,
     }
 }
@@ -909,7 +907,7 @@ fn convert_to_meta_event(meta_event: ParsedMetaEvent, peer_list: &PeerList<PeerI
         observer: if observees.is_empty() {
             Observer::None
         } else {
-            Observer::First(observees)
+            Observer::This(observees)
         },
         interesting_content: meta_event.interesting_content,
         meta_votes: convert_peer_id_map(meta_event.meta_votes, peer_list),

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -19,7 +19,7 @@ use crate::gossip::EventContextRef;
 use crate::gossip::{CauseInput, Event, EventIndex, Graph, IndexedEventRef};
 use crate::hash::Hash;
 use crate::hash::HASH_LEN;
-use crate::meta_voting::{BoolSet, MetaElection, MetaEvent, MetaVote, Step};
+use crate::meta_voting::{BoolSet, MetaElection, MetaEvent, MetaVote, Observer, Step};
 use crate::mock::{PeerId, Transaction};
 #[cfg(any(
     all(test, feature = "malice-detection", feature = "mock"),
@@ -904,8 +904,14 @@ fn convert_to_meta_election(
 }
 
 fn convert_to_meta_event(meta_event: ParsedMetaEvent, peer_list: &PeerList<PeerId>) -> MetaEvent {
+    let observees = convert_peer_id_set(meta_event.observees, peer_list);
+
     MetaEvent {
-        observees: convert_peer_id_set(meta_event.observees, peer_list),
+        observer: if observees.is_empty() {
+            Observer::None
+        } else {
+            Observer::First(observees)
+        },
         interesting_content: meta_event.interesting_content,
         meta_votes: convert_peer_id_map(meta_event.meta_votes, peer_list),
     }

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -732,7 +732,7 @@ mod detail {
                 self.indent();
 
                 let observees = match mev.observer {
-                    Observer::First(ref observees) => {
+                    Observer::This(ref observees) => {
                         convert_peer_index_set(observees, &self.peer_list)
                     }
                     _ => BTreeSet::new(),

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -289,8 +289,13 @@ mod detail {
                     .to_string(),
             );
         }
-        for (peer_index, meta_votes) in meta_votes {
-            let peer_id = unwrap!(peer_list.get(peer_index)).id();
+
+        let meta_votes: BTreeMap<_, _> = meta_votes
+            .iter()
+            .map(|(peer_index, meta_votes)| (unwrap!(peer_list.get(peer_index)).id(), meta_votes))
+            .collect();
+
+        for (peer_id, meta_votes) in meta_votes {
             let mut prefix = format!("{}: ", first_char(peer_id).unwrap_or('?'));
             for mv in meta_votes {
                 let est = mv.estimates.as_short_string();
@@ -548,6 +553,8 @@ mod detail {
                 .all_ids()
                 .map(|(_, id)| id)
                 .collect::<Vec<_>>();
+            peer_ids.sort();
+
             for peer_id in &peer_ids {
                 self.writeln(format_args!(
                     "    \"{:?}\" [style=filled, color=white]",
@@ -836,6 +843,11 @@ mod detail {
                     attr.fillcolor = "style=filled, fillcolor=crimson";
                     attr.is_rectangle = true;
                 }
+
+                if meta_event.is_observer() {
+                    attr.fillcolor = "style=filled, fillcolor=orange";
+                }
+
                 if !meta_event.meta_votes.is_empty() {
                     let meta_votes =
                         dump_meta_votes(peer_list, &meta_event.meta_votes, false).join("\n");

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -682,7 +682,7 @@ mod detail {
                 "{}{}all_voters: {:?}",
                 Self::COMMENT,
                 self.indentation(),
-                convert_peer_index_set(&self.meta_election.all_voters, &self.peer_list)
+                convert_peer_index_set(&self.meta_election.voters, &self.peer_list)
             ));
 
             // write unconsensused events

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -61,7 +61,7 @@ pub use self::detail::DIR;
 mod detail {
     use crate::gossip::{Event, EventHash, EventIndex, Graph, GraphSnapshot, IndexedEventRef};
     use crate::id::{PublicId, SecretId};
-    use crate::meta_voting::{MetaElection, MetaElectionSnapshot, MetaEvent, MetaVote};
+    use crate::meta_voting::{MetaElection, MetaElectionSnapshot, MetaEvent, MetaVote, Observer};
     use crate::network_event::NetworkEvent;
     use crate::observation::ObservationStore;
     use crate::peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet, PeerList};
@@ -730,11 +730,19 @@ mod detail {
                     short_name
                 ));
                 self.indent();
+
+                let observees = match mev.observer {
+                    Observer::First(ref observees) => {
+                        convert_peer_index_set(observees, &self.peer_list)
+                    }
+                    _ => BTreeSet::new(),
+                };
+
                 lines.push(format!(
                     "{}{}observees: {:?}",
                     Self::COMMENT,
                     self.indentation(),
-                    convert_peer_index_set(&mev.observees, &self.peer_list)
+                    observees
                 ));
                 let interesting_content = mev
                     .interesting_content

--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -792,7 +792,7 @@ mod handle_malice {
         assert_eq!(*hash, a_5_hash);
     }
 
-    // TODO: enable this when InvalidGossipCreator malice handlind works again
+    // TODO: enable this when InvalidGossipCreator malice handling works again.
     #[ignore]
     #[test]
     fn invalid_gossip_creator() {

--- a/src/meta_voting/meta_election.rs
+++ b/src/meta_voting/meta_election.rs
@@ -30,8 +30,6 @@ pub(crate) struct MetaElection {
     pub(crate) interesting_events: PeerIndexMap<Vec<EventIndex>>,
     // Set of all events that carry a payload that hasn't yet been consensused.
     pub(crate) unconsensused_events: BTreeSet<EventIndex>,
-    // Set of all events that are observers.
-    pub(crate) observers: BTreeSet<EventIndex>,
     // Keys of the consensused blocks' payloads in the order they were consensused.
     pub(crate) consensus_history: Vec<ObservationKey>,
 }
@@ -44,7 +42,6 @@ impl MetaElection {
             voters,
             interesting_events: PeerIndexMap::default(),
             unconsensused_events: BTreeSet::new(),
-            observers: BTreeSet::new(),
             consensus_history: Vec::new(),
         }
     }
@@ -76,11 +73,6 @@ impl MetaElection {
                 .entry(creator)
                 .or_insert_with(Vec::new)
                 .push(event_index);
-        }
-
-        // Update observers
-        if meta_event.is_observer() {
-            let _ = self.observers.insert(event_index);
         }
 
         // Insert the meta-event itself.
@@ -198,7 +190,6 @@ impl MetaElection {
             self.meta_events.clear();
         }
 
-        self.observers.clear();
         self.consensus_history.push(decided_key);
     }
 

--- a/src/meta_voting/meta_event.rs
+++ b/src/meta_voting/meta_event.rs
@@ -95,19 +95,6 @@ impl<'a, P: PublicId + 'a> MetaEventBuilder<'a, P> {
         }
     }
 
-    pub fn can_reuse_observer(&self) -> bool {
-        // If this event wasn't observer in the previous meta-election and there was no membership
-        // change, it won't be observer in the current meta-election either.
-        if self.new {
-            return false;
-        }
-
-        match self.meta_event.observer {
-            Observer::None => true,
-            _ => false,
-        }
-    }
-
     pub fn set_observer(&mut self, observer: Observer) {
         self.meta_event.observer = observer;
     }

--- a/src/meta_voting/meta_event.rs
+++ b/src/meta_voting/meta_event.rs
@@ -104,18 +104,6 @@ impl<'a, P: PublicId + 'a> MetaEventBuilder<'a, P> {
         self.meta_event.interesting_content = content;
     }
 
-    /// Reuse the interesting content for which the given predicate returns true.
-    pub fn reuse_interesting_content<F>(&mut self, f: F)
-    where
-        F: FnMut(&ObservationKey) -> bool,
-    {
-        if self.new {
-            log_or_panic!("Can't reuse interesting content of new meta-event.");
-        }
-
-        self.meta_event.interesting_content.retain(f)
-    }
-
     pub fn add_meta_votes(&mut self, peer_index: PeerIndex, votes: Vec<MetaVote>) {
         let _ = self.meta_event.meta_votes.insert(peer_index, votes);
     }

--- a/src/meta_voting/mod.rs
+++ b/src/meta_voting/mod.rs
@@ -17,5 +17,5 @@ pub(crate) use self::bool_set::BoolSet;
 #[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
 pub(crate) use self::meta_election::snapshot::MetaElectionSnapshot;
 pub(crate) use self::meta_election::MetaElection;
-pub(crate) use self::meta_event::{MetaEvent, MetaEventBuilder};
+pub(crate) use self::meta_event::{MetaEvent, MetaEventBuilder, Observer};
 pub(crate) use self::meta_vote::{MetaVote, Step};

--- a/src/peer_list/mod.rs
+++ b/src/peer_list/mod.rs
@@ -112,6 +112,7 @@ impl<S: SecretId> PeerList<S> {
     }
 
     /// Returns an iterator of peers that can vote.
+    #[cfg(feature = "malice-detection")]
     pub fn voters(&self) -> impl Iterator<Item = (PeerIndex, &Peer<S::PublicId>)> {
         self.iter().filter(|(_, peer)| peer.state.can_vote())
     }
@@ -141,11 +142,6 @@ impl<S: SecretId> PeerList<S> {
     /// Returns an unsorted map of peer index => Hash(peer_id).
     pub fn all_id_hashes(&self) -> impl Iterator<Item = (PeerIndex, &Hash)> {
         self.iter().map(|(index, peer)| (index, peer.id_hash()))
-    }
-
-    /// Returns indices of the peers that can vote.
-    pub fn voter_indices<'a>(&'a self) -> impl Iterator<Item = PeerIndex> + 'a {
-        self.voters().map(|(index, _)| index)
     }
 
     pub fn peer_state(&self, index: PeerIndex) -> PeerState {
@@ -391,6 +387,13 @@ impl Builder {
 
         self.peer_list
     }
+}
+
+/// Type of change to the peer list
+#[derive(Clone, Copy)]
+pub(crate) enum PeerListChange {
+    Add(PeerIndex),
+    Remove(PeerIndex),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is simply #233 rebased on current master.

1. Try optimize the computation of observer. Before we calculated the set of "observees" for every event and then use it to determine if the event is observer. But we don't need to keep the observees around, we only need to know if the event is observer.
So we now compute the observer status right away and store the observees only if the event IS observer. This saves memory and might also improve performance a bit. I was also hoping to reuse the observer status in subsequent meta-elections, but that didn't work out.

2. Mostly refactoring to simplify how we calculate interesting content. This also improves the performance: Only calculate interesting content when creating new meta-event, not when reprocessing them. On membership-change, clear all meta-events first so we falls-back to recalculating everything.
Note: recalculate everything in this case also fixed a bug where we would sometimes invalidly reuse some meta-events after a membership change.

3. Tried to reuse the observer status from previous meta-election, but I think this change is reverted in later  commits because it didn't really work and/or make a difference.

4. Better graph dumps (not really related to the rest of the PR, but it simplified debugging some issues).

5. Main part of the PR: Now reprocess only from the first observer instead of from the first unconsensused event.