### PR TITLE
MAID-3296: Fix interesting event detection in presence of forks

### DIFF
--- a/src/gossip/abstract_event.rs
+++ b/src/gossip/abstract_event.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::{observation::ObservationKey, peer_list::PeerIndex};
+
+/// Provide a small interface to Event not dependent on PublicId. Serves as a test seam.
+pub(crate) trait AbstractEventRef<'a>: Copy {
+    /// The vote payload_key for an Observation event
+    fn payload_key(self) -> Option<&'a ObservationKey>
+    where
+        Self: Sized;
+
+    /// The PeerIndex for this event creator
+    fn creator(self) -> PeerIndex
+    where
+        Self: Sized;
+
+    // Index of this event relative to other events by the same creator.
+    fn index_by_creator(self) -> usize
+    where
+        Self: Sized;
+}

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -33,36 +33,6 @@ use std::cmp;
 use std::collections::BTreeMap;
 use std::fmt::{self, Debug, Display, Formatter};
 
-/// Provide a small interface to Event not dependent on PublicId. Serves as a test seam.
-pub(crate) trait AbstractEvent {
-    /// Returns whether this event can see `other`, i.e. whether there's a directed path from `other`
-    /// to `self` in the graph, and no two events created by `other`'s creator are ancestors to
-    /// `self` (fork).
-    fn sees<E: AsRef<Self>>(&self, other: E) -> bool
-    where
-        Self: Sized;
-
-    /// The vote payload_key for an Observation event
-    fn payload_key(&self) -> Option<&ObservationKey>
-    where
-        Self: Sized;
-
-    /// The PeerIndex for this event creator
-    fn creator(&self) -> PeerIndex
-    where
-        Self: Sized;
-
-    /// Whether we have seen any forking peers
-    fn sees_fork(&self) -> bool
-    where
-        Self: Sized;
-
-    // Index of this event relative to other events by the same creator.
-    fn index_by_creator(&self) -> usize
-    where
-        Self: Sized;
-}
-
 pub(crate) struct Event<P: PublicId> {
     content: Content<VoteKey<P>, EventIndex, PeerIndex>,
     // Creator's signature of `content`.
@@ -431,28 +401,6 @@ impl<P: PublicId> Event<P> {
     #[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
     pub fn cause(&self) -> &Cause<VoteKey<P>, EventIndex, PeerIndex> {
         &self.content.cause
-    }
-}
-
-impl<P: PublicId> AbstractEvent for Event<P> {
-    fn sees<E: AsRef<Self>>(&self, other: E) -> bool {
-        self.sees(other)
-    }
-
-    fn payload_key(&self) -> Option<&ObservationKey> {
-        self.payload_key()
-    }
-
-    fn creator(&self) -> PeerIndex {
-        self.creator()
-    }
-
-    fn sees_fork(&self) -> bool {
-        self.sees_fork()
-    }
-
-    fn index_by_creator(&self) -> usize {
-        self.index_by_creator()
     }
 }
 

--- a/src/gossip/graph/event_ref.rs
+++ b/src/gossip/graph/event_ref.rs
@@ -6,11 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::super::event::Event;
-use super::event_index::EventIndex;
-use crate::id::PublicId;
-use std::cmp::{Ord, Ordering, PartialOrd};
-use std::ops::Deref;
+use super::{
+    super::{abstract_event::AbstractEventRef, event::Event},
+    event_index::EventIndex,
+};
+use crate::{id::PublicId, observation::ObservationKey, peer_list::PeerIndex};
+use std::{
+    cmp::{Ord, Ordering, PartialOrd},
+    ops::Deref,
+};
 
 /// Reference to `Event` together with its index.
 #[derive(Clone, Debug)]
@@ -69,5 +73,19 @@ impl<'a, P: PublicId> PartialOrd for IndexedEventRef<'a, P> {
 impl<'a, P: PublicId> Ord for IndexedEventRef<'a, P> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.index.cmp(&other.index)
+    }
+}
+
+impl<'a, P: PublicId> AbstractEventRef<'a> for IndexedEventRef<'a, P> {
+    fn payload_key(self) -> Option<&'a ObservationKey> {
+        self.event.payload_key()
+    }
+
+    fn creator(self) -> PeerIndex {
+        self.event.creator()
+    }
+
+    fn index_by_creator(self) -> usize {
+        self.event.index_by_creator()
     }
 }

--- a/src/gossip/mod.rs
+++ b/src/gossip/mod.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+mod abstract_event;
 mod cause;
 mod content;
 mod event;
@@ -15,13 +16,14 @@ mod graph;
 mod messages;
 mod packed_event;
 
+pub(super) use self::abstract_event::AbstractEventRef;
 #[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
 pub(super) use self::cause::Cause;
 #[cfg(test)]
 pub(super) use self::event::find_event_by_short_name;
 #[cfg(any(test, feature = "testing"))]
 pub(super) use self::event::CauseInput;
-pub(super) use self::event::{AbstractEvent, Event};
+pub(super) use self::event::Event;
 #[cfg(all(test, feature = "mock", feature = "malice-detection"))]
 pub(super) use self::event_context::EventContext;
 pub(super) use self::event_context::EventContextRef;

--- a/src/meta_voting/meta_election.rs
+++ b/src/meta_voting/meta_election.rs
@@ -157,10 +157,6 @@ impl MetaElection {
         self.continue_consensus_start_index
     }
 
-    pub fn new_consensus_start_index(&self) -> usize {
-        self.new_consensus_start_index
-    }
-
     /// Starts new election.
     pub fn new_election<P: PublicId>(
         &mut self,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -410,8 +410,6 @@ fn extensive_dynamic_membership() {
 // execute it when the feature is disabled.
 // TODO: remove this after MAID-3270 is completed.
 #[cfg(not(feature = "malice-detection"))]
-// TODO: remove this after MAID-3164 is completed.
-#[ignore]
 #[test]
 fn consensus_with_fork() {
     let mut env = Environment::new(SEED);


### PR DESCRIPTION
This PR changes the implementation of the detection of interesting event to not be based on the `sees` relation, but instead on the `is_descendant`. This makes it resilient to forks as the result of `is_descendant` never changes retroactively (unlike `sees`).