### PR TITLE
Meta election perf

### DIFF
--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -764,7 +764,7 @@ mod detail {
 
             let interesting_events =
                 self.convert_peer_index_map(&self.meta_election.interesting_events);
-            for (peer, events) in interesting_events {
+            for (peer, (events, _)) in &interesting_events {
                 let event_names: Vec<String> = events
                     .iter()
                     .filter_map(|index| self.index_to_short_name(*index))

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -792,6 +792,7 @@ mod detail {
             let unconsensused_events: BTreeSet<_> = self
                 .meta_election
                 .unconsensused_events
+                .ordered_indices
                 .iter()
                 .filter_map(|index| self.index_to_short_name(*index))
                 .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,6 @@
     clippy::new_ret_no_self
 )]
 
-#[cfg(any(test, feature = "dump-graphs", feature = "mock"))]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]

--- a/src/meta_voting/mod.rs
+++ b/src/meta_voting/mod.rs
@@ -17,5 +17,7 @@ pub(crate) use self::bool_set::BoolSet;
 #[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
 pub(crate) use self::meta_election::snapshot::MetaElectionSnapshot;
 pub(crate) use self::meta_election::MetaElection;
+#[cfg(any(test, feature = "testing"))]
+pub(crate) use self::meta_election::UnconsensusedEvents;
 pub(crate) use self::meta_event::{MetaEvent, MetaEventBuilder, Observer};
 pub(crate) use self::meta_vote::{MetaVote, Step};

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -235,7 +235,7 @@ pub(crate) type ObservationStore<T, P> = BTreeMap<ObservationKey, ObservationInf
 pub(crate) type ObservationForStore<T, P> = Option<(ObservationKey, ObservationInfo<T, P>)>;
 
 // Key to compare observations.
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(crate) enum ObservationKey {
     Single(ObservationHash, PeerIndex),
     Supermajority(ObservationHash),

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -1319,13 +1319,13 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
                     .iter()
                     .map(|event| event.inner())
                     .filter(|event| voters.contains(event.creator()))
+                    .filter(|event| event.payload_key() == Some(payload_key))
                     .filter_map(|event| {
                         let (vote, key) = event.vote_and_payload_key(&self.observations)?;
                         let creator_id =
                             self.peer_list.get(event.creator()).map(|peer| peer.id())?;
                         Some((key, vote, creator_id))
                     })
-                    .filter(|(key, _, _)| payload_key == key)
                     .map(|(_, vote, creator_id)| (creator_id.clone(), vote.clone()))
                     .collect();
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -584,23 +584,26 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             return Err(Error::InvalidEvent);
         }
 
-        let has_unconsensused_payload = if let Some(info) = event
+        let unconsensused_payload_key = event
             .payload_key()
-            .and_then(|key| self.observations.get_mut(key))
-        {
-            if our {
-                info.created_by_us = true;
-            }
-            !info.consensused
-        } else {
-            false
-        };
+            .and_then(|key| self.observations.get_mut(key).map(|info| (key, info)))
+            .and_then(|(key, info)| {
+                if our {
+                    info.created_by_us = true;
+                }
+                if info.consensused {
+                    None
+                } else {
+                    Some(*key)
+                }
+            });
 
         let event_index = self.insert_event(event);
 
-        if has_unconsensused_payload {
-            self.meta_election.add_unconsensused_event(event_index);
-        }
+        let _ = unconsensused_payload_key.map(|payload_key| {
+            self.meta_election
+                .add_unconsensused_event(event_index, payload_key);
+        });
 
         self.process_events(event_index.topological_index())?;
 
@@ -850,7 +853,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
 
         let payloads = find_interesting_content_for_event(
             builder.event().as_ref(),
-            self.unconsensused_events().map(|event| event.inner()),
+            self.unconsensused_events(None).map(|event| event.inner()),
             is_already_interesting_content,
             is_interesting_payload,
             has_interesting_ancestor,
@@ -931,9 +934,8 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         payload_key: &ObservationKey,
     ) -> usize {
         let unconsensused_events = self
-            .unconsensused_events()
+            .unconsensused_events(Some(payload_key))
             .map(|that_event| that_event.inner())
-            .filter(|that_event| that_event.payload_key() == Some(payload_key))
             .collect_vec();
 
         peers_that_can_vote
@@ -1247,9 +1249,12 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         self.meta_election.voters().len()
     }
 
-    fn unconsensused_events(&self) -> impl Iterator<Item = IndexedEventRef<S::PublicId>> {
+    fn unconsensused_events(
+        &self,
+        filter_key: Option<&ObservationKey>,
+    ) -> impl Iterator<Item = IndexedEventRef<S::PublicId>> {
         self.meta_election
-            .unconsensused_events()
+            .unconsensused_events(filter_key)
             .filter_map(move |index| self.get_known_event(index).ok())
     }
 
@@ -2258,11 +2263,22 @@ impl<T: NetworkEvent, S: SecretId> TestParsec<T, S> {
             event_index,
             unwrap!(self.peer_list.remove_last_event(event.creator()))
         );
-        let _ = self
-            .0
-            .meta_election
-            .unconsensused_events
-            .remove(&event_index);
+
+        if let Some(payload_key) = event.payload_key() {
+            let _ = self
+                .0
+                .meta_election
+                .unconsensused_events
+                .ordered_indices
+                .remove(&event_index);
+            let _ = self
+                .0
+                .meta_election
+                .unconsensused_events
+                .indices_by_key
+                .get_mut(payload_key)
+                .map(|indices| indices.remove(&event_index));
+        }
 
         Some((event_index, event))
     }


### PR DESCRIPTION
This address 3 different issue that occur when having many events and that are blocking generating benchmarks for multiple 1000's of events.

1- is_already_interesting_content doing linear search on events.
2- On consensus, avoid expensive vote resolving if not the needed payload key.
3- Avoid N^2 on number of unconsensused events in num_creators_of_ancestors_carrying_payload


Combined performance Test results

time cargo bench --features=testing -- --baseline pr267 t1024

a_node4_opaque_evt1024 - bench_section_size_evt1024_interleave
                        time:   [101.69 ms 101.74 ms 101.85 ms]
                        change: [-68.700% -68.632% -68.576%] (p = 0.02 < 0.05)
                        Performance has improved.
a_node8_opaque_evt1024 - bench_section_size_evt1024_interleave
                        time:   [293.68 ms 317.17 ms 328.20 ms]
                        change: [-71.050% -69.783% -67.682%] (p = 0.02 < 0.05)
                        Performance has improved.#
a_node16_opaque_evt1024 - bench_section_size_evt1024_interleave
                        time:   [706.60 ms 710.02 ms 710.42 ms]
                        change: [-56.815% -56.624% -56.444%] (p = 0.02 < 0.05)
                        Performance has improved.
a_node32_opaque_evt1024 - bench_section_size_evt1024_interleave
                        time:   [2.3159 s 2.3210 s 2.3313 s]
                        change: [-45.645% -45.469% -45.298%] (p = 0.02 < 0.05)
                        Performance has improved.