### PR TITLE
MAID-3293: Fix our_unpolled_observations

### DIFF
--- a/dot_gen/src/main.rs
+++ b/dot_gen/src/main.rs
@@ -321,6 +321,29 @@ fn add_functional_tests(scenarios: &mut Scenarios) {
         })
         .seed([411278735, 3293288956, 208850454, 2872654992])
         .file("Alice", "alice.dot");
+
+    let _ = scenarios
+        .add(
+            "functional_tests::our_unpolled_observations_with_consensus_mode_single",
+            |env| {
+                let obs = ObservationSchedule {
+                    genesis: Genesis::new(peer_ids!("Alice", "Bob")),
+                    // Make the votes sufficiently far apart from each other so they are placed
+                    // each in its own block group.
+                    schedule: vec![
+                        (0, Opaque(Transaction::new("A"))),
+                        (1000, Opaque(Transaction::new("A"))),
+                    ],
+                };
+
+                Schedule::from_observation_schedule(env, &ScheduleOptions::default(), obs)
+            },
+        )
+        // Note: Make sure to only use seeds that make Alice reach consensus on Transaction(A) by
+        // Alice before Transaction(A) by Bob.
+        .seed([834576548, 1145967030, 3794692405, 640370552])
+        .consensus_mode(ConsensusMode::Single)
+        .file("Alice", "alice.dot");
 }
 
 fn add_dev_utils_record_smoke_tests(scenarios: &mut Scenarios) {

--- a/input_graphs/functional_tests_our_unpolled_observations_with_consensus_mode_single/alice.dot
+++ b/input_graphs/functional_tests_our_unpolled_observations_with_consensus_mode_single/alice.dot
@@ -1,0 +1,432 @@
+/// our_id: Alice
+/// peer_list: {
+///   Alice: PeerState(VOTE|SEND|RECV)
+///   Bob: PeerState(VOTE|SEND|RECV)
+/// }
+/// consensus_mode: Single
+digraph GossipGraph {
+  splines=false
+  rankdir=BT
+
+  style=invis
+  subgraph cluster_Alice {
+    label="Alice"
+    "Alice" [style=invis]
+    "Alice" -> "A_0" [style=invis]
+    "A_0" -> "A_1" [minlen=1]
+    "A_1" -> "A_2" [minlen=2]
+    "A_2" -> "A_3" [minlen=3]
+    "A_3" -> "A_4" [minlen=1]
+    "A_4" -> "A_5" [minlen=2]
+    "A_5" -> "A_6" [minlen=1]
+    "A_6" -> "A_7" [minlen=1]
+    "A_7" -> "A_8" [minlen=1]
+    "A_8" -> "A_9" [minlen=2]
+    "A_9" -> "A_10" [minlen=1]
+    "A_10" -> "A_11" [minlen=1]
+    "A_11" -> "A_12" [minlen=2]
+    "A_12" -> "A_13" [minlen=1]
+    "A_13" -> "A_14" [minlen=3]
+    "A_14" -> "A_15" [minlen=1]
+    "A_15" -> "A_16" [minlen=1]
+    "A_16" -> "A_17" [minlen=1]
+  }
+  "B_2" -> "A_2" [constraint=false]
+  "B_4" -> "A_3" [constraint=false]
+  "B_6" -> "A_5" [constraint=false]
+  "B_7" -> "A_7" [constraint=false]
+  "B_9" -> "A_9" [constraint=false]
+  "B_10" -> "A_10" [constraint=false]
+  "B_13" -> "A_12" [constraint=false]
+  "B_15" -> "A_14" [constraint=false]
+  "B_14" -> "A_15" [constraint=false]
+  "B_16" -> "A_16" [constraint=false]
+
+  style=invis
+  subgraph cluster_Bob {
+    label="Bob"
+    "Bob" [style=invis]
+    "Bob" -> "B_0" [style=invis]
+    "B_0" -> "B_1" [minlen=1]
+    "B_1" -> "B_2" [minlen=1]
+    "B_2" -> "B_3" [minlen=2]
+    "B_3" -> "B_4" [minlen=1]
+    "B_4" -> "B_5" [minlen=2]
+    "B_5" -> "B_6" [minlen=1]
+    "B_6" -> "B_7" [minlen=1]
+    "B_7" -> "B_8" [minlen=3]
+    "B_8" -> "B_9" [minlen=1]
+    "B_9" -> "B_10" [minlen=1]
+    "B_10" -> "B_11" [minlen=1]
+    "B_11" -> "B_12" [minlen=1]
+    "B_12" -> "B_13" [minlen=1]
+    "B_13" -> "B_14" [minlen=3]
+    "B_14" -> "B_15" [minlen=1]
+    "B_15" -> "B_16" [minlen=1]
+    "B_16" -> "B_17" [minlen=1]
+  }
+  "A_2" -> "B_3" [constraint=false]
+  "A_3" -> "B_5" [constraint=false]
+  "A_4" -> "B_6" [constraint=false]
+  "A_7" -> "B_8" [constraint=false]
+  "A_8" -> "B_9" [constraint=false]
+  "A_10" -> "B_12" [constraint=false]
+  "A_11" -> "B_13" [constraint=false]
+  "A_13" -> "B_14" [constraint=false]
+  "A_14" -> "B_17" [constraint=false]
+
+  {
+    rank=same
+    "Alice" [style=filled, color=white]
+    "Bob" [style=filled, color=white]
+  }
+  "Alice" -> "Bob" [style=invis]
+
+/// ===== details of events =====
+  "A_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_0</td></tr>
+</table>>]
+/// cause: Initial
+/// last_ancestors: {Alice: 0}
+
+  "A_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_1</td></tr>
+<tr><td colspan="6">Genesis({Alice, Bob})</td></tr>
+</table>>]
+/// cause: Observation(Genesis({Alice, Bob}))
+/// last_ancestors: {Alice: 1}
+
+  "A_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_2</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 2, Bob: 2}
+
+  "A_3" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_3</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 3, Bob: 4}
+
+  "A_4" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_4</td></tr>
+</table>>]
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 4, Bob: 4}
+
+  "A_5" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_5</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 5, Bob: 6}
+
+  "A_6" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_6</td></tr>
+<tr><td colspan="6">OpaquePayload(A)</td></tr>
+</table>>]
+/// cause: Observation(OpaquePayload(A))
+/// last_ancestors: {Alice: 6, Bob: 6}
+
+  "A_7" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_7</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 7, Bob: 7}
+
+  "A_8" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_8</td></tr>
+</table>>]
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 8, Bob: 7}
+
+  "A_9" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_9</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 9, Bob: 9}
+
+  "A_10" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_10</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 10, Bob: 10}
+
+  "A_11" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_11</td></tr>
+</table>>]
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 11, Bob: 10}
+
+  "A_12" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_12</td></tr>
+<tr><td colspan="6">[OpaquePayload(A)]</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 12, Bob: 13}
+
+  "A_13" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_13</td></tr>
+</table>>]
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 13, Bob: 13}
+
+  "A_14" [style=filled, fillcolor=orange, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_14</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 14, Bob: 15}
+
+  "A_15" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_15</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 15, Bob: 15}
+
+  "A_16" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_16</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 16, Bob: 16}
+
+  "A_17" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_17</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>-</td></tr></table>>]
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 17, Bob: 16}
+
+  "B_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_0</td></tr>
+</table>>]
+/// cause: Initial
+/// last_ancestors: {Bob: 0}
+
+  "B_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_1</td></tr>
+<tr><td colspan="6">Genesis({Alice, Bob})</td></tr>
+</table>>]
+/// cause: Observation(Genesis({Alice, Bob}))
+/// last_ancestors: {Bob: 1}
+
+  "B_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_2</td></tr>
+</table>>]
+/// cause: Requesting(Alice)
+/// last_ancestors: {Bob: 2}
+
+  "B_3" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_3</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 2, Bob: 3}
+
+  "B_4" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_4</td></tr>
+</table>>]
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 2, Bob: 4}
+
+  "B_5" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_5</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 3, Bob: 5}
+
+  "B_6" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_6</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 4, Bob: 6}
+
+  "B_7" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_7</td></tr>
+</table>>]
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 4, Bob: 7}
+
+  "B_8" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_8</td></tr>
+</table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 7, Bob: 8}
+
+  "B_9" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_9</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 8, Bob: 9}
+
+  "B_10" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_10</td></tr>
+</table>>]
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 8, Bob: 10}
+
+  "B_11" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_11</td></tr>
+<tr><td colspan="6">OpaquePayload(A)</td></tr>
+</table>>]
+/// cause: Observation(OpaquePayload(A))
+/// last_ancestors: {Alice: 8, Bob: 11}
+
+  "B_12" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_12</td></tr>
+<tr><td colspan="6">[OpaquePayload(A)]</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 10, Bob: 12}
+
+  "B_13" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_13</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 11, Bob: 13}
+
+  "B_14" [style=filled, fillcolor=orange, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_14</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 13, Bob: 14}
+
+  "B_15" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_15</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 13, Bob: 15}
+
+  "B_16" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_16</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 13, Bob: 16}
+
+  "B_17" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_17</td></tr>
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>t</td><td>t</td><td>t</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 14, Bob: 17}
+
+}
+
+/// ===== meta-elections =====
+/// consensus_history:
+/// ff0ee6e4f926724d0873007b3bbb6001d954fd3eba178ac91b4d5a4a5b91fe8d
+/// b6d1c725f300e054b0942ee3726dbf8a83f40062a3d32704acbbc7b128679b22
+
+/// round_hashes: {
+///   Alice -> [
+///     RoundHash { round: 0, latest_block_hash: b6d1c725f300e054b0942ee3726dbf8a83f40062a3d32704acbbc7b128679b22 }
+///   ]
+///   Bob -> [
+///     RoundHash { round: 0, latest_block_hash: b6d1c725f300e054b0942ee3726dbf8a83f40062a3d32704acbbc7b128679b22 }
+///   ]
+/// }
+/// interesting_events: {
+///   Alice -> ["A_12"]
+///   Bob -> ["B_12"]
+/// }
+/// all_voters: {Alice, Bob}
+/// unconsensused_events: {"B_11"}
+/// meta_events: {
+///   A_12 -> {
+///     observees: {}
+///     interesting_content: [OpaquePayload(A)]
+///   }
+///   A_13 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   A_14 -> {
+///     observees: {Alice, Bob}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///     }
+///   }
+///   A_15 -> {
+///     observees: {}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///     }
+///   }
+///   A_16 -> {
+///     observees: {}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///     }
+///   }
+///   A_17 -> {
+///     observees: {}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   - 
+///       B: 0/0   t   t   t   - 
+///     }
+///   }
+///   B_12 -> {
+///     observees: {}
+///     interesting_content: [OpaquePayload(A)]
+///   }
+///   B_13 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   B_14 -> {
+///     observees: {Alice, Bob}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///     }
+///   }
+///   B_15 -> {
+///     observees: {}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///     }
+///   }
+///   B_16 -> {
+///     observees: {}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///     }
+///   }
+///   B_17 -> {
+///     observees: {}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   t   t   t 
+///       B: 0/0   t   t   t   t 
+///     }
+///   }
+/// }

--- a/src/block.rs
+++ b/src/block.rs
@@ -59,6 +59,11 @@ impl<T: NetworkEvent, P: PublicId> Block<T, P> {
         &self.proofs
     }
 
+    /// Is this block signed by the given peer?
+    pub fn is_signed_by(&self, peer_id: &P) -> bool {
+        self.proofs.iter().any(|proof| proof.public_id() == peer_id)
+    }
+
     /// Converts `vote` to a `Proof` and attempts to add it to the block.  Returns an error if
     /// `vote` is invalid (i.e. signature check fails or the `vote` is for a different network
     /// event), `Ok(true)` if the `Proof` wasn't previously held in this `Block`, or `Ok(false)` if

--- a/src/block.rs
+++ b/src/block.rs
@@ -13,6 +13,7 @@ use crate::observation::Observation;
 use crate::vote::Vote;
 use std::{
     collections::{BTreeMap, BTreeSet},
+    ops::Deref,
     slice, vec,
 };
 
@@ -96,5 +97,12 @@ impl<'a, T: NetworkEvent, P: PublicId> IntoIterator for &'a BlockGroup<T, P> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
+    }
+}
+
+impl<T: NetworkEvent, P: PublicId> Deref for BlockGroup<T, P> {
+    type Target = [Block<T, P>];
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/src/dev_utils/mod.rs
+++ b/src/dev_utils/mod.rs
@@ -15,7 +15,7 @@ mod peer;
 mod peer_statuses;
 #[cfg(feature = "testing")]
 pub mod proptest;
-#[cfg(feature = "testing")]
+#[cfg(any(all(test, feature = "mock"), feature = "testing"))]
 mod record;
 mod schedule;
 
@@ -29,7 +29,7 @@ pub use self::environment::{Environment, RngChoice};
 pub use self::network::{ConsensusError, Network};
 pub use self::peer::{NetworkView, Peer, PeerStatus};
 pub use self::peer_statuses::PeerStatuses;
-#[cfg(feature = "testing")]
+#[cfg(any(all(test, feature = "mock"), feature = "testing"))]
 pub use self::record::Record;
 pub use self::schedule::*;
 

--- a/src/dev_utils/record.rs
+++ b/src/dev_utils/record.rs
@@ -212,7 +212,7 @@ impl From<ParsedContents> for Record {
             genesis_group,
             actions,
             consensus_history: contents.meta_election.consensus_history,
-            consensus_mode: ConsensusMode::Supermajority,
+            consensus_mode: contents.consensus_mode,
         }
     }
 }

--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -414,12 +414,10 @@ fn our_unpolled_observations_with_consensus_mode_single() {
         x => panic!("Unexpected block payload: {:?}", x),
     }
     assert_eq!(blocks[0].proofs().len(), 1);
-    assert!(blocks[0]
-        .proofs()
-        .iter()
-        .any(|proof| proof.public_id() == alice.our_pub_id()));
+    assert!(blocks[0].is_signed_by(alice.our_pub_id()));
 
-    // Bob's vote is still in, but should not be returned here, as it's not "ours"
+    // Bob's vote is still in, but should not be returned here, as it's not "ours" (from Alice's
+    // point of view).
     assert_eq!(alice.our_unpolled_observations().next(), None);
 }
 

--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -10,23 +10,19 @@ use crate::block::Block;
 use crate::dev_utils::{parse_test_dot_file, Record};
 use crate::error::Error;
 use crate::gossip::{Event, Graph, GraphSnapshot};
-use crate::id::PublicId;
+use crate::id::{Proof, PublicId};
 use crate::meta_voting::MetaElectionSnapshot;
 use crate::mock::{self, PeerId, Transaction};
 use crate::observation::{ConsensusMode, Observation};
 use crate::parsec::TestParsec;
 use crate::peer_list::{PeerIndexSet, PeerListSnapshot, PeerState};
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, fmt::Debug};
 
-macro_rules! assert_err {
-    ($expected_error:pat, $result:expr) => {
-        match $result {
-            Err($expected_error) => (),
-            unexpected => panic!(
-                "Expected {}, but got {:?}",
-                stringify!($expected_error),
-                unexpected
-            ),
+macro_rules! assert_matches {
+    ($actual:expr, $expected:pat) => {
+        match $actual {
+            $expected => (),
+            ref unexpected => panic!("{:?} does not match {}", unexpected, stringify!($expected)),
         }
     };
 }
@@ -67,6 +63,27 @@ impl Snapshot {
 fn nth_event<P: PublicId>(graph: &Graph<P>, n: usize) -> &Event<P> {
     unwrap!(graph.iter_from(n).next()).inner()
 }
+
+/// Testing related extensions to `Iterator`.
+trait TestIterator: Iterator {
+    /// Returns the only element in the iterator. Panics if the iterator yields less or more than
+    /// one element.
+    fn only(mut self) -> Self::Item
+    where
+        Self: Sized,
+        Self::Item: Debug,
+    {
+        let item = unwrap!(self.next(), "Expected one element - got none.");
+        assert!(
+            self.by_ref().peekable().peek().is_none(),
+            "Expected one element - got more (excess: {:?}).",
+            self.collect::<Vec<_>>()
+        );
+        item
+    }
+}
+
+impl<I: Iterator> TestIterator for I {}
 
 #[test]
 fn from_existing() {
@@ -246,7 +263,7 @@ fn add_peer() {
     let alice_snapshot = Snapshot::new(&alice);
 
     // Try calling `create_gossip()` for a peer which doesn't exist yet.
-    assert_err!(Error::UnknownPeer, alice.create_gossip(&fred_id));
+    assert_matches!(alice.create_gossip(&fred_id), Err(Error::UnknownPeer));
     assert_eq!(alice_snapshot, Snapshot::new(&alice));
 
     // Now add D_18, which should result in Alice adding Fred.
@@ -306,7 +323,10 @@ fn remove_peer() {
     );
 
     // Try calling `create_gossip()` for Eric shall result in error.
-    assert_err!(Error::InvalidPeerState { .. }, alice.create_gossip(&eric_id));
+    assert_matches!(
+        alice.create_gossip(&eric_id),
+        Err(Error::InvalidPeerState { .. })
+    );
 
     // Construct Eric's parsec instance.
     let mut section: BTreeSet<_> = alice
@@ -329,9 +349,9 @@ fn remove_peer() {
     }
 
     // Eric can no longer gossip to anyone.
-    assert_err!(
-        Error::InvalidSelfState { .. },
-        eric.create_gossip(&PeerId::new("Alice"))
+    assert_matches!(
+        eric.create_gossip(&PeerId::new("Alice")),
+        Err(Error::InvalidSelfState { .. })
     );
 }
 
@@ -402,19 +422,15 @@ fn unpolled_and_unconsensused_observations() {
 fn our_unpolled_observations_with_consensus_mode_single() {
     let mut alice = Record::from(parse_test_dot_file("alice.dot")).play();
 
-    let blocks = unwrap!(alice.poll());
-    match blocks[0].payload() {
-        Observation::Genesis(_) => (),
-        x => panic!("Unexpected block payload: {:?}", x),
-    }
+    let block = alice.poll().into_iter().flatten().only();
+    assert_matches!(*block.payload(), Observation::Genesis(_));
 
-    let blocks = unwrap!(alice.poll());
-    match blocks[0].payload() {
-        Observation::OpaquePayload(_) => (),
-        x => panic!("Unexpected block payload: {:?}", x),
-    }
-    assert_eq!(blocks[0].proofs().len(), 1);
-    assert!(blocks[0].is_signed_by(alice.our_pub_id()));
+    let block = alice.poll().into_iter().flatten().only();
+    assert_matches!(*block.payload(), Observation::OpaquePayload(_));
+    assert_eq!(
+        block.proofs().iter().map(Proof::public_id).only(),
+        alice.our_pub_id()
+    );
 
     // Bob's vote is still in, but should not be returned here, as it's not "ours" (from Alice's
     // point of view).
@@ -732,7 +748,10 @@ mod handle_malice {
         // Send gossip from Alice to Dave.
         let message = unwrap!(alice.create_gossip(&dave_id));
         // Alice's genesis should be rejected as invalid
-        assert_err!(Error::InvalidEvent, dave.handle_request(&alice_id, message));
+        assert_matches!(
+            dave.handle_request(&alice_id, message),
+            Err(Error::InvalidEvent)
+        );
         assert!(dave.graph().contains(&a_0_hash));
         // Dave's events shouldn't contain Alice's genesis because of the rejection
         assert!(!dave.graph().contains(&a_1_hash));
@@ -1093,9 +1112,9 @@ mod handle_malice {
         let mut alice = TestParsec::from_parsed_contents(parse_test_dot_file("alice.dot"));
 
         // Try to add the event.
-        assert_err!(
-            Error::InvalidEvent,
-            alice.unpack_and_add_event(c_25_packed.clone())
+        assert_matches!(
+            alice.unpack_and_add_event(c_25_packed.clone()),
+            Err(Error::InvalidEvent)
         );
 
         // The invalid event should trigger an accusation vote to be raised immediately, and the
@@ -1150,7 +1169,10 @@ mod handle_malice {
         unwrap!(alice.unpack_and_add_event(b_1_packed));
 
         // This should fail, as B_2 has other-parent by the same creator.
-        assert_err!(Error::InvalidEvent, alice.unpack_and_add_event(b_2_packed));
+        assert_matches!(
+            alice.unpack_and_add_event(b_2_packed),
+            Err(Error::InvalidEvent)
+        );
 
         // Alice should raise accusation against Bob
         let (offender, event) = unwrap!(our_votes(&alice)
@@ -1196,7 +1218,7 @@ mod handle_malice {
         let alice_snapshot = Snapshot::new(&alice);
 
         // Try calling `create_gossip()` for a peer which doesn't exist yet.
-        assert_err!(Error::UnknownPeer, alice.create_gossip(&fred_id));
+        assert_matches!(alice.create_gossip(&fred_id), Err(Error::UnknownPeer));
         assert_eq!(alice_snapshot, Snapshot::new(&alice));
 
         // We'll modify Alice's peer list to allow her to create gossip for Fred
@@ -1221,7 +1243,7 @@ mod handle_malice {
         let result = fred.handle_request(&alice_id, request);
 
         // check that Fred detected premature gossip
-        assert_err!(Error::PrematureGossip, result);
+        assert_matches!(result, Err(Error::PrematureGossip));
 
         // Check that Fred has all the events that Alice has
         assert!(alice

--- a/src/gossip/cause.rs
+++ b/src/gossip/cause.rs
@@ -186,6 +186,7 @@ impl Cause<VoteKey<PeerId>, EventIndex, PeerIndex> {
         recipient: Option<PeerIndex>,
         self_parent: Option<EventIndex>,
         other_parent: Option<EventIndex>,
+        consensus_mode: ConsensusMode,
         observations: &mut ObservationStore<Transaction, PeerId>,
     ) -> Self {
         let self_parent = self_parent.unwrap_or(EventIndex::PHONY);
@@ -205,8 +206,7 @@ impl Cause<VoteKey<PeerId>, EventIndex, PeerIndex> {
                 other_parent,
             },
             Cause::Observation { vote, .. } => {
-                let (vote_key, observation) =
-                    VoteKey::new(vote, creator, ConsensusMode::Supermajority);
+                let (vote_key, observation) = VoteKey::new(vote, creator, consensus_mode);
                 let _ = observations
                     .entry(*vote_key.payload_key())
                     .or_insert_with(|| ObservationInfo::new(observation));

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -22,6 +22,8 @@ use crate::id::{PublicId, SecretId};
 #[cfg(any(test, feature = "testing"))]
 use crate::mock::{PeerId, Transaction};
 use crate::network_event::NetworkEvent;
+#[cfg(any(test, feature = "testing"))]
+use crate::observation::ConsensusMode;
 use crate::observation::{Observation, ObservationForStore, ObservationKey, ObservationStore};
 use crate::peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet, PeerList};
 use crate::serialise;
@@ -502,6 +504,7 @@ impl Event<PeerId> {
         self_parent: Option<(EventIndex, EventHash)>,
         other_parent: Option<(EventIndex, EventHash)>,
         index_by_creator: usize,
+        consensus_mode: ConsensusMode,
         last_ancestors: BTreeMap<PeerId, usize>,
         peer_list: &PeerList<PeerId>,
         observations: &mut ObservationStore<Transaction, PeerId>,
@@ -529,6 +532,7 @@ impl Event<PeerId> {
             recipient,
             self_parent.map(|(i, _)| i),
             other_parent.map(|(i, _)| i),
+            consensus_mode,
             observations,
         );
         let content = Content { creator, cause };

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -13,7 +13,7 @@ use crate::dump_graph;
 use crate::error::{Error, Result};
 #[cfg(all(test, feature = "mock"))]
 use crate::gossip::EventHash;
-#[cfg(all(test, feature = "testing"))]
+#[cfg(all(test, any(feature = "testing", feature = "mock")))]
 use crate::gossip::GraphSnapshot;
 use crate::gossip::{
     Event, EventContextRef, EventIndex, Graph, IndexedEventRef, PackedEvent, Request, Response,
@@ -705,6 +705,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
     fn output_consensus_info(&self, payload_keys: &[ObservationKey]) {
         dump_graph::to_file(
             self.our_pub_id(),
+            self.consensus_mode,
             &self.graph,
             &self.meta_election,
             &self.peer_list,
@@ -712,7 +713,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             &dump_graph::DumpGraphContext::ConsensusReached,
         );
 
-        for payload_key in payload_keys {
+        for (index, payload_key) in payload_keys.iter().enumerate() {
             let payload = self
                 .observations
                 .get(payload_key)
@@ -720,7 +721,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             info!(
                 "{:?} got consensus on block {} with payload {:?} and payload hash {:?}",
                 self.our_pub_id(),
-                self.meta_election.consensus_history().len(),
+                self.meta_election.consensus_history().len() + index,
                 payload,
                 payload_key.hash()
             )
@@ -2085,6 +2086,7 @@ impl<T: NetworkEvent, S: SecretId> Drop for Parsec<T, S> {
     fn drop(&mut self) {
         dump_graph::to_file(
             self.our_pub_id(),
+            self.consensus_mode,
             &self.graph,
             &self.meta_election,
             &self.peer_list,
@@ -2148,7 +2150,7 @@ impl Parsec<Transaction, PeerId> {
         let mut parsec = Parsec::empty(
             peer_list,
             PeerIndexSet::default(),
-            ConsensusMode::Supermajority,
+            parsed_contents.consensus_mode,
         );
 
         for event in &parsed_contents.graph {
@@ -2391,7 +2393,7 @@ impl<T: NetworkEvent, S: SecretId> DerefMut for TestParsec<T, S> {
 }
 
 /// Get the parsec graph snapshot with inserted events out of order.
-#[cfg(all(test, feature = "testing"))]
+#[cfg(all(test, any(feature = "testing", feature = "mock")))]
 pub(crate) fn get_graph_snapshot<T: NetworkEvent, S: SecretId>(
     parsec: &Parsec<T, S>,
     ignore_last_events: usize,

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -435,15 +435,12 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         // In `Supermajority` mode, check only if the payload matches, as there can be blocks not
         // signed by us, yet with payloads voted for by us.
         // In `Single` mode, on the other hand, check also that we signed it, to avoid false
-        // positives when there are blocks with the same payloads but signed by somone else.
+        // positives when there are blocks with the same payloads but signed by someone else.
         match self.consensus_mode.of(payload) {
             ConsensusMode::Supermajority => matching_blocks.next().is_some(),
-            ConsensusMode::Single => matching_blocks.any(|block| {
-                block
-                    .proofs()
-                    .iter()
-                    .any(|proof| proof.public_id() == self.our_pub_id())
-            }),
+            ConsensusMode::Single => {
+                matching_blocks.any(|block| block.is_signed_by(self.our_pub_id()))
+            }
         }
     }
 


### PR DESCRIPTION
The bug was that when using `ConsensusMode::Single`, `our_unpolled_observation` sometimes returned observations that have already been polled. This PR also contains a test case exposing the bug.