### PR TITLE
Fix clippy and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ jobs:
     - script: scripts/clippy
       env: CACHE_NAME=clippy_linux
       os: linux
-    - script: scripts/clippy
-      env: CACHE_NAME=clippy_osx
-      os: osx
     - script: scripts/tests
       env: CACHE_NAME=tests_linux
       os: linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ safe_crypto = { version = "~0.4.0", optional = true }
 serde = "~1.0.66"
 serde_derive = "~1.0.66"
 tiny-keccak = "~1.4.2"
-unwrap = "~1.2.0"
+unwrap = "~1.2.1"
 
 [dev-dependencies]
-clap = "~2.31.2"
+clap = "~2.32.0"
 criterion = "~0.2.5"
 pom = "~1.1.0"
 safe_crypto = "~0.4.0"
@@ -37,6 +37,9 @@ dump-graphs = []
 mock = ["safe_crypto/mock"]
 testing = ["maidsafe_utilities/testing", "proptest", "mock", "pom"]
 malice-detection = []
+
+[workspace]
+members = ["dot_gen"]
 
 [lib]
 # https://japaric.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -3,7 +3,6 @@
 set -e -x
 
 cargo fmt -- --check
-( cd dot_gen ; cargo fmt -- --check )
 cargo clippy --verbose --all-targets
 cargo clippy --verbose --all-targets --features=dump-graphs
 cargo clippy --verbose --all-targets --features=testing


### PR DESCRIPTION
Make Parsec a workspace to address issues with multi crates and travis.
Fix version discrepancies detected by workspace.
Remove osx clippy from travis.