### PR TITLE
Travis stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,16 @@ before_script:
 jobs:
   include:
     - script: scripts/clippy
+      env: CACHE_NAME=clippylinux
       os: linux
     - script: scripts/clippy
+      env: CACHE_NAME=clippyosx
       os: osx
     - script: scripts/tests
+      env: CACHE_NAME=testslinux
       os: linux
     - script: scripts/tests
+      env: CACHE_NAME=testsosx
       os: osx
 before_cache:
  - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ env:
   global:
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
-os:
-  - linux
-  - osx
 language: rust
 rust:
   - stable
@@ -20,25 +17,13 @@ before_script:
   - rustup component add rustfmt clippy
 jobs:
   include:
-    - name: "clippy"
-      script:
-      - set -x -e;
-        cargo fmt -- --check
-        cargo clippy --verbose --all-targets
-        cargo clippy --verbose --all-targets --features=dump-graphs
-        cargo clippy --verbose --all-targets --features=testing
-        cargo clippy --verbose --all-targets --features=testing,malice-detection
-        cargo clippy --verbose --all-targets --features=dump-graphs,testing
-        cargo clippy --verbose --all-targets --features=dump-graphs,testing,malice-detection
-        cargo clippy --verbose --all-targets --features=mock
-        cargo clippy --verbose --all-targets --features=mock,dump-graphs
-        cargo clippy --verbose --all-targets --features=mock,dump-graphs,malice-detection
-        cargo clippy --verbose --manifest-path=dot_gen/Cargo.toml
-    - name: "tests"
-      script:
-      - set -x -e;
-        cargo test --verbose --release --features=testing
-        cargo test --verbose --release --features=testing,malice-detection
-        cargo test --verbose --release --features=dump-graphs dot_parser
+    - script: scripts/clippy
+      os: linux
+    - script: scripts/clippy
+      os: osx
+    - script: scripts/tests
+      os: linux
+    - script: scripts/tests
+      os: osx
 before_cache:
  - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,21 +18,27 @@ before_script:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune;
   - rustup component add rustfmt clippy
-script:
-  - set -x;
-    cargo fmt -- --check &&
-    cargo clippy --verbose --all-targets &&
-    cargo clippy --verbose --all-targets --features=dump-graphs &&
-    cargo clippy --verbose --all-targets --features=testing &&
-    cargo clippy --verbose --all-targets --features=testing,malice-detection &&
-    cargo clippy --verbose --all-targets --features=dump-graphs,testing &&
-    cargo clippy --verbose --all-targets --features=dump-graphs,testing,malice-detection &&
-    cargo clippy --verbose --all-targets --features=mock &&
-    cargo clippy --verbose --all-targets --features=mock,dump-graphs &&
-    cargo clippy --verbose --all-targets --features=mock,dump-graphs,malice-detection &&
-    cargo clippy --verbose --manifest-path=dot_gen/Cargo.toml &&
-    cargo test --verbose --release --features=testing &&
-    cargo test --verbose --release --features=testing,malice-detection &&
-    cargo test --verbose --release --features=dump-graphs dot_parser
+jobs:
+  include:
+    - name: "clippy"
+      script:
+      - set -x -e;
+        cargo fmt -- --check
+        cargo clippy --verbose --all-targets
+        cargo clippy --verbose --all-targets --features=dump-graphs
+        cargo clippy --verbose --all-targets --features=testing
+        cargo clippy --verbose --all-targets --features=testing,malice-detection
+        cargo clippy --verbose --all-targets --features=dump-graphs,testing
+        cargo clippy --verbose --all-targets --features=dump-graphs,testing,malice-detection
+        cargo clippy --verbose --all-targets --features=mock
+        cargo clippy --verbose --all-targets --features=mock,dump-graphs
+        cargo clippy --verbose --all-targets --features=mock,dump-graphs,malice-detection
+        cargo clippy --verbose --manifest-path=dot_gen/Cargo.toml
+    - name: "tests"
+      script:
+      - set -x -e;
+        cargo test --verbose --release --features=testing
+        cargo test --verbose --release --features=testing,malice-detection
+        cargo test --verbose --release --features=dump-graphs dot_parser
 before_cache:
  - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,16 @@ before_script:
 jobs:
   include:
     - script: scripts/clippy
-      env: CACHE_NAME=clippylinux
+      env: CACHE_NAME=clippy_linux
       os: linux
     - script: scripts/clippy
-      env: CACHE_NAME=clippyosx
+      env: CACHE_NAME=clippy_osx
       os: osx
     - script: scripts/tests
-      env: CACHE_NAME=testslinux
+      env: CACHE_NAME=tests_linux
       os: linux
     - script: scripts/tests
-      env: CACHE_NAME=testsosx
+      env: CACHE_NAME=tests_osx
       os: osx
 before_cache:
  - cargo prune

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e -x
+
+cargo fmt -- --check
+cargo clippy --verbose --all-targets
+cargo clippy --verbose --all-targets --features=dump-graphs
+cargo clippy --verbose --all-targets --features=testing
+cargo clippy --verbose --all-targets --features=testing,malice-detection
+cargo clippy --verbose --all-targets --features=dump-graphs,testing
+cargo clippy --verbose --all-targets --features=dump-graphs,testing,malice-detection
+cargo clippy --verbose --all-targets --features=mock
+cargo clippy --verbose --all-targets --features=mock,dump-graphs
+cargo clippy --verbose --all-targets --features=mock,dump-graphs,malice-detection
+cargo clippy --verbose --manifest-path=dot_gen/Cargo.toml

--- a/scripts/tests
+++ b/scripts/tests
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e -x
+
+cargo test --verbose --release --features=testing
+cargo test --verbose --release --features=testing,malice-detection
+cargo test --verbose --release --features=dump-graphs dot_parser


### PR DESCRIPTION
Hi Pierre/JP,

We don't actually need more than 1 stage for this. This setup runs 4 jobs in parallel:
* clippy commands on Linux
* clippy commands on OSX
* test commands on Linux
* test commands on OSX

Neither the test or clippy commands individually take long to run after compilation has been done, so it's not really worth separating them out into parallel jobs, since each parallel job spins up a fresh machine and would do re-compilation.

I think this is the best you would get out of Travis. Removing OSX clippy wouldn't save that much time since the tests take longer to run anyway, and the total time taken for this is whatever one of these 4 jobs takes the longest to run.

Cheers,

Chris