### PR TITLE
Scalability: is_interesting_payload

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.5.0"
 
 [dependencies]
 fnv = "~1.0.6"
+itertools = "~0.6.1"
 lazy_static = "~1.0.1"
 log = "~0.3.8"
 maidsafe_utilities = "~0.17.0"

--- a/src/gossip/mod.rs
+++ b/src/gossip/mod.rs
@@ -21,7 +21,7 @@ pub(super) use self::event::find_event_by_short_name;
 pub(super) use self::event::CauseInput;
 #[cfg(feature = "malice-detection")]
 pub(super) use self::event::LastAncestor;
-pub(super) use self::event::{Event, UnpackedEvent};
+pub(super) use self::event::{AbstractEvent, Event, UnpackedEvent};
 pub(super) use self::event_context::{EventContextMut, EventContextRef};
 pub use self::event_hash::EventHash;
 #[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,7 @@ mod meta_voting;
 mod network_event;
 mod observation;
 mod parsec;
+mod parsec_helpers;
 mod peer_list;
 mod round_hash;
 mod vote;

--- a/src/parsec_helpers.rs
+++ b/src/parsec_helpers.rs
@@ -30,6 +30,7 @@ where
         .filter_map(|event| {
             event
                 .payload_key()
+                .filter(|payload_key| !is_already_interesting_content(payload_key))
                 .map(|payload_key| {
                     (
                         event,
@@ -37,7 +38,6 @@ where
                     )
                 })
         })
-        .filter(|(_, payload_key, _)| !is_already_interesting_content(payload_key))
         .collect_vec();
 
     // Transform to `Vec<(PayloadKey, Vec<Event>)>` so we can process identical payload once.

--- a/src/parsec_helpers.rs
+++ b/src/parsec_helpers.rs
@@ -1,0 +1,323 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::gossip::AbstractEvent;
+use crate::observation::ObservationKey;
+use std::usize;
+
+/// Find interesting payloads for the builder_event.
+/// For payload observed from builder_event, order them by creation index.
+#[allow(unused_qualifications)]
+// E: std::convert::AsRef<E> both requiered and considered unused by 1.32
+pub(crate) fn find_interesting_content_for_event<'a, E>(
+    builder_event: &E,
+    unconsensused_events: impl Iterator<Item = &'a E>,
+    is_already_interesting_content: impl Fn(&ObservationKey) -> bool,
+    is_interesting_payload: impl Fn(&ObservationKey) -> bool,
+    has_interesting_ancestor: impl Fn(&ObservationKey) -> bool,
+) -> Vec<ObservationKey>
+where
+    E: 'a + AbstractEvent,
+    E: std::convert::AsRef<E>,
+{
+    let mut payloads: Vec<_> = unconsensused_events
+        .filter(|event| builder_event.sees(event))
+        .filter_map(|event| event.payload_key().map(|key| (event, key)))
+        .filter(|(_, payload_key)| !is_already_interesting_content(payload_key))
+        .filter(|(event, payload_key)| {
+            is_interesting_payload(payload_key)
+                || event.sees_fork() && has_interesting_ancestor(payload_key)
+        })
+        .map(|(event, payload_key)| {
+            (
+                if event.creator() == builder_event.creator() {
+                    event.index_by_creator()
+                } else {
+                    usize::MAX
+                },
+                payload_key,
+            )
+        })
+        .collect();
+
+    // First, remove duplicates (preferring payloads voted for by the creator)...
+    payloads.sort_by(|(l_index, l_key), (r_index, r_key)| (l_key, l_index).cmp(&(r_key, r_index)));
+    payloads.dedup_by(|(_, l_key), (_, r_key)| l_key == r_key);
+
+    // ...then sort the payloads in the order the creator voted for them, followed by the ones
+    // not voted for by the creator (if any).
+    payloads.sort();
+
+    payloads.into_iter().map(|(_, key)| key).cloned().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hash::Hash;
+    use crate::observation::{ConsensusMode, ObservationHash};
+    use crate::peer_list::PeerIndex;
+
+    lazy_static! {
+        /// Hashes for opaque events to use in tests.
+        static ref OPAQUE_HASHES: Vec<ObservationHash> =
+            (0..9).map(observation_hash_from_u8).collect();
+
+        /// Peer indexes to use in tests.
+        static ref PEER_IDS: Vec<PeerIndex> =
+            (0..9).map(PeerIndex::new_test_peer_index).collect();
+    }
+
+    /// Stand in stub for Event: Implement AbstractEvent.
+    #[derive(Debug, Clone)]
+    struct TestEvent {
+        peer_index: PeerIndex,
+        creator_index: usize,
+        payload_key: Option<ObservationKey>,
+        sees_others: bool,
+        sees_forks: bool,
+    }
+
+    impl TestEvent {
+        fn new(
+            peer_index: PeerIndex,
+            creator_index: usize,
+            payload_hash: Option<ObservationHash>,
+        ) -> Self {
+            Self {
+                peer_index,
+                creator_index,
+                payload_key: payload_hash.map(|hash| {
+                    ObservationKey::new(hash, peer_index, ConsensusMode::Supermajority)
+                }),
+                sees_others: false,
+                sees_forks: false,
+            }
+        }
+
+        fn with_sees_others(self) -> Self {
+            Self {
+                sees_others: true,
+                ..self
+            }
+        }
+
+        fn with_sees_forks(self) -> Self {
+            Self {
+                sees_forks: true,
+                ..self
+            }
+        }
+    }
+
+    impl AbstractEvent for TestEvent {
+        fn sees<E: AsRef<Self>>(&self, _other: E) -> bool {
+            self.sees_others
+        }
+
+        fn payload_key(&self) -> Option<&ObservationKey> {
+            self.payload_key.as_ref()
+        }
+
+        fn creator(&self) -> PeerIndex {
+            self.peer_index
+        }
+
+        fn sees_fork(&self) -> bool {
+            self.sees_forks
+        }
+
+        fn index_by_creator(&self) -> usize {
+            self.creator_index
+        }
+    }
+
+    impl AsRef<Self> for TestEvent {
+        fn as_ref(&self) -> &Self {
+            self
+        }
+    }
+
+    /// Observation key with readable assertion result and creation.
+    #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug)]
+    pub(crate) enum AssertObservationKey {
+        Single(u8, PeerIndex),
+        Supermajority(u8),
+    }
+
+    impl AssertObservationKey {
+        pub fn new_from_key(key: &ObservationKey, hashes: &[ObservationHash]) -> Self {
+            match *key {
+                ObservationKey::Single(ref hash, peer) => {
+                    AssertObservationKey::Single(find_observation_hash_index(hash, hashes), peer)
+                }
+                ObservationKey::Supermajority(ref hash) => {
+                    AssertObservationKey::Supermajority(find_observation_hash_index(hash, hashes))
+                }
+            }
+        }
+    }
+
+    fn observation_hash_from_u8(value: u8) -> ObservationHash {
+        ObservationHash(Hash::from(vec![value].as_slice()))
+    }
+
+    fn find_observation_hash_index(hash: &ObservationHash, hashes: &[ObservationHash]) -> u8 {
+        unwrap!(hashes.iter().position(|obs_hash| obs_hash == hash)) as u8
+    }
+
+    /// Tests for find_interesting_content_for_event.
+    mod find_interesting_content_for_event {
+        use super::*;
+        use AssertObservationKey::*;
+
+        /// Data driven test configuration for test_find_interesting_content_for_event
+        struct TestSimpleData {
+            /// Events setup used for test
+            events: Events,
+            /// Return values for injected closures
+            payload_properties: PayloadProperties,
+            /// Expected returned payloads
+            expected_payloads: Vec<AssertObservationKey>,
+        }
+
+        struct PayloadProperties {
+            is_already_interesting_content: bool,
+            is_interesting_payload: bool,
+            has_interesting_ancestor: bool,
+        }
+
+        struct Events {
+            builder_event: TestEvent,
+            unconsensused_events: Vec<TestEvent>,
+        }
+
+        impl Events {
+            fn with_builder_event_sees_other(self) -> Self {
+                Self {
+                    builder_event: self.builder_event.with_sees_others(),
+                    ..self
+                }
+            }
+
+            fn with_unconsensused_events_sees_forks(self) -> Self {
+                Self {
+                    unconsensused_events: self
+                        .unconsensused_events
+                        .into_iter()
+                        .map(|e| e.with_sees_forks())
+                        .collect(),
+                    ..self
+                }
+            }
+
+            /// A simple setup for Events that can be used in multiple tests.
+            fn new_basic_setup() -> Self {
+                let opaque_1 = Some(OPAQUE_HASHES[1]);
+                let opaque_2 = Some(OPAQUE_HASHES[2]);
+                let last_event_peer = PEER_IDS[6];
+
+                Self {
+                    builder_event: TestEvent::new(last_event_peer, 100, None),
+                    unconsensused_events: vec![
+                        TestEvent::new(PEER_IDS[2], 2, opaque_1),
+                        TestEvent::new(PEER_IDS[8], 11, opaque_1),
+                        TestEvent::new(last_event_peer, 6, opaque_1),
+                        TestEvent::new(last_event_peer, 10, opaque_2),
+                    ],
+                }
+            }
+        }
+
+        /// Test function for find_interesting_content_for_event
+        /// Call with different TestSimpleData for data driven tests
+        /// (Follows AAA(Arrange/Act/Assert) test Pattern)
+        fn test_find_interesting_content_for_event(data: TestSimpleData) {
+            let TestSimpleData {
+                events,
+                payload_properties,
+                expected_payloads,
+            } = data;
+
+            let payloads = find_interesting_content_for_event(
+                &events.builder_event,
+                events.unconsensused_events.iter(),
+                |_payload_key| payload_properties.is_already_interesting_content,
+                |_payload_key| payload_properties.is_interesting_payload,
+                |_payload_key| payload_properties.has_interesting_ancestor,
+            );
+
+            assert_eq!(
+                expected_payloads,
+                payloads
+                    .iter()
+                    .map(|key| AssertObservationKey::new_from_key(key, &OPAQUE_HASHES))
+                    .collect_vec()
+            );
+        }
+
+        #[test]
+        /// Basic happy path
+        fn all_payloads_interesting() {
+            test_find_interesting_content_for_event(TestSimpleData {
+                events: Events::new_basic_setup().with_builder_event_sees_other(),
+                payload_properties: PayloadProperties {
+                    is_already_interesting_content: false,
+                    is_interesting_payload: true,
+                    has_interesting_ancestor: false,
+                },
+                expected_payloads: vec![Supermajority(1), Supermajority(2)],
+            });
+        }
+
+        #[test]
+        /// Filter out already interesting payloads
+        fn all_payloads_already_interesting() {
+            test_find_interesting_content_for_event(TestSimpleData {
+                events: Events::new_basic_setup().with_builder_event_sees_other(),
+                payload_properties: PayloadProperties {
+                    is_already_interesting_content: true,
+                    is_interesting_payload: true,
+                    has_interesting_ancestor: false,
+                },
+                expected_payloads: vec![],
+            });
+        }
+
+        #[test]
+        /// Basic case where we found no interesting payloads
+        fn no_payloads_interesting() {
+            test_find_interesting_content_for_event(TestSimpleData {
+                events: Events::new_basic_setup().with_builder_event_sees_other(),
+                payload_properties: PayloadProperties {
+                    is_already_interesting_content: false,
+                    is_interesting_payload: false,
+                    has_interesting_ancestor: false,
+                },
+                expected_payloads: vec![],
+            });
+        }
+
+        #[test]
+        /// Handle forks: interesting payload if has_interesting_ancestor and
+        /// an event see a fork.
+        fn all_payloads_interesting_because_of_forks_and_ancestor() {
+            test_find_interesting_content_for_event(TestSimpleData {
+                events: Events::new_basic_setup()
+                    .with_builder_event_sees_other()
+                    .with_unconsensused_events_sees_forks(),
+                payload_properties: PayloadProperties {
+                    is_already_interesting_content: false,
+                    is_interesting_payload: false,
+                    has_interesting_ancestor: true,
+                },
+                expected_payloads: vec![Supermajority(1), Supermajority(2)],
+            });
+        }
+    }
+}

--- a/src/peer_list/peer_index.rs
+++ b/src/peer_list/peer_index.rs
@@ -16,6 +16,11 @@ pub(crate) struct PeerIndex(pub(super) usize);
 impl PeerIndex {
     /// `PeerIndex` of ourselves.
     pub const OUR: Self = PeerIndex(0);
+
+    #[cfg(any(test, feature = "testing"))]
+    pub fn new_test_peer_index(index: usize) -> Self {
+        Self(index)
+    }
 }
 
 /// Map keyed by `PeerIndex`.


### PR DESCRIPTION
When we have duplicate payloads in 'unconsensused_events' voted by different peers, only call is_interesting_payload on unique playloads.

This situation occurs with ConsensusMode::Supermajority, or for adding/removing peers where we can have 2/3*peer_count duplicate events.


Add tests to support changes:
-A bug was introduced in initial implementation, not caught by `cargo test` and was difficult to debug.
-Split testable free function in initial commit to ensure clear diff on this update without unit tests.
-This free function has its dependecy on Parsec injected as closure and use the new AbstractEvent trait so a light weight and easily configurable Event stub/mock can be used in tests.


Note on tests:

-Use AAA(Arrange/Act/Assert) test pattern for test function as it ensure test remain readable over time.
-Apply a data driven approach to the test: A single function is executed with different data providing the setup and expected outcome. (Generally, code would specify a collection of test cases and the testing framework would run all of them. Here, I adapted the pattern by having one test function per data calling a common sub-function as a simpler approach to avoid bringing dependency to this test for now.)
-I use a nested  module 'find_interesting_content_for_event' to define types and function only relevant for testing our new function. The types and functions more generally useful for parsec testing are defined in tests.


Performance results:
Over 50% for large test cases.
Small regression on very small test cases with very few peers (First 3 benchmarks).

minimal                 time:   [851.75 us 866.10 us 880.02 us]
                        change: [+2.7617% +5.1026% +7.2277%] (p = 0.00 < 0.05)
                        Performance has regressed.

static                  time:   [4.1517 ms 4.2511 ms 4.4013 ms]
                        change: [+1.8617% +5.0668% +8.7181%] (p = 0.01 < 0.05)
                        Performance has regressed.

dynamic                 time:   [2.8286 ms 2.9064 ms 2.9841 ms]
                        change: [+2.2913% +5.0127% +7.7377%] (p = 0.00 < 0.05)
                        Performance has regressed.

a_node4_opaque_evt16    time:   [3.0903 ms 3.1319 ms 3.2025 ms]
                        change: [-2.1895% -0.1052% +2.1168%] (p = 0.93 > 0.05)
                        No change in performance detected.

a_node8_opaque_evt16    time:   [12.695 ms 12.849 ms 13.192 ms]
                        change: [-37.835% -36.282% -34.501%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node12_opaque_evt16   time:   [95.981 ms 97.514 ms 98.197 ms]
                        change: [-36.983% -34.989% -32.622%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node16_opaque_evt16   time:   [229.51 ms 231.06 ms 232.88 ms]
                        change: [-37.909% -35.791% -34.382%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node24_opaque_evt16   time:   [840.21 ms 846.48 ms 853.49 ms]
                        change: [-50.129% -49.764% -49.390%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node32_opaque_evt16   time:   [2.1901 s 2.2141 s 2.2400 s]
                        change: [-54.058% -53.511% -52.926%] (p = 0.00 < 0.05)
                        Performance has improved.