### PR TITLE
Dot files with generic peer ids

### DIFF
--- a/dot_gen/src/main.rs
+++ b/dot_gen/src/main.rs
@@ -187,6 +187,18 @@ fn main() {
         .file("Carol", "carol.dot");
 
     let _ = scenarios
+        .add("dev_utils::record::tests::smoke_other_peer_names", |env| {
+            let obs = ObservationSchedule {
+                genesis: peer_ids!("Annie", "Bill", "Claire", "Dan"),
+                schedule: vec![(0, Opaque(Transaction::new("1")))],
+            };
+
+            Schedule::from_observation_schedule(env, &ScheduleOptions::default(), obs)
+        })
+        .seed([1, 2, 3, 4])
+        .file("Annie", "annie.dot");
+
+    let _ = scenarios
         .add("benches", |env| {
             Schedule::new(
                 env,

--- a/input_graphs/dev_utils_record_tests_smoke_other_peer_names/annie.dot
+++ b/input_graphs/dev_utils_record_tests_smoke_other_peer_names/annie.dot
@@ -1,0 +1,1325 @@
+/// our_id: Annie
+/// peer_list: {
+///   Annie: PeerState(VOTE|SEND|RECV)
+///   Bill: PeerState(VOTE|SEND|RECV)
+///   Claire: PeerState(VOTE|SEND|RECV)
+///   Dan: PeerState(VOTE|SEND|RECV)
+/// }
+digraph GossipGraph {
+  splines=false
+  rankdir=BT
+
+  style=invis
+  subgraph cluster_Annie {
+    label="Annie"
+    "Annie" [style=invis]
+    "Annie" -> "A_0" [style=invis]
+    "A_0" -> "A_1" [minlen=1]
+    "A_1" -> "A_2" [minlen=1]
+    "A_2" -> "A_3" [minlen=1]
+    "A_3" -> "A_4" [minlen=1]
+    "A_4" -> "A_5" [minlen=4]
+    "A_5" -> "A_6" [minlen=2]
+    "A_6" -> "A_7" [minlen=2]
+    "A_7" -> "A_8" [minlen=1]
+    "A_8" -> "A_9" [minlen=1]
+    "A_9" -> "A_10" [minlen=2]
+    "A_10" -> "A_11" [minlen=6]
+    "A_11" -> "A_12" [minlen=1]
+    "A_12" -> "A_13" [minlen=1]
+    "A_13" -> "A_14" [minlen=2]
+    "A_14" -> "A_15" [minlen=2]
+    "A_15" -> "A_16" [minlen=2]
+    "A_16" -> "A_17" [minlen=2]
+    "A_17" -> "A_18" [minlen=3]
+    "A_18" -> "A_19" [minlen=5]
+    "A_19" -> "A_20" [minlen=1]
+    "A_20" -> "A_21" [minlen=1]
+  }
+  "B_1" -> "A_2" [constraint=false]
+  "C_2" -> "A_3" [constraint=false]
+  "D_1" -> "A_4" [constraint=false]
+  "D_4" -> "A_5" [constraint=false]
+  "D_6" -> "A_6" [constraint=false]
+  "C_5" -> "A_7" [constraint=false]
+  "D_7" -> "A_9" [constraint=false]
+  "C_8" -> "A_10" [constraint=false]
+  "C_10" -> "A_11" [constraint=false]
+  "B_10" -> "A_12" [constraint=false]
+  "C_10" -> "A_13" [constraint=false]
+  "D_14" -> "A_14" [constraint=false]
+  "B_14" -> "A_15" [constraint=false]
+  "B_15" -> "A_16" [constraint=false]
+  "D_18" -> "A_17" [constraint=false]
+  "D_20" -> "A_18" [constraint=false]
+  "C_17" -> "A_19" [constraint=false]
+  "D_23" -> "A_20" [constraint=false]
+  "D_23" -> "A_21" [constraint=false]
+
+  style=invis
+  subgraph cluster_Bill {
+    label="Bill"
+    "Bill" [style=invis]
+    "Bill" -> "B_0" [style=invis]
+    "B_0" -> "B_1" [minlen=1]
+    "B_1" -> "B_2" [minlen=2]
+    "B_2" -> "B_3" [minlen=2]
+    "B_3" -> "B_4" [minlen=4]
+    "B_4" -> "B_5" [minlen=1]
+    "B_5" -> "B_6" [minlen=4]
+    "B_6" -> "B_7" [minlen=1]
+    "B_7" -> "B_8" [minlen=3]
+    "B_8" -> "B_9" [minlen=1]
+    "B_9" -> "B_10" [minlen=1]
+    "B_10" -> "B_11" [minlen=1]
+    "B_11" -> "B_12" [minlen=1]
+    "B_12" -> "B_13" [minlen=4]
+    "B_13" -> "B_14" [minlen=1]
+    "B_14" -> "B_15" [minlen=2]
+    "B_15" -> "B_16" [minlen=1]
+    "B_16" -> "B_17" [minlen=3]
+    "B_17" -> "B_18" [minlen=10]
+  }
+  "A_2" -> "B_2" [constraint=false]
+  "C_4" -> "B_3" [constraint=false]
+  "D_5" -> "B_4" [constraint=false]
+  "C_7" -> "B_6" [constraint=false]
+  "D_8" -> "B_7" [constraint=false]
+  "D_10" -> "B_8" [constraint=false]
+  "C_7" -> "B_9" [constraint=false]
+  "A_9" -> "B_10" [constraint=false]
+  "D_10" -> "B_11" [constraint=false]
+  "D_10" -> "B_12" [constraint=false]
+  "D_14" -> "B_13" [constraint=false]
+  "D_14" -> "B_14" [constraint=false]
+  "A_15" -> "B_15" [constraint=false]
+  "A_15" -> "B_16" [constraint=false]
+  "C_15" -> "B_17" [constraint=false]
+  "A_21" -> "B_18" [constraint=false]
+
+  style=invis
+  subgraph cluster_Claire {
+    label="Claire"
+    "Claire" [style=invis]
+    "Claire" -> "C_0" [style=invis]
+    "C_0" -> "C_1" [minlen=1]
+    "C_1" -> "C_2" [minlen=1]
+    "C_2" -> "C_3" [minlen=1]
+    "C_3" -> "C_4" [minlen=1]
+    "C_4" -> "C_5" [minlen=7]
+    "C_5" -> "C_6" [minlen=1]
+    "C_6" -> "C_7" [minlen=1]
+    "C_7" -> "C_8" [minlen=2]
+    "C_8" -> "C_9" [minlen=5]
+    "C_9" -> "C_10" [minlen=1]
+    "C_10" -> "C_11" [minlen=2]
+    "C_11" -> "C_12" [minlen=2]
+    "C_12" -> "C_13" [minlen=4]
+    "C_13" -> "C_14" [minlen=1]
+    "C_14" -> "C_15" [minlen=2]
+    "C_15" -> "C_16" [minlen=6]
+    "C_16" -> "C_17" [minlen=1]
+  }
+  "A_1" -> "C_2" [constraint=false]
+  "D_1" -> "C_3" [constraint=false]
+  "B_2" -> "C_4" [constraint=false]
+  "A_6" -> "C_5" [constraint=false]
+  "B_4" -> "C_7" [constraint=false]
+  "A_9" -> "C_8" [constraint=false]
+  "B_9" -> "C_9" [constraint=false]
+  "A_10" -> "C_10" [constraint=false]
+  "D_11" -> "C_11" [constraint=false]
+  "A_13" -> "C_12" [constraint=false]
+  "D_16" -> "C_13" [constraint=false]
+  "D_17" -> "C_14" [constraint=false]
+  "D_18" -> "C_15" [constraint=false]
+  "D_22" -> "C_16" [constraint=false]
+  "B_17" -> "C_17" [constraint=false]
+
+  style=invis
+  subgraph cluster_Dan {
+    label="Dan"
+    "Dan" [style=invis]
+    "Dan" -> "D_0" [style=invis]
+    "D_0" -> "D_1" [minlen=1]
+    "D_1" -> "D_2" [minlen=4]
+    "D_2" -> "D_3" [minlen=1]
+    "D_3" -> "D_4" [minlen=1]
+    "D_4" -> "D_5" [minlen=1]
+    "D_5" -> "D_6" [minlen=1]
+    "D_6" -> "D_7" [minlen=2]
+    "D_7" -> "D_8" [minlen=1]
+    "D_8" -> "D_9" [minlen=4]
+    "D_9" -> "D_10" [minlen=1]
+    "D_10" -> "D_11" [minlen=5]
+    "D_11" -> "D_12" [minlen=1]
+    "D_12" -> "D_13" [minlen=1]
+    "D_13" -> "D_14" [minlen=1]
+    "D_14" -> "D_15" [minlen=2]
+    "D_15" -> "D_16" [minlen=1]
+    "D_16" -> "D_17" [minlen=1]
+    "D_17" -> "D_18" [minlen=2]
+    "D_18" -> "D_19" [minlen=2]
+    "D_19" -> "D_20" [minlen=1]
+    "D_20" -> "D_21" [minlen=2]
+    "D_21" -> "D_22" [minlen=1]
+    "D_22" -> "D_23" [minlen=1]
+  }
+  "A_4" -> "D_2" [constraint=false]
+  "C_3" -> "D_3" [constraint=false]
+  "A_4" -> "D_4" [constraint=false]
+  "B_2" -> "D_5" [constraint=false]
+  "A_5" -> "D_6" [constraint=false]
+  "A_6" -> "D_7" [constraint=false]
+  "B_7" -> "D_9" [constraint=false]
+  "B_7" -> "D_10" [constraint=false]
+  "C_10" -> "D_11" [constraint=false]
+  "B_11" -> "D_12" [constraint=false]
+  "B_12" -> "D_13" [constraint=false]
+  "A_13" -> "D_14" [constraint=false]
+  "B_13" -> "D_15" [constraint=false]
+  "C_12" -> "D_16" [constraint=false]
+  "B_14" -> "D_17" [constraint=false]
+  "C_14" -> "D_18" [constraint=false]
+  "A_17" -> "D_19" [constraint=false]
+  "C_15" -> "D_20" [constraint=false]
+  "A_18" -> "D_21" [constraint=false]
+  "C_15" -> "D_22" [constraint=false]
+  "A_18" -> "D_23" [constraint=false]
+
+  {
+    rank=same
+    "Annie" [style=filled, color=white]
+    "Bill" [style=filled, color=white]
+    "Claire" [style=filled, color=white]
+    "Dan" [style=filled, color=white]
+  }
+  "Annie" -> "Bill" -> "Claire" -> "Dan" [style=invis]
+
+/// ===== details of events =====
+  "A_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_0</td></tr>
+</table>>]
+/// cause: Initial
+/// last_ancestors: {Annie: 0}
+
+  "A_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_1</td></tr>
+<tr><td colspan="6">Genesis({Annie, Bill, Claire, Dan})</td></tr>
+</table>>]
+/// cause: Observation(Genesis({Annie, Bill, Claire, Dan}))
+/// last_ancestors: {Annie: 1}
+
+  "A_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_2</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 2, Bill: 1}
+
+  "A_3" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_3</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 3, Bill: 1, Claire: 2}
+
+  "A_4" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_4</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 4, Bill: 1, Claire: 2, Dan: 1}
+
+  "A_5" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_5</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 5, Bill: 1, Claire: 3, Dan: 4}
+
+  "A_6" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_6</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 6, Bill: 2, Claire: 3, Dan: 6}
+
+  "A_7" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_7</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 7, Bill: 2, Claire: 5, Dan: 6}
+
+  "A_8" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_8</td></tr>
+<tr><td colspan="6">OpaquePayload(1)</td></tr>
+</table>>]
+/// cause: Observation(OpaquePayload(1))
+/// last_ancestors: {Annie: 8, Bill: 2, Claire: 5, Dan: 6}
+
+  "A_9" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_9</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 9, Bill: 2, Claire: 5, Dan: 7}
+
+  "A_10" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_10</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 10, Bill: 4, Claire: 8, Dan: 7}
+
+  "A_11" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_11</td></tr>
+<tr><td colspan="6">[OpaquePayload(1)]</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 11, Bill: 9, Claire: 10, Dan: 10}
+
+  "A_12" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_12</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 12, Bill: 10, Claire: 10, Dan: 10}
+
+  "A_13" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_13</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 13, Bill: 10, Claire: 10, Dan: 10}
+
+  "A_14" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_14</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 14, Bill: 12, Claire: 10, Dan: 14}
+
+  "A_15" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_15</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 15, Bill: 14, Claire: 10, Dan: 14}
+
+  "A_16" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_16</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 16, Bill: 15, Claire: 10, Dan: 14}
+
+  "A_17" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_17</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 17, Bill: 15, Claire: 14, Dan: 18}
+
+  "A_18" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_18</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 18, Bill: 15, Claire: 15, Dan: 20}
+
+  "A_19" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_19</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 19, Bill: 17, Claire: 17, Dan: 22}
+
+  "A_20" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_20</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 20, Bill: 17, Claire: 17, Dan: 23}
+
+  "A_21" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_21</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 21, Bill: 17, Claire: 17, Dan: 23}
+
+  "B_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_0</td></tr>
+</table>>]
+/// cause: Initial
+/// last_ancestors: {Bill: 0}
+
+  "B_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_1</td></tr>
+<tr><td colspan="6">Genesis({Annie, Bill, Claire, Dan})</td></tr>
+</table>>]
+/// cause: Observation(Genesis({Annie, Bill, Claire, Dan}))
+/// last_ancestors: {Bill: 1}
+
+  "B_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_2</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 2, Bill: 2}
+
+  "B_3" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_3</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 2, Bill: 3, Claire: 4, Dan: 1}
+
+  "B_4" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_4</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 4, Bill: 4, Claire: 4, Dan: 5}
+
+  "B_5" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_5</td></tr>
+<tr><td colspan="6">OpaquePayload(1)</td></tr>
+</table>>]
+/// cause: Observation(OpaquePayload(1))
+/// last_ancestors: {Annie: 4, Bill: 5, Claire: 4, Dan: 5}
+
+  "B_6" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_6</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 6, Bill: 6, Claire: 7, Dan: 6}
+
+  "B_7" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_7</td></tr>
+<tr><td colspan="6">[OpaquePayload(1)]</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 6, Bill: 7, Claire: 7, Dan: 8}
+
+  "B_8" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_8</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 6, Bill: 8, Claire: 7, Dan: 10}
+
+  "B_9" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_9</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 6, Bill: 9, Claire: 7, Dan: 10}
+
+  "B_10" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_10</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 9, Bill: 10, Claire: 7, Dan: 10}
+
+  "B_11" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_11</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 9, Bill: 11, Claire: 7, Dan: 10}
+
+  "B_12" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_12</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 9, Bill: 12, Claire: 7, Dan: 10}
+
+  "B_13" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_13</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 13, Bill: 13, Claire: 10, Dan: 14}
+
+  "B_14" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_14</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 13, Bill: 14, Claire: 10, Dan: 14}
+
+  "B_15" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_15</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 15, Bill: 15, Claire: 10, Dan: 14}
+
+  "B_16" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_16</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 15, Bill: 16, Claire: 10, Dan: 14}
+
+  "B_17" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_17</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 15, Bill: 17, Claire: 15, Dan: 18}
+
+  "B_18" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_18</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>b</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>f</td><td>f</td><td>f</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 21, Bill: 18, Claire: 17, Dan: 23}
+
+  "C_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_0</td></tr>
+</table>>]
+/// cause: Initial
+/// last_ancestors: {Claire: 0}
+
+  "C_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_1</td></tr>
+<tr><td colspan="6">Genesis({Annie, Bill, Claire, Dan})</td></tr>
+</table>>]
+/// cause: Observation(Genesis({Annie, Bill, Claire, Dan}))
+/// last_ancestors: {Claire: 1}
+
+  "C_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_2</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 1, Claire: 2}
+
+  "C_3" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_3</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 1, Claire: 3, Dan: 1}
+
+  "C_4" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_4</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 2, Bill: 2, Claire: 4, Dan: 1}
+
+  "C_5" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_5</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 6, Bill: 2, Claire: 5, Dan: 6}
+
+  "C_6" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_6</td></tr>
+<tr><td colspan="6">OpaquePayload(1)</td></tr>
+</table>>]
+/// cause: Observation(OpaquePayload(1))
+/// last_ancestors: {Annie: 6, Bill: 2, Claire: 6, Dan: 6}
+
+  "C_7" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_7</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 6, Bill: 4, Claire: 7, Dan: 6}
+
+  "C_8" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_8</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 9, Bill: 4, Claire: 8, Dan: 7}
+
+  "C_9" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_9</td></tr>
+<tr><td colspan="6">[OpaquePayload(1)]</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 9, Bill: 9, Claire: 9, Dan: 10}
+
+  "C_10" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_10</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 10, Bill: 9, Claire: 10, Dan: 10}
+
+  "C_11" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_11</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 10, Bill: 9, Claire: 11, Dan: 11}
+
+  "C_12" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_12</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 13, Bill: 10, Claire: 12, Dan: 11}
+
+  "C_13" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_13</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 13, Bill: 13, Claire: 13, Dan: 16}
+
+  "C_14" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_14</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 13, Bill: 14, Claire: 14, Dan: 17}
+
+  "C_15" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_15</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 13, Bill: 14, Claire: 15, Dan: 18}
+
+  "C_16" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_16</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 18, Bill: 15, Claire: 16, Dan: 22}
+
+  "C_17" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_17</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 18, Bill: 17, Claire: 17, Dan: 22}
+
+  "D_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_0</td></tr>
+</table>>]
+/// cause: Initial
+/// last_ancestors: {Dan: 0}
+
+  "D_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_1</td></tr>
+<tr><td colspan="6">Genesis({Annie, Bill, Claire, Dan})</td></tr>
+</table>>]
+/// cause: Observation(Genesis({Annie, Bill, Claire, Dan}))
+/// last_ancestors: {Dan: 1}
+
+  "D_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_2</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 4, Bill: 1, Claire: 2, Dan: 2}
+
+  "D_3" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_3</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 4, Bill: 1, Claire: 3, Dan: 3}
+
+  "D_4" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_4</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 4, Bill: 1, Claire: 3, Dan: 4}
+
+  "D_5" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_5</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 4, Bill: 2, Claire: 3, Dan: 5}
+
+  "D_6" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_6</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 5, Bill: 2, Claire: 3, Dan: 6}
+
+  "D_7" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_7</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 6, Bill: 2, Claire: 3, Dan: 7}
+
+  "D_8" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_8</td></tr>
+<tr><td colspan="6">OpaquePayload(1)</td></tr>
+</table>>]
+/// cause: Observation(OpaquePayload(1))
+/// last_ancestors: {Annie: 6, Bill: 2, Claire: 3, Dan: 8}
+
+  "D_9" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_9</td></tr>
+<tr><td colspan="6">[OpaquePayload(1)]</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 6, Bill: 7, Claire: 7, Dan: 9}
+
+  "D_10" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_10</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 6, Bill: 7, Claire: 7, Dan: 10}
+
+  "D_11" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_11</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 10, Bill: 9, Claire: 10, Dan: 11}
+
+  "D_12" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_12</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 10, Bill: 11, Claire: 10, Dan: 12}
+
+  "D_13" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_13</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 10, Bill: 12, Claire: 10, Dan: 13}
+
+  "D_14" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_14</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 13, Bill: 12, Claire: 10, Dan: 14}
+
+  "D_15" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_15</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 13, Bill: 13, Claire: 10, Dan: 15}
+
+  "D_16" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_16</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 13, Bill: 13, Claire: 12, Dan: 16}
+
+  "D_17" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_17</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 13, Bill: 14, Claire: 12, Dan: 17}
+
+  "D_18" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_18</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 13, Bill: 14, Claire: 14, Dan: 18}
+
+  "D_19" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_19</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 17, Bill: 15, Claire: 14, Dan: 19}
+
+  "D_20" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_20</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 17, Bill: 15, Claire: 15, Dan: 20}
+
+  "D_21" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_21</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Annie: 18, Bill: 15, Claire: 15, Dan: 21}
+
+  "D_22" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_22</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 18, Bill: 15, Claire: 15, Dan: 22}
+
+  "D_23" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_23</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>f</td><td>f</td><td>f</td><td>-</td></tr>
+<tr><td>   </td><td>0/1</td><td>f</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>D: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Annie: 18, Bill: 15, Claire: 15, Dan: 23}
+
+}
+
+/// ===== meta-elections =====
+/// consensus_history:
+/// d9dd1b5706ef0431e6517996127be2adbc7d367f09f653ea97e92798255481af
+
+/// round_hashes: {
+///   Annie -> [
+///     RoundHash { round: 0, latest_block_hash: d9dd1b5706ef0431e6517996127be2adbc7d367f09f653ea97e92798255481af }
+///   ]
+///   Bill -> [
+///     RoundHash { round: 0, latest_block_hash: d9dd1b5706ef0431e6517996127be2adbc7d367f09f653ea97e92798255481af }
+///   ]
+///   Claire -> [
+///     RoundHash { round: 0, latest_block_hash: d9dd1b5706ef0431e6517996127be2adbc7d367f09f653ea97e92798255481af }
+///   ]
+///   Dan -> [
+///     RoundHash { round: 0, latest_block_hash: d9dd1b5706ef0431e6517996127be2adbc7d367f09f653ea97e92798255481af }
+///   ]
+/// }
+/// interesting_events: {
+///   Annie -> ["A_11"]
+///   Bill -> ["B_7"]
+///   Claire -> ["C_9"]
+///   Dan -> ["D_9"]
+/// }
+/// all_voters: {Annie, Bill, Claire, Dan}
+/// unconsensused_events: {"A_8", "B_5", "C_6", "D_8"}
+/// meta_events: {
+///   A_8 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   A_9 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   A_10 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   A_11 -> {
+///     observees: {Bill, Dan}
+///     interesting_content: [OpaquePayload(1)]
+///   }
+///   A_12 -> {
+///     observees: {Bill, Dan}
+///     interesting_content: []
+///   }
+///   A_13 -> {
+///     observees: {Bill, Dan}
+///     interesting_content: []
+///   }
+///   A_14 -> {
+///     observees: {Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///       D: 0/0   t   -   -   - 
+///     }
+///   }
+///   A_15 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   -   -   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   t   t   t   - 
+///       D: 0/0   t   t   t   - 
+///     }
+///   }
+///   A_16 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   t   t   t   - 
+///       D: 0/0   t   t   t   - 
+///     }
+///   }
+///   A_17 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   A_18 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///          0/1   f   -   -   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   A_19 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///          0/1   f   f   f   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   A_20 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///          0/1   f   f   f   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   A_21 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///          0/1   f   f   f   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   B_3 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   B_4 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   B_5 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   B_6 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   B_7 -> {
+///     observees: {}
+///     interesting_content: [OpaquePayload(1)]
+///   }
+///   B_8 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   B_9 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   B_10 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   B_11 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   B_12 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   B_13 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///       D: 0/0   t   -   -   - 
+///     }
+///   }
+///   B_14 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///       D: 0/0   t   -   -   - 
+///     }
+///   }
+///   B_15 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   b   f   f   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   t   t   t   - 
+///       D: 0/0   t   t   t   - 
+///     }
+///   }
+///   B_16 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   b   f   f   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   t   t   t   - 
+///       D: 0/0   t   t   t   - 
+///     }
+///   }
+///   B_17 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   b   f   f   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   B_18 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   b   f   f   - 
+///          0/1   f   f   f   f 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   C_6 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   C_7 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   C_8 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   C_9 -> {
+///     observees: {Bill, Dan}
+///     interesting_content: [OpaquePayload(1)]
+///   }
+///   C_10 -> {
+///     observees: {Bill, Dan}
+///     interesting_content: []
+///   }
+///   C_11 -> {
+///     observees: {Bill, Dan}
+///     interesting_content: []
+///   }
+///   C_12 -> {
+///     observees: {Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///       D: 0/0   t   -   -   - 
+///     }
+///   }
+///   C_13 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   -   -   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   t   t   t   - 
+///       D: 0/0   t   t   t   - 
+///     }
+///   }
+///   C_14 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   -   -   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   t   t   t   - 
+///       D: 0/0   t   t   t   - 
+///     }
+///   }
+///   C_15 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   -   -   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   t   t   t   - 
+///       D: 0/0   t   t   t   - 
+///     }
+///   }
+///   C_16 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///          0/1   f   f   f   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   C_17 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///          0/1   f   f   f   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   D_7 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   D_8 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   D_9 -> {
+///     observees: {}
+///     interesting_content: [OpaquePayload(1)]
+///   }
+///   D_10 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   D_11 -> {
+///     observees: {Bill, Dan}
+///     interesting_content: []
+///   }
+///   D_12 -> {
+///     observees: {Bill, Dan}
+///     interesting_content: []
+///   }
+///   D_13 -> {
+///     observees: {Bill, Dan}
+///     interesting_content: []
+///   }
+///   D_14 -> {
+///     observees: {Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///       D: 0/0   t   -   -   - 
+///     }
+///   }
+///   D_15 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///       D: 0/0   t   -   -   - 
+///     }
+///   }
+///   D_16 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   -   -   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   t   t   t   - 
+///       D: 0/0   t   t   t   - 
+///     }
+///   }
+///   D_17 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   -   -   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   t   t   t   - 
+///       D: 0/0   t   t   t   - 
+///     }
+///   }
+///   D_18 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   -   -   - 
+///       B: 0/0   t   t   t   - 
+///       C: 0/0   t   t   t   - 
+///       D: 0/0   t   t   t   - 
+///     }
+///   }
+///   D_19 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///          0/1   f   -   -   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   D_20 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///          0/1   f   -   -   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   D_21 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///          0/1   f   -   -   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   D_22 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///          0/1   f   -   -   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+///   D_23 -> {
+///     observees: {Annie, Bill, Claire, Dan}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   f   f   f   - 
+///          0/1   f   -   -   - 
+///       B: 0/0   t   t   t   t 
+///       C: 0/0   t   t   t   t 
+///       D: 0/0   t   t   t   t 
+///     }
+///   }
+/// }

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -766,7 +766,8 @@ impl ParsedContents {
 
 /// Read a dumped dot file and return with parsed event graph and associated info.
 pub(crate) fn parse_dot_file<P: AsRef<Path>>(full_path: P) -> io::Result<ParsedContents> {
-    let result = unwrap!(read(File::open(full_path)?));
+    let name: Option<String> = full_path.as_ref().to_str().map(|s| s.to_string());
+    let result = unwrap!(read(File::open(full_path)?), "Failed to read {:?}", name);
     Ok(convert_into_parsed_contents(result))
 }
 

--- a/src/gossip/graph/mod.rs
+++ b/src/gossip/graph/mod.rs
@@ -222,11 +222,22 @@ pub(crate) mod snapshot {
     /// Snapshot of the graph. Two snapshots compare as equal if the graphs had the same events
     /// modulo their insertion order.
     #[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
-    pub(crate) struct GraphSnapshot(BTreeSet<EventHash>);
+    pub(crate) struct GraphSnapshot(pub BTreeSet<EventHash>);
 
     impl GraphSnapshot {
         pub fn new<P: PublicId>(graph: &Graph<P>) -> Self {
-            GraphSnapshot(graph.iter().map(|event| *event.hash()).collect())
+            Self::new_with_ignore(graph, 0)
+        }
+
+        /// Generate a snapshot without the last `ignore_last_events` events
+        pub fn new_with_ignore<P: PublicId>(graph: &Graph<P>, ignore_last_events: usize) -> Self {
+            GraphSnapshot(
+                graph
+                    .iter()
+                    .map(|event| *event.hash())
+                    .take(graph.len() - ignore_last_events)
+                    .collect(),
+            )
         }
     }
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -34,6 +34,11 @@ impl Hash {
     pub fn from_bytes(bytes: [u8; HASH_LEN]) -> Self {
         Hash(bytes)
     }
+
+    #[cfg(feature = "mock")]
+    pub fn as_bytes(&self) -> &[u8; HASH_LEN] {
+        &self.0
+    }
 }
 
 impl<'a> From<&'a [u8]> for Hash {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ extern crate maidsafe_utilities;
 extern crate proptest as proptest_crate;
 #[macro_use]
 extern crate serde_derive;
-#[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
+#[cfg(any(test, feature = "mock", feature = "testing", feature = "dump-graphs"))]
 #[macro_use]
 extern crate unwrap;
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -13,6 +13,8 @@ use crate::dump_graph;
 use crate::error::{Error, Result};
 #[cfg(all(test, feature = "mock"))]
 use crate::gossip::EventHash;
+#[cfg(all(test, feature = "testing"))]
+use crate::gossip::GraphSnapshot;
 use crate::gossip::{
     Event, EventContextRef, EventIndex, Graph, IndexedEventRef, PackedEvent, Request, Response,
     UnpackedEvent,
@@ -2373,13 +2375,11 @@ impl<T: NetworkEvent, S: SecretId> DerefMut for TestParsec<T, S> {
     }
 }
 
-/// Assert that the two parsec instances have the same events modulo their insertion order.
+/// Get the parsec graph snapshot with inserted events out of order.
 #[cfg(all(test, feature = "testing"))]
-pub(crate) fn assert_same_events<T: NetworkEvent, S: SecretId>(a: &Parsec<T, S>, b: &Parsec<T, S>) {
-    use crate::gossip::GraphSnapshot;
-
-    let a = GraphSnapshot::new(&a.graph);
-    let b = GraphSnapshot::new(&b.graph);
-
-    assert_eq!(a, b)
+pub(crate) fn get_graph_snapshot<T: NetworkEvent, S: SecretId>(
+    parsec: &Parsec<T, S>,
+    ignore_last_events: usize,
+) -> GraphSnapshot {
+    GraphSnapshot::new_with_ignore(&parsec.graph, ignore_last_events)
 }


### PR DESCRIPTION
Allow replay dump graphs that contain peer Ids not in our list of hard coded names.
It is the initial step in replaying dump graph from routing tests, but does not handle peer ids with the same initial (multi-char short name), or non alpha numerical characters yet(id sanitizing).

Add smoke test to support this current and future development.
Note: .dot file does not contain everything, so we need to ignore some things in our comparison:
- consensus history: the .dot file does not contain the last consensused block as the dump occurs before it is added to the history
- The graph of events may contain a fake request that send us the remaining gossip events if the dump graph was produced on a gossip event that was not ours (consensus when processing another peer gossip event). 