### PR TITLE
fix/bench: workaround criterion bug

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -162,7 +162,7 @@ fn bench_dot_file(
     name: &'static str,
     consensus_mode: ConsensusMode,
 ) {
-    let test_name = format!("{}::{}", group_name, name);
+    let test_name = format!("{} - {}", name, group_name);
     let _ = c.bench_function(&test_name, move |b| {
         let record = {
             let mut record = unwrap!(Record::parse(format!(


### PR DESCRIPTION
Criterion is truncating the benchmark names to 64 characters and
confusing baselines for tests that start with the same long sequence of
characters.

See https://github.com/bheisler/criterion.rs/issues/272

Work around this bug by putting the test name (most significant letters
of the benchmark) first.