### PR TITLE
fix/parsec: ensure benchmarks reach same consensus as .dot file

### DIFF
--- a/src/dev_utils/record.rs
+++ b/src/dev_utils/record.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::dot_parser::{parse_dot_file, ParsedContents};
+use crate::gossip::IndexedEventRef;
 use crate::gossip::{Event, Request, Response};
 use crate::hash::Hash;
 use crate::mock::{PeerId, Transaction};
@@ -16,7 +17,6 @@ use crate::peer_list::PeerIndex;
 use std::collections::BTreeSet;
 use std::io;
 use std::path::Path;
-use crate::gossip::IndexedEventRef;
 
 /// Record of a Parsec session which consist of sequence of operations (`vote_for`, `handle_request`
 /// and `handle_response`). Can be produced from a previously dumped DOT file and after replaying,
@@ -187,9 +187,9 @@ impl From<ParsedContents> for Record {
         let (events_to_gossip, other_parent) = collect_remaining_event_to_gossip(&mut known);
         if let Some(other_parent) = other_parent {
             let src = unwrap!(contents
-                    .peer_list
-                    .get(other_parent.creator())
-                    .map(|peer| peer.id().clone()));
+                .peer_list
+                .get(other_parent.creator())
+                .map(|peer| peer.id().clone()));
             actions.push(Action::Request(src, Request::new(events_to_gossip)));
         }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -17,6 +17,8 @@ use crate::gossip::{
     Event, EventContextMut, EventContextRef, EventIndex, Graph, IndexedEventRef, PackedEvent,
     Request, Response, UnpackedEvent,
 };
+#[cfg(any(feature = "testing", all(test, feature = "mock")))]
+use crate::hash::Hash;
 use crate::id::{PublicId, SecretId};
 use crate::meta_voting::{MetaElection, MetaEvent, MetaEventBuilder, MetaVote, Step};
 #[cfg(any(feature = "testing", all(test, feature = "mock")))]
@@ -2188,6 +2190,15 @@ impl Parsec<Transaction, PeerId> {
         parsec.peer_list = parsed_contents.peer_list;
         parsec.observations = parsed_contents.observations;
         parsec
+    }
+
+    /// The consensus history hashes in order of consensus (for testing)
+    pub fn meta_election_consensus_history_hash(&self) -> Vec<Hash> {
+        self.meta_election
+            .consensus_history
+            .iter()
+            .map(|observation| observation.hash().0)
+            .collect()
     }
 }
 


### PR DESCRIPTION
The series of benchmark with different section size aims to provide
scalability information. This only work if they reach the same
consensus.

Consensus can be reached before the create_sync_event occurs.
In this case, the dot file replay needs to create a new request so all
the gossip event that were processed to reach the consensus are given.

This request could be considered as spam as it will send events from
multiple nodes that do not have a common parent.

cargo test
cargo bench --test (no pannic)

When there is a problem, the benchmark fails with:
"
thread 'main' panicked at 'assertion failed: `(left == right)`
left: `(9, [a9d4c41b69.., e2eabbc898.., d08b8bc951.., 2de98dadad..,
8df8111faf.., c93ff2cda7.., 536064db2b.., 9daa8f8e91..])`,
 right: `(1, [a9d4c41b69..])`', benches/bench.rs:141:17
"