### PR TITLE
MAID-3282: add malice protection for Requesting type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ clap = "~2.32.0"
 criterion = "~0.2.5"
 pom = "~1.1.0"
 safe_crypto = "~0.4.0"
+walkdir = "~2.2.7"
 
 [features]
 dump-graphs = []

--- a/dot_gen/src/main.rs
+++ b/dot_gen/src/main.rs
@@ -14,7 +14,7 @@
 //!
 //! ```
 //! scenarios
-//!     .add("parsec::functional_tests::my_test_function", |env| {
+//!     .add("functional_tests::my_test_function", |env| {
 //!         Schedule::new(
 //!             env,
 //!             &ScheduleOptions {

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -6,10 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(any(
-    all(test, feature = "malice-detection", feature = "mock"),
-    feature = "testing"
-))]
+#[cfg(all(test, feature = "malice-detection", feature = "mock"))]
 use crate::error::Error;
 #[cfg(any(all(test, feature = "mock"), feature = "testing"))]
 use crate::gossip::EventContextRef;
@@ -736,7 +733,7 @@ impl ParsedContents {
         Some(event)
     }
 
-    #[cfg(all(feature = "malice-detection", feature = "mock"))]
+    #[cfg(all(test, feature = "malice-detection", feature = "mock"))]
     /// Insert event into the `ParsedContents`. Note this does not perform any validations
     /// whatsoever, so this is useful for simulating all kinds of invalid or malicious situations.
     pub fn add_event(&mut self, event: Event<PeerId>) -> EventIndex {
@@ -760,10 +757,7 @@ impl ParsedContents {
         }
     }
 
-    #[cfg(any(
-        all(test, feature = "malice-detection", feature = "mock"),
-        feature = "testing"
-    ))]
+    #[cfg(all(test, feature = "malice-detection", feature = "mock"))]
     pub fn new_event_from_observation(
         &mut self,
         self_parent: EventIndex,

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,9 +47,10 @@ pub enum Error {
     DuplicateVote,
     /// The peer sent a message to us before knowing we could handle it.
     PrematureGossip,
-    /// The request or response contains at least one event, but doesn't contain an event created by
-    /// the sender.
+    /// The request or response is invalid.
     InvalidMessage,
+    /// The request or response has already been handled by us.
+    DuplicateMessage,
     /// Logic error.
     Logic,
 }
@@ -93,11 +94,12 @@ impl Display for Error {
                 f,
                 "The peer did not know we could handle a message from it."
             ),
-            Error::InvalidMessage => write!(
+            Error::InvalidMessage => write!(f, "This non-empty message is invalid."),
+            Error::DuplicateMessage => write!(f, "This message has already been handled."),
+            Error::Logic => write!(
                 f,
-                "This non-empty message doesn't contain an event created by the sender."
+                "This is a logic error and represents a flaw in the code."
             ),
-            Error::Logic => write!(f, "This a logic error and represents a flaw in the code."),
         }
     }
 }

--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -15,7 +15,9 @@ use crate::meta_voting::MetaElectionSnapshot;
 use crate::mock::{self, PeerId, Transaction};
 use crate::observation::{ConsensusMode, Observation};
 use crate::parsec::TestParsec;
-use crate::peer_list::{PeerIndexSet, PeerListSnapshot, PeerState};
+#[cfg(feature = "malice-detection")]
+use crate::peer_list::PeerIndexSet;
+use crate::peer_list::{PeerListSnapshot, PeerState};
 use std::{collections::BTreeSet, fmt::Debug};
 
 macro_rules! assert_matches {
@@ -241,8 +243,8 @@ fn add_peer() {
     // Generated with RNG seed: [411278735, 3293288956, 208850454, 2872654992].
     let mut parsed_contents = parse_test_dot_file("alice.dot");
 
-    // The final decision to add Fred is reached in D_18, so pop this event for now.
-    let d_18 = unwrap!(parsed_contents.remove_last_event());
+    // The final decision to add Fred is reached in E_25, so pop this event for now.
+    let e_25 = unwrap!(parsed_contents.remove_last_event());
 
     let mut alice = TestParsec::from_parsed_contents(parsed_contents);
     let genesis_group: BTreeSet<_> = alice
@@ -252,7 +254,6 @@ fn add_peer() {
         .collect();
 
     let alice_id = PeerId::new("Alice");
-    let dave_id = PeerId::new("Dave");
     let fred_id = PeerId::new("Fred");
 
     assert!(!alice
@@ -266,10 +267,8 @@ fn add_peer() {
     assert_matches!(alice.create_gossip(&fred_id), Err(Error::UnknownPeer));
     assert_eq!(alice_snapshot, Snapshot::new(&alice));
 
-    // Now add D_18, which should result in Alice adding Fred.
-    let d_18_hash = *d_18.hash();
-    unwrap!(alice.add_event(d_18));
-    unwrap!(alice.create_sync_event(&dave_id, true, PeerIndexSet::default(), Some(d_18_hash)));
+    // Now add E_25, which should result in Alice adding Fred.
+    let _e_25_index = unwrap!(alice.add_event(e_25));
     assert!(alice
         .peer_list()
         .all_ids()

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -361,6 +361,15 @@ impl<P: PublicId> Event<P> {
         }
     }
 
+    #[cfg(feature = "malice-detection")]
+    pub fn requesting_recipient(&self) -> Option<PeerIndex> {
+        if let Cause::Requesting { recipient, .. } = self.content.cause {
+            Some(recipient)
+        } else {
+            None
+        }
+    }
+
     pub fn is_request(&self) -> bool {
         if let Cause::Request { .. } = self.content.cause {
             true

--- a/src/gossip/messages.rs
+++ b/src/gossip/messages.rs
@@ -6,11 +6,21 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#[cfg(feature = "malice-detection")]
 use crate::error::{Error, Result};
-use crate::gossip::event_hash::EventHash;
+#[cfg(feature = "malice-detection")]
+use crate::gossip::cause::Cause;
 use crate::gossip::packed_event::PackedEvent;
+#[cfg(feature = "malice-detection")]
+use crate::gossip::{EventContextRef, IndexedEventRef};
 use crate::id::PublicId;
+#[cfg(feature = "malice-detection")]
+use crate::id::SecretId;
 use crate::network_event::NetworkEvent;
+#[cfg(feature = "malice-detection")]
+use crate::observation::Observation;
+#[cfg(feature = "malice-detection")]
+use crate::peer_list::PeerIndex;
 
 /// A gossip request message.
 #[serde(bound = "")]
@@ -24,8 +34,43 @@ impl<T: NetworkEvent, P: PublicId> Request<T, P> {
         Self { packed_events }
     }
 
-    pub(crate) fn hash_of_last_event_created_by(&self, src: &P) -> Result<Option<EventHash>> {
-        hash_of_last_event_created_by(src, &self.packed_events)
+    /// Returns `Ok` if the final event is a `Requesting` by `sender` targeting us, and for which we
+    /// have not yet recorded an associated `Request` event.  Otherwise returns `Err`.
+    #[cfg(feature = "malice-detection")]
+    pub(crate) fn validate<S: SecretId<PublicId = P>>(
+        &self,
+        sender: &P,
+        ctx: EventContextRef<T, S>,
+    ) -> Result<()> {
+        let packed_event = self.packed_events.last().ok_or(Error::InvalidMessage)?;
+
+        if packed_event.content.creator != *sender {
+            return Err(Error::InvalidMessage);
+        }
+
+        if let Cause::Requesting { ref recipient, .. } = packed_event.content.cause {
+            if recipient != ctx.peer_list.our_pub_id() {
+                return Err(Error::InvalidMessage);
+            }
+        } else {
+            return Err(Error::InvalidMessage);
+        }
+
+        // We may validly have received this request after already finding out about all the
+        // events in it.  In this case, check that the sender's `Requesting` event is currently
+        // missing its associated `Request` created by us in the graph.  Otherwise, this message has
+        // already been handled by us.
+        let sender_requesting_hash = packed_event.compute_hash();
+        if ctx
+            .graph
+            .get_index(&sender_requesting_hash)
+            .and_then(|index| ctx.graph.get(index))
+            .map(|event| ctx.graph.is_awaiting_associated_event(event))
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        Err(Error::DuplicateMessage)
     }
 }
 
@@ -41,24 +86,66 @@ impl<T: NetworkEvent, P: PublicId> Response<T, P> {
         Self { packed_events }
     }
 
-    pub(crate) fn hash_of_last_event_created_by(&self, src: &P) -> Result<Option<EventHash>> {
-        hash_of_last_event_created_by(src, &self.packed_events)
-    }
-}
+    /// Returns `Ok` if:
+    ///   * the final event is a `Request` by `sender`
+    ///   * with its other_parent as a `Requesting` event created by us, targeting `sender` and
+    ///   * for which we have not yet recorded an associated `Response` event
+    ///   * or if such an event immediately precedes a series of accusations by `sender`.
+    /// Otherwise returns `Err`.
+    #[cfg(feature = "malice-detection")]
+    pub(crate) fn validate<S: SecretId<PublicId = P>>(
+        &self,
+        sender: &P,
+        ctx: EventContextRef<T, S>,
+    ) -> Result<()> {
+        for packed_event in self.packed_events.iter().rev() {
+            if packed_event.content.creator != *sender {
+                break;
+            }
 
-// Returns `Err(Error::InvalidMessage)` if `packed_events` is non-empty, but doesn't contain an
-// event created by `src`.
-fn hash_of_last_event_created_by<T: NetworkEvent, P: PublicId>(
-    src: &P,
-    packed_events: &[PackedEvent<T, P>],
-) -> Result<Option<EventHash>> {
-    if packed_events.is_empty() {
-        return Ok(None);
+            match packed_event.content.cause {
+                Cause::Request {
+                    ref other_parent, ..
+                } => {
+                    let is_valid = |event: IndexedEventRef<P>| {
+                        event.creator() == PeerIndex::OUR
+                            && event.requesting_recipient() == ctx.peer_list.get_index(sender)
+                            && ctx.graph.is_awaiting_associated_event(event)
+                    };
+                    if ctx
+                        .graph
+                        .get_index(other_parent)
+                        .and_then(|index| ctx.graph.get(index))
+                        .map(is_valid)
+                        .unwrap_or(false)
+                    {
+                        return Ok(());
+                    }
+
+                    // We may validly have received this response after already finding out about
+                    // all the events in it.  In this case, check that the sender's `Request` event
+                    // is currently missing its associated `Response` created by us in the graph.
+                    // Otherwise, this message has already been handled by us.
+                    let sender_request_hash = packed_event.compute_hash();
+                    if ctx
+                        .graph
+                        .get_index(&sender_request_hash)
+                        .and_then(|index| ctx.graph.get(index))
+                        .map(|event| ctx.graph.is_awaiting_associated_event(event))
+                        .unwrap_or(false)
+                    {
+                        return Ok(());
+                    } else {
+                        return Err(Error::DuplicateMessage);
+                    }
+                }
+                Cause::Observation { ref vote, .. } => match vote.payload() {
+                    Observation::Accusation { .. } => continue,
+                    _ => break,
+                },
+                _ => break,
+            }
+        }
+        Err(Error::InvalidMessage)
     }
-    packed_events
-        .iter()
-        .rev()
-        .find(|packed_event| packed_event.content.creator == *src)
-        .ok_or_else(|| Error::InvalidMessage)
-        .map(|packed_event| Some(packed_event.compute_hash()))
 }

--- a/src/gossip/messages.rs
+++ b/src/gossip/messages.rs
@@ -6,21 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(feature = "malice-detection")]
-use crate::error::{Error, Result};
-#[cfg(feature = "malice-detection")]
-use crate::gossip::cause::Cause;
 use crate::gossip::packed_event::PackedEvent;
-#[cfg(feature = "malice-detection")]
-use crate::gossip::{EventContextRef, IndexedEventRef};
 use crate::id::PublicId;
-#[cfg(feature = "malice-detection")]
-use crate::id::SecretId;
 use crate::network_event::NetworkEvent;
-#[cfg(feature = "malice-detection")]
-use crate::observation::Observation;
-#[cfg(feature = "malice-detection")]
-use crate::peer_list::PeerIndex;
 
 /// A gossip request message.
 #[serde(bound = "")]
@@ -32,45 +20,6 @@ pub struct Request<T: NetworkEvent, P: PublicId> {
 impl<T: NetworkEvent, P: PublicId> Request<T, P> {
     pub(crate) fn new(packed_events: Vec<PackedEvent<T, P>>) -> Self {
         Self { packed_events }
-    }
-
-    /// Returns `Ok` if the final event is a `Requesting` by `sender` targeting us, and for which we
-    /// have not yet recorded an associated `Request` event.  Otherwise returns `Err`.
-    #[cfg(feature = "malice-detection")]
-    pub(crate) fn validate<S: SecretId<PublicId = P>>(
-        &self,
-        sender: &P,
-        ctx: EventContextRef<T, S>,
-    ) -> Result<()> {
-        let packed_event = self.packed_events.last().ok_or(Error::InvalidMessage)?;
-
-        if packed_event.content.creator != *sender {
-            return Err(Error::InvalidMessage);
-        }
-
-        if let Cause::Requesting { ref recipient, .. } = packed_event.content.cause {
-            if recipient != ctx.peer_list.our_pub_id() {
-                return Err(Error::InvalidMessage);
-            }
-        } else {
-            return Err(Error::InvalidMessage);
-        }
-
-        // We may validly have received this request after already finding out about all the
-        // events in it.  In this case, check that the sender's `Requesting` event is currently
-        // missing its associated `Request` created by us in the graph.  Otherwise, this message has
-        // already been handled by us.
-        let sender_requesting_hash = packed_event.compute_hash();
-        if ctx
-            .graph
-            .get_index(&sender_requesting_hash)
-            .and_then(|index| ctx.graph.get(index))
-            .map(|event| ctx.graph.is_awaiting_associated_event(event))
-            .unwrap_or(true)
-        {
-            return Ok(());
-        }
-        Err(Error::DuplicateMessage)
     }
 }
 
@@ -84,68 +33,5 @@ pub struct Response<T: NetworkEvent, P: PublicId> {
 impl<T: NetworkEvent, P: PublicId> Response<T, P> {
     pub(crate) fn new(packed_events: Vec<PackedEvent<T, P>>) -> Self {
         Self { packed_events }
-    }
-
-    /// Returns `Ok` if:
-    ///   * the final event is a `Request` by `sender`
-    ///   * with its other_parent as a `Requesting` event created by us, targeting `sender` and
-    ///   * for which we have not yet recorded an associated `Response` event
-    ///   * or if such an event immediately precedes a series of accusations by `sender`.
-    /// Otherwise returns `Err`.
-    #[cfg(feature = "malice-detection")]
-    pub(crate) fn validate<S: SecretId<PublicId = P>>(
-        &self,
-        sender: &P,
-        ctx: EventContextRef<T, S>,
-    ) -> Result<()> {
-        for packed_event in self.packed_events.iter().rev() {
-            if packed_event.content.creator != *sender {
-                break;
-            }
-
-            match packed_event.content.cause {
-                Cause::Request {
-                    ref other_parent, ..
-                } => {
-                    let is_valid = |event: IndexedEventRef<P>| {
-                        event.creator() == PeerIndex::OUR
-                            && event.requesting_recipient() == ctx.peer_list.get_index(sender)
-                            && ctx.graph.is_awaiting_associated_event(event)
-                    };
-                    if ctx
-                        .graph
-                        .get_index(other_parent)
-                        .and_then(|index| ctx.graph.get(index))
-                        .map(is_valid)
-                        .unwrap_or(false)
-                    {
-                        return Ok(());
-                    }
-
-                    // We may validly have received this response after already finding out about
-                    // all the events in it.  In this case, check that the sender's `Request` event
-                    // is currently missing its associated `Response` created by us in the graph.
-                    // Otherwise, this message has already been handled by us.
-                    let sender_request_hash = packed_event.compute_hash();
-                    if ctx
-                        .graph
-                        .get_index(&sender_request_hash)
-                        .and_then(|index| ctx.graph.get(index))
-                        .map(|event| ctx.graph.is_awaiting_associated_event(event))
-                        .unwrap_or(false)
-                    {
-                        return Ok(());
-                    } else {
-                        return Err(Error::DuplicateMessage);
-                    }
-                }
-                Cause::Observation { ref vote, .. } => match vote.payload() {
-                    Observation::Accusation { .. } => continue,
-                    _ => break,
-                },
-                _ => break,
-            }
-        }
-        Err(Error::InvalidMessage)
     }
 }

--- a/src/gossip/packed_event.rs
+++ b/src/gossip/packed_event.rs
@@ -6,13 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::content::Content;
-use super::event_hash::EventHash;
-use crate::hash::Hash;
-use crate::id::PublicId;
-use crate::network_event::NetworkEvent;
-use crate::serialise;
-use crate::vote::Vote;
+use super::{content::Content, event_hash::EventHash};
+#[cfg(all(feature = "mock", any(feature = "testing", test)))]
+use crate::{
+    gossip::Cause,
+    id::SecretId,
+    mock::{PeerId, Transaction},
+    observation::Observation,
+};
+use crate::{hash::Hash, serialise, NetworkEvent, PublicId, Vote};
 use std::fmt::{self, Debug, Formatter};
 
 /// Packed event contains only content and signature.
@@ -39,5 +41,78 @@ impl<T: NetworkEvent, P: PublicId> Debug for PackedEvent<T, P> {
 impl<T: NetworkEvent, P: PublicId> PackedEvent<T, P> {
     pub(crate) fn compute_hash(&self) -> EventHash {
         EventHash(Hash::from(serialise(&self.content).as_slice()))
+    }
+}
+
+#[cfg(all(feature = "mock", any(feature = "testing", test)))]
+impl PackedEvent<Transaction, PeerId> {
+    /// Construct a new `Requesting` packed event.
+    pub fn new_requesting(creator: PeerId, recipient: PeerId, self_parent: EventHash) -> Self {
+        let content = Content {
+            creator,
+            cause: Cause::Requesting {
+                self_parent,
+                recipient,
+            },
+        };
+        Self::new(content)
+    }
+
+    /// Construct a new `Request` packed event.
+    pub fn new_request(creator: PeerId, self_parent: EventHash, other_parent: EventHash) -> Self {
+        let content = Content {
+            creator,
+            cause: Cause::Request {
+                self_parent,
+                other_parent,
+            },
+        };
+        Self::new(content)
+    }
+
+    /// Construct a new `Response` packed event.
+    pub fn new_response(creator: PeerId, self_parent: EventHash, other_parent: EventHash) -> Self {
+        let content = Content {
+            creator,
+            cause: Cause::Response {
+                self_parent,
+                other_parent,
+            },
+        };
+        Self::new(content)
+    }
+
+    /// Construct a new `Observation` packed event.
+    pub fn new_observation(
+        creator: PeerId,
+        self_parent: EventHash,
+        observation: Observation<Transaction, PeerId>,
+    ) -> Self {
+        let vote = Vote::new(&creator, observation);
+        let content = Content {
+            creator,
+            cause: Cause::Observation { self_parent, vote },
+        };
+        Self::new(content)
+    }
+
+    /// Construct a new `Initial` packed event.
+    pub fn new_initial(creator: PeerId) -> Self {
+        let content = Content {
+            creator,
+            cause: Cause::Initial,
+        };
+        Self::new(content)
+    }
+
+    fn new(content: Content<Vote<Transaction, PeerId>, EventHash, PeerId>) -> Self {
+        let serialised_content = serialise(&content);
+        let signature = content.creator.sign_detached(&serialised_content);
+        PackedEvent { content, signature }
+    }
+
+    /// Getter for the event's creator.
+    pub fn creator(&self) -> &PeerId {
+        &self.content.creator
     }
 }

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -100,9 +100,9 @@ pub enum Malice<T: NetworkEvent, P: PublicId> {
     SelfParentByDifferentCreator(Box<PackedEvent<T, P>>),
     /// The event should be a request with other_parent as a requesting event specifying this peer,
     /// but isn't.
-    InvalidRequest(EventHash),
+    InvalidRequest(Box<PackedEvent<T, P>>),
     /// The event should be a response to a request made to the peer, but isn't.
-    InvalidResponse(EventHash),
+    InvalidResponse(Box<PackedEvent<T, P>>),
     /// Detectable but unprovable malice. Relies on consensus.
     Unprovable(UnprovableMalice),
     /// A node is not reporting malice when it should.
@@ -128,12 +128,12 @@ impl<T: NetworkEvent, P: PublicId> Malice<T, P> {
             | Malice::IncorrectGenesis(hash)
             | Malice::Fork(hash)
             | Malice::InvalidAccusation(hash)
-            | Malice::InvalidRequest(hash)
-            | Malice::InvalidResponse(hash)
             | Malice::Accomplice(hash, _) => Some(hash),
             Malice::DuplicateVote(_, _)
             | Malice::OtherParentBySameCreator(_)
             | Malice::SelfParentByDifferentCreator(_)
+            | Malice::InvalidRequest(_)
+            | Malice::InvalidResponse(_)
             | Malice::Unprovable(_) => None,
         }
     }
@@ -144,8 +144,6 @@ impl<T: NetworkEvent, P: PublicId> Malice<T, P> {
 pub enum UnprovableMalice {
     // A node is spamming us.
     Spam,
-    InvalidRequestMessage,
-    InvalidResponseMessage,
     // Other, unspecified malice.
     Unspecified,
 }

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -98,9 +98,14 @@ pub enum Malice<T: NetworkEvent, P: PublicId> {
     /// Event's creator is different to its self_parent's creator. The accusation contains the
     /// original event so other peers can verify the accusation directly.
     SelfParentByDifferentCreator(Box<PackedEvent<T, P>>),
+    /// The event should be a request with other_parent as a requesting event specifying this peer,
+    /// but isn't.
+    InvalidRequest(EventHash),
+    /// The event should be a response to a request made to the peer, but isn't.
+    InvalidResponse(EventHash),
     /// Detectable but unprovable malice. Relies on consensus.
     Unprovable(UnprovableMalice),
-    /// A node is not reporting malice when it should
+    /// A node is not reporting malice when it should.
     Accomplice(EventHash, Box<Malice<T, P>>),
     // TODO: add other malice variants
 }
@@ -123,6 +128,8 @@ impl<T: NetworkEvent, P: PublicId> Malice<T, P> {
             | Malice::IncorrectGenesis(hash)
             | Malice::Fork(hash)
             | Malice::InvalidAccusation(hash)
+            | Malice::InvalidRequest(hash)
+            | Malice::InvalidResponse(hash)
             | Malice::Accomplice(hash, _) => Some(hash),
             Malice::DuplicateVote(_, _)
             | Malice::OtherParentBySameCreator(_)
@@ -137,6 +144,8 @@ impl<T: NetworkEvent, P: PublicId> Malice<T, P> {
 pub enum UnprovableMalice {
     // A node is spamming us.
     Spam,
+    InvalidRequestMessage,
+    InvalidResponseMessage,
     // Other, unspecified malice.
     Unspecified,
 }

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -11,8 +11,6 @@ use crate::block::{Block, BlockGroup};
 use crate::dev_utils::ParsedContents;
 use crate::dump_graph;
 use crate::error::{Error, Result};
-#[cfg(all(test, feature = "mock"))]
-use crate::gossip::EventHash;
 #[cfg(all(test, any(feature = "testing", feature = "mock")))]
 use crate::gossip::GraphSnapshot;
 use crate::gossip::{
@@ -25,6 +23,8 @@ use crate::meta_voting::{MetaElection, MetaEvent, MetaEventBuilder, MetaVote, Ob
 #[cfg(any(feature = "testing", all(test, feature = "mock")))]
 use crate::mock::{PeerId, Transaction};
 use crate::network_event::NetworkEvent;
+#[cfg(feature = "malice-detection")]
+use crate::observation::UnprovableMalice;
 use crate::observation::{
     is_more_than_two_thirds, ConsensusMode, Malice, Observation, ObservationHash, ObservationKey,
     ObservationStore,
@@ -320,13 +320,14 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             self.our_pub_id(),
             src
         );
+
+        #[cfg(feature = "malice-detection")]
+        self.detect_invalid_request_message(&req, src)?;
+
         let src_index = self.get_peer_index(src)?;
-
-        let other_parent = req.hash_of_last_event_created_by(src)?;
-        let other_parent = other_parent.and_then(|hash| self.graph.get_index(&hash));
-
-        let forking_peers = self.unpack_and_add_events(src_index, req.packed_events)?;
-        self.create_sync_event(src_index, true, forking_peers, other_parent)?;
+        let (other_parent, forking_peers) =
+            self.unpack_and_add_events(src_index, req.packed_events)?;
+        self.create_sync_event(true, other_parent, forking_peers)?;
         self.create_accusation_events()?;
         self.flush_pending_events()?;
 
@@ -346,13 +347,14 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             self.our_pub_id(),
             src
         );
+
+        #[cfg(feature = "malice-detection")]
+        self.detect_invalid_response_message(&resp, src)?;
+
         let src_index = self.get_peer_index(src)?;
-
-        let other_parent = resp.hash_of_last_event_created_by(src)?;
-        let other_parent = other_parent.and_then(|hash| self.graph.get_index(&hash));
-
-        let forking_peers = self.unpack_and_add_events(src_index, resp.packed_events)?;
-        self.create_sync_event(src_index, false, forking_peers, other_parent)?;
+        let (other_parent, forking_peers) =
+            self.unpack_and_add_events(src_index, resp.packed_events)?;
+        self.create_sync_event(false, other_parent, forking_peers)?;
         self.create_accusation_events()?;
         self.flush_pending_events()
     }
@@ -514,14 +516,20 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             .collect()
     }
 
+    // Returns the list peers which have created forked events, and the event to use as the
+    // other-parent when creating our sync event as a result of handling this message.
     fn unpack_and_add_events(
         &mut self,
         src_index: PeerIndex,
         packed_events: Vec<PackedEvent<T, S::PublicId>>,
-    ) -> Result<PeerIndexSet> {
+    ) -> Result<(EventIndex, PeerIndexSet)> {
         self.confirm_self_state(PeerState::RECV)?;
         self.confirm_peer_state(src_index, PeerState::SEND)?;
 
+        let hash_of_last_event = packed_events
+            .last()
+            .map(PackedEvent::compute_hash)
+            .ok_or_else(|| Error::InvalidMessage)?;
         let mut forking_peers = PeerIndexSet::default();
         for packed_event in packed_events {
             if let Some(event) = self.unpack(packed_event, &forking_peers)? {
@@ -552,7 +560,11 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         #[cfg(feature = "malice-detection")]
         self.detect_premature_gossip()?;
 
-        Ok(forking_peers)
+        let last_event_index = self
+            .graph
+            .get_index(&hash_of_last_event)
+            .ok_or_else(|| Error::InvalidMessage)?;
+        Ok((last_event_index, forking_peers))
     }
 
     fn unpack(
@@ -1426,19 +1438,12 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
 
     // Constructs a sync event to prove receipt of a `Request` or `Response` (depending on the value
     // of `is_request`) from `src`, then add it to our graph.
-    //
-    // `opt_other_parent` will contain the other-parent this new sync event should use, unless the
-    // gossip message from the peer was empty, in which case this will be `None` and we'll just use
-    // `src`'s most recent event we know of.
     fn create_sync_event(
         &mut self,
-        src_index: PeerIndex,
         is_request: bool,
+        other_parent: EventIndex,
         forking_peers: PeerIndexSet,
-        opt_other_parent: Option<EventIndex>,
     ) -> Result<()> {
-        let other_parent = self.other_parent_for_sync_event(src_index, opt_other_parent)?;
-
         if self.peer_list.last_event(PeerIndex::OUR).is_none() {
             self.pending_events.push(PendingEvent::Sync {
                 is_request,
@@ -1476,24 +1481,6 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
 
         let _ = self.add_event(event)?;
         Ok(())
-    }
-
-    fn other_parent_for_sync_event(
-        &self,
-        src_index: PeerIndex,
-        opt_other_parent: Option<EventIndex>,
-    ) -> Result<EventIndex> {
-        match opt_other_parent {
-            Some(index) => Ok(index),
-            None => self.peer_list.last_event(src_index).ok_or_else(|| {
-                log_or_panic!(
-                    "{:?} missing last event index of {:?}.",
-                    self.our_pub_id(),
-                    src_index
-                );
-                Error::Logic
-            }),
-        }
     }
 
     // Returns an iterator over `self.events` which will yield all the events we think `peer_id`
@@ -1640,6 +1627,8 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         self.detect_duplicate_vote(event);
         self.detect_fork(event);
         self.detect_invalid_accusation(event);
+        self.detect_invalid_request_event(event);
+        self.detect_invalid_response_event(event);
 
         // TODO: detect other forms of malice here
 
@@ -1946,6 +1935,8 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             | Malice::MissingGenesis(hash)
             | Malice::IncorrectGenesis(hash)
             | Malice::InvalidAccusation(hash)
+            | Malice::InvalidRequest(hash)
+            | Malice::InvalidResponse(hash)
             | Malice::Accomplice(hash, _) => self
                 .graph
                 .get_index(hash)
@@ -2055,6 +2046,83 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             })
             .cloned()
             .collect())
+    }
+
+    fn detect_invalid_request_message(
+        &mut self,
+        request: &Request<T, S::PublicId>,
+        src: &S::PublicId,
+    ) -> Result<()> {
+        let result = request.validate(src, self.event_context());
+        if result.is_err() {
+            let sender = self.get_peer_index(src)?;
+            self.accuse(
+                sender,
+                Malice::Unprovable(UnprovableMalice::InvalidRequestMessage),
+            );
+        }
+        result
+    }
+
+    fn detect_invalid_response_message(
+        &mut self,
+        response: &Response<T, S::PublicId>,
+        src: &S::PublicId,
+    ) -> Result<()> {
+        let result = response.validate(src, self.event_context());
+        if result.is_err() {
+            let sender = self.get_peer_index(src)?;
+            self.accuse(
+                sender,
+                Malice::Unprovable(UnprovableMalice::InvalidResponseMessage),
+            );
+        }
+        result
+    }
+
+    fn detect_invalid_request_event(&mut self, event: &Event<S::PublicId>) {
+        if !event.is_request() {
+            return;
+        }
+
+        let is_valid = self
+            .graph
+            .other_parent(event)
+            .map(|other_parent| {
+                Some(event.creator()) == other_parent.requesting_recipient()
+                    && self.graph.is_awaiting_associated_event(other_parent)
+            })
+            .unwrap_or(false);
+
+        if !is_valid {
+            self.accuse(event.creator(), Malice::InvalidRequest(*event.hash()));
+        }
+    }
+
+    fn detect_invalid_response_event(&mut self, event: &Event<S::PublicId>) {
+        if !event.is_response() {
+            return;
+        }
+
+        let is_valid = self
+            .graph
+            .other_parent(event)
+            .and_then(|other_parent| self.graph.self_sync_ancestor(other_parent))
+            .and_then(|request_event| {
+                self.graph
+                    .other_parent(request_event)
+                    .map(|requesting_event| (request_event, requesting_event))
+            })
+            .map(|(request_event, requesting_event)| {
+                Some(request_event.creator()) == requesting_event.requesting_recipient()
+                    && requesting_event.creator() == event.creator()
+                    && self.graph.is_awaiting_associated_event(request_event)
+            })
+            .unwrap_or(false);
+
+        if !is_valid {
+            self.accuse(event.creator(), Malice::InvalidResponse(*event.hash()));
+        }
     }
 
     fn genesis_group(&self) -> BTreeSet<&S::PublicId> {
@@ -2222,23 +2290,6 @@ impl<T: NetworkEvent, S: SecretId> TestParsec<T, S> {
     #[cfg(all(test, feature = "mock"))]
     pub fn consensused_blocks(&self) -> impl Iterator<Item = &Block<T, S::PublicId>> {
         self.0.consensused_blocks.iter().flatten()
-    }
-
-    #[cfg(all(test, feature = "mock"))]
-    pub fn create_sync_event(
-        &mut self,
-        src: &S::PublicId,
-        is_request: bool,
-        forking_peers: PeerIndexSet,
-        other_parent: Option<EventHash>,
-    ) -> Result<()> {
-        let src_index = unwrap!(self.0.peer_list.get_index(src));
-        let other_parent = other_parent
-            .as_ref()
-            .map(|hash| unwrap!(self.0.graph.get_index(hash)));
-
-        self.0
-            .create_sync_event(src_index, is_request, forking_peers, other_parent)
     }
 
     #[cfg(all(test, feature = "mock"))]


### PR DESCRIPTION
This PR adds validation that incoming messages are correct (wrt the sender correctly following the `Requesting` → `Request` → `Response` flow) and also similar validation for all sync events as they're added to the graph.

In the case of the former, the message isn't handled at all (no events are added to our graph) and an accusation of `UnprovableMalice` is made against the sender.

To allow efficient checking that a sync event's corresponding descendant hasn't yet been added, a hash-set containing all the `Requesting` and `Request` sync events which don't yet have their partner `Request` or `Response` sync event has been added to `Graph`.

This also required the `dev_utils::Record` to be updated for the case where, at the end of iterating through the parsed dot file creating actions, we send the final few events via a new Request.  For that message to be valid, we now also create a `Requesting` sync event by the sender.  This means that after running `Record::play()`, the parsec instance will have two events not contained in the input dot file.