### PR TITLE
refactor/parsec remove EventContextMut

### DIFF
--- a/src/gossip/event_context.rs
+++ b/src/gossip/event_context.rs
@@ -16,6 +16,7 @@ pub(crate) struct EventContextRef<'a, T: NetworkEvent, S: SecretId> {
     pub(crate) graph: &'a Graph<S::PublicId>,
     pub(crate) peer_list: &'a PeerList<S>,
     pub(crate) observations: &'a ObservationStore<T, S::PublicId>,
+    pub(crate) consensus_mode: ConsensusMode,
 }
 
 // `#[derive(Clone)]` doesn't work here for some reason...
@@ -25,16 +26,10 @@ impl<'a, T: NetworkEvent, S: SecretId> Clone for EventContextRef<'a, T, S> {
             graph: self.graph,
             peer_list: self.peer_list,
             observations: self.observations,
+            consensus_mode: self.consensus_mode,
         }
     }
 }
 
 // ...neither does `#[derive(Copy)]`.
 impl<'a, T: NetworkEvent, S: SecretId> Copy for EventContextRef<'a, T, S> {}
-
-pub(crate) struct EventContextMut<'a, T: NetworkEvent, S: SecretId> {
-    pub(crate) graph: &'a Graph<S::PublicId>,
-    pub(crate) peer_list: &'a PeerList<S>,
-    pub(crate) observations: &'a mut ObservationStore<T, S::PublicId>,
-    pub(crate) consensus_mode: ConsensusMode,
-}

--- a/src/gossip/mod.rs
+++ b/src/gossip/mod.rs
@@ -22,7 +22,7 @@ pub(super) use self::event::CauseInput;
 #[cfg(feature = "malice-detection")]
 pub(super) use self::event::LastAncestor;
 pub(super) use self::event::{AbstractEvent, Event, UnpackedEvent};
-pub(super) use self::event_context::{EventContextMut, EventContextRef};
+pub(super) use self::event_context::EventContextRef;
 pub use self::event_hash::EventHash;
 #[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
 pub(super) use self::graph::snapshot::GraphSnapshot;

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -243,6 +243,9 @@ impl<T: NetworkEvent, P: PublicId> ObservationInfo<T, P> {
 // Storage for observations
 pub(crate) type ObservationStore<T, P> = BTreeMap<ObservationKey, ObservationInfo<T, P>>;
 
+// Observation with corresponding key for ObservationStore
+pub(crate) type ObservationForStore<T, P> = Option<(ObservationKey, ObservationInfo<T, P>)>;
+
 // Key to compare observations.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub(crate) enum ObservationKey {


### PR DESCRIPTION
Refactor to simplify future work, particularly with performance.

In order to dump all events received on dump-graph, we may want to
unpack all events up-front. Using EventContextMut made it unclear whether it
was safe.

Also, observation is populated on unpack, but we may not add the event
to the graph in case of malice. This maybe something we want to change.

Test:
cargo test --features=testing,malice-detection