### PR TITLE
fix/integration_tests: avoid adding peers too aggressively

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -219,7 +219,7 @@ fn random_schedule_no_delays() {
 fn add_many_peers() {
     let mut env = Environment::new(SEED);
     let options = ScheduleOptions {
-        genesis_size: 2,
+        genesis_size: 3,
         peers_to_add: 8,
         opaque_to_add: 0,
         ..Default::default()
@@ -259,7 +259,7 @@ fn add_few_peers_and_vote() {
 fn add_many_peers_and_vote() {
     let mut env = Environment::new(SEED);
     let options = ScheduleOptions {
-        genesis_size: 2,
+        genesis_size: 3,
         peers_to_add: 8,
         opaque_to_add: 10,
         ..Default::default()


### PR DESCRIPTION
This resolves an issue in the test framework where we would add many peers in a short period, and then start dropping the existing ones as the new ones are voted in.  When that happened, a new peer could end up not receiving gossip from any of the peers with which it was initialised, and would hence be stalled as it wouldn't accept messages from any of the new peers.

This commit changes the test framework to only allow the addition and voting for addition of new peers if that would retain a supermajority of "Joined" peers out of "Joined and Joining" ones.  When this is not the case, addition and voting is postponed, not cancelled.