### PR TITLE
Perf fix vote collection

### DIFF
--- a/src/meta_voting/meta_election.rs
+++ b/src/meta_voting/meta_election.rs
@@ -88,10 +88,15 @@ impl MetaElection {
         self.meta_events.get(&event_index)
     }
 
-    pub fn meta_votes(&self, event_index: EventIndex) -> Option<&PeerIndexMap<Vec<MetaVote>>> {
+    /// The event meta votes if available
+    pub fn populated_meta_votes(
+        &self,
+        event_index: EventIndex,
+    ) -> Option<&PeerIndexMap<Vec<MetaVote>>> {
         self.meta_events
             .get(&event_index)
             .map(|meta_event| &meta_event.meta_votes)
+            .filter(|meta_votes| !meta_votes.is_empty())
     }
 
     pub fn round_hashes(&self, peer_index: PeerIndex) -> Option<&Vec<RoundHash>> {

--- a/src/meta_voting/meta_vote.rs
+++ b/src/meta_voting/meta_vote.rs
@@ -74,7 +74,7 @@ impl Debug for MetaVote {
 impl MetaVote {
     pub fn new(
         initial_estimate: bool,
-        others: &[Vec<MetaVote>],
+        others: &[&[MetaVote]],
         total_peers: usize,
         is_voter: bool,
     ) -> Vec<Self> {
@@ -87,7 +87,7 @@ impl MetaVote {
 
     pub fn next(
         parent: &[MetaVote],
-        others: &[Vec<MetaVote>],
+        others: &[&[MetaVote]],
         coin_tosses: &BTreeMap<usize, bool>,
         total_peers: usize,
         is_voter: bool,
@@ -109,6 +109,10 @@ impl MetaVote {
             next.push(next_meta_vote);
         }
         next
+    }
+
+    pub fn round_and_step(&self) -> (usize, Step) {
+        (self.round, self.step)
     }
 
     fn update_meta_vote(
@@ -138,7 +142,7 @@ impl MetaVote {
 
     fn next_meta_vote(
         parent: Option<&MetaVote>,
-        others: &[Vec<MetaVote>],
+        others: &[&[MetaVote]],
         coin_tosses: &BTreeMap<usize, bool>,
         total_peers: usize,
         is_voter: bool,

--- a/src/meta_voting/meta_vote_counts.rs
+++ b/src/meta_voting/meta_vote_counts.rs
@@ -29,7 +29,7 @@ impl MetaVoteCounts {
     // meta vote, if `is_voter` is true.
     pub fn new(
         parent: &MetaVote,
-        others: &[Vec<MetaVote>],
+        others: &[&[MetaVote]],
         total_peers: usize,
         is_voter: bool,
     ) -> Self {
@@ -40,7 +40,7 @@ impl MetaVoteCounts {
             .filter_map(|other| {
                 other
                     .iter()
-                    .filter(|vote| vote.round == parent.round && vote.step == parent.step)
+                    .filter(|vote| vote.round_and_step() == parent.round_and_step())
                     .last()
             })
             .chain(if is_voter { Some(parent) } else { None })

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -1063,14 +1063,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         let parent_meta_votes = builder
             .event()
             .self_parent()
-            .and_then(|parent_hash| self.meta_election.meta_votes(parent_hash))
-            .and_then(|parent_meta_votes| {
-                if !parent_meta_votes.is_empty() {
-                    Some(parent_meta_votes)
-                } else {
-                    None
-                }
-            });
+            .and_then(|parent_hash| self.meta_election.populated_meta_votes(parent_hash));
 
         // If self-parent already has meta votes associated with it, derive this event's meta votes
         // from those ones.
@@ -1253,7 +1246,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             }
         };
         self.meta_election
-            .meta_votes(event_index)
+            .populated_meta_votes(event_index)
             .and_then(|meta_votes| meta_votes.get(event.creator()))
             .map_or(false, |event_votes| {
                 event_votes
@@ -1276,7 +1269,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         if fork_event.is_none() {
             // Not a fork
             if let Some(event) = event {
-                return self.meta_election.meta_votes(event);
+                return self.meta_election.populated_meta_votes(event);
             }
         }
         None
@@ -1329,7 +1322,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
     }
 
     fn compute_consensus(&self, event_index: EventIndex) -> Option<ObservationKey> {
-        let last_meta_votes = self.meta_election.meta_votes(event_index)?;
+        let last_meta_votes = self.meta_election.populated_meta_votes(event_index)?;
 
         let decided_meta_votes = last_meta_votes
             .iter()


### PR DESCRIPTION
Address performance issue related to set_meta_votes.

The first 2 commits apply smaller updates close to refactoring, but they do change behavior:
-First use references to vector instead of cloning the contents.
-Then: like for parent_meta_votes ignore empty meta_votes everywhere meta_votes was called: rename to populated_meta_votes

Finally Update code to avoid duplicate lookup highlighted by 'perf' and 'callgrind'
```
RUSTFLAGS=-g RUST_BACKTRACE=1 cargo bench --features=testing -- --baseline=master-da5b291

minimal                 time:   [726.91 us 744.71 us 764.01 us]
                        change: [-17.884% -14.460% -10.985%] (p = 0.00 < 0.05)
                        Performance has improved.

static                  time:   [3.7173 ms 3.7292 ms 3.7455 ms]
                        change: [-12.445% -12.002% -11.570%] (p = 0.00 < 0.05)
                        Performance has improved.

dynamic                 time:   [2.4579 ms 2.4616 ms 2.4669 ms]
                        change: [-9.6652% -8.6950% -7.4378%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node4_opaque_evt8     time:   [1.4799 ms 1.4824 ms 1.4860 ms]
                        change: [-9.7467% -8.8776% -7.9721%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node8_opaque_evt8     time:   [8.3695 ms 8.4027 ms 8.4609 ms]
                        change: [-25.324% -24.511% -23.396%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node12_opaque_evt8    time:   [31.629 ms 31.786 ms 31.915 ms]
                        change: [-32.982% -32.524% -32.065%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node16_opaque_evt8    time:   [59.365 ms 59.632 ms 59.896 ms]
                        change: [-38.843% -38.333% -37.779%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node24_opaque_evt8    time:   [207.65 ms 209.20 ms 210.63 ms]
                        change: [-44.275% -43.856% -43.450%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node32_opaque_evt8    time:   [683.51 ms 707.38 ms 732.72 ms]
                        change: [-53.254% -52.011% -50.657%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node4_opaque_evt16    time:   [2.9375 ms 3.0356 ms 3.1498 ms]
                        change: [-13.487% -8.0745% -2.7411%] (p = 0.02 < 0.05)
                        Performance has improved.

a_node8_opaque_evt16    time:   [21.749 ms 21.877 ms 22.117 ms]
                        change: [-26.768% -24.192% -21.836%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node12_opaque_evt16   time:   [70.469 ms 70.733 ms 71.084 ms]
                        change: [-33.807% -30.776% -28.163%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node16_opaque_evt16   time:   [166.09 ms 166.51 ms 166.89 ms]
                        change: [-35.255% -34.316% -33.516%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node24_opaque_evt16   time:   [540.04 ms 544.97 ms 552.49 ms]
                        change: [-36.192% -35.299% -34.419%] (p = 0.00 < 0.05)
                        Performance has improved.

a_node32_opaque_evt16   time:   [1.3376 s 1.3637 s 1.3879 s]
                        change: [-39.308% -38.306% -37.251%] (p = 0.00 < 0.05)
                        Performance has improved.
```