### PR TITLE
fix/parsec: create own events only when we become voter

### DIFF
--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -79,11 +79,8 @@ fn from_existing() {
     // Existing section + us
     assert_eq!(parsec.peer_list().all_ids().count(), peers.len() + 1);
 
-    // Only the initial event should be in the gossip graph.
-    assert_eq!(parsec.graph().len(), 1);
-    let event = nth_event(parsec.graph(), 0);
-    assert_eq!(*parsec.event_creator_id(&event), our_id);
-    assert!(event.is_initial());
+    // The gossip graph should be initially empty.
+    assert_eq!(parsec.graph().len(), 0);
 }
 
 // TODO: remove this `cfg` once the `maidsafe_utilities` crate with PR 130 is published.
@@ -222,7 +219,7 @@ fn add_peer() {
     // Now add D_18, which should result in Alice adding Fred.
     let d_18_hash = *d_18.hash();
     unwrap!(alice.add_event(d_18));
-    unwrap!(alice.create_sync_event(&dave_id, true, &PeerIndexSet::default(), Some(d_18_hash)));
+    unwrap!(alice.create_sync_event(&dave_id, true, PeerIndexSet::default(), Some(d_18_hash)));
     assert!(alice
         .peer_list()
         .all_ids()

--- a/src/peer_list/mod.rs
+++ b/src/peer_list/mod.rs
@@ -281,11 +281,6 @@ impl<S: SecretId> PeerList<S> {
     }
 
     /// Indices of events of the given creator, in insertion order.
-    #[cfg(any(
-        all(test, feature = "mock"),
-        feature = "dump-graphs",
-        feature = "malice-detection"
-    ))]
     pub fn peer_events<'a>(
         &'a self,
         peer_index: PeerIndex,
@@ -296,7 +291,6 @@ impl<S: SecretId> PeerList<S> {
     }
 
     /// Hashes of our events in insertion order.
-    #[cfg(any(all(test, feature = "mock"), feature = "malice-detection"))]
     pub fn our_events<'a>(&'a self) -> impl DoubleEndedIterator<Item = EventIndex> + 'a {
         self.peer_events(PeerIndex::OUR)
     }

--- a/src/peer_list/peer.rs
+++ b/src/peer_list/peer.rs
@@ -11,7 +11,11 @@ use crate::gossip::{EventIndex, IndexedEventRef};
 use crate::hash::Hash;
 use crate::id::PublicId;
 use crate::serialise;
-use std::iter::{self, FromIterator};
+use itertools::Itertools;
+use std::{
+    fmt::{self, Debug, Formatter},
+    iter::{self, FromIterator},
+};
 
 #[derive(Debug)]
 pub(crate) struct Peer<P: PublicId> {
@@ -152,7 +156,6 @@ where
     }
 }
 
-#[derive(Debug)]
 struct Slot {
     first: EventIndex,
     rest: Vec<EventIndex>,
@@ -172,5 +175,11 @@ impl Slot {
 
     fn iter<'a>(&'a self) -> impl DoubleEndedIterator<Item = EventIndex> + 'a {
         iter::once(self.first).chain(self.rest.iter().cloned())
+    }
+}
+
+impl Debug for Slot {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.iter().format(", "))
     }
 }


### PR DESCRIPTION
This PR fixes the following issue:

1. Node (A) is removed from the section
2. New node (B) joins and recieves a gossip message from someone
3. The events in the gossip message might be ordered so that an event from A is before an event which triggers the consensus to add A (*)
4. But B doesn't yet know A, so it reject that event and return error, never processing the rest of the gossip message
5. This might sometimes prevent consensus to be reached and make the section disfunctional

The fix is to make sure that any event from A always comes after the event which triggers the consensus on add A. This is achieved by postponing inserting our events into the graph until we become voter - that is - we are either genesis node or we have observed consensus on adding ourselves.

(*) This is because the initial event and the event which triggered the consensus are neither ancestor nor descendant of each other, so they can be ordered in arbitrarily.