### PR TITLE
MAID-2939 + MAID-3204 + MAID-3283 + MAID-3292: Fork resilience

### DIFF
--- a/input_graphs/functional_tests_sees/alice.dot
+++ b/input_graphs/functional_tests_sees/alice.dot
@@ -1,0 +1,172 @@
+/// our_id: Alice
+/// peer_list: {
+///   Alice: PeerState(VOTE|SEND|RECV)
+///   Bob: PeerState(VOTE|SEND|RECV)
+///   Carol: PeerState(VOTE|SEND|RECV)
+/// }
+/// consensus_mode: Supermajority
+digraph GossipGraph {
+  splines=false
+  rankdir=BT
+
+  style=invis
+  subgraph cluster_Alice {
+    label="Alice"
+    "Alice" [style=invis]
+    "Alice" -> "A_0" [style=invis]
+    "A_0" -> "A_1" [minlen=1]
+    "A_1" -> "A_2" [minlen=2]
+    "A_2" -> "A_3" [minlen=2]
+  }
+  "C_2,0" -> "A_2" [constraint=false]
+  "B_3" -> "A_3" [constraint=false]
+
+  style=invis
+  subgraph cluster_Bob {
+    label="Bob"
+    "Bob" [style=invis]
+    "Bob" -> "B_0" [style=invis]
+    "B_0" -> "B_1" [minlen=1]
+    "B_1" -> "B_2" [minlen=2]
+    "B_2" -> "B_3" [minlen=1]
+  }
+  "C_2,1" -> "B_2" [constraint=false]
+
+  style=invis
+  subgraph cluster_Carol {
+    label="Carol"
+    "Carol" [style=invis]
+    "Carol" -> "C_0" [style=invis]
+    "C_0" -> "C_1" [minlen=1]
+    "C_1" -> "C_2,0" [minlen=1]
+    "C_1" -> "C_2,1" [minlen=1]
+  }
+
+
+  {
+    rank=same
+    "Alice" [style=filled, color=white]
+    "Bob" [style=filled, color=white]
+    "Carol" [style=filled, color=white]
+  }
+  "Alice" -> "Bob" -> "Carol" [style=invis]
+
+/// ===== details of events =====
+  "A_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_0</td></tr>
+</table>>]
+/// cause: Initial
+/// last_ancestors: {Alice: 0}
+
+  "A_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_1</td></tr>
+<tr><td colspan="6">Genesis({Alice, Bob, Carol})</td></tr>
+</table>>]
+/// cause: Observation(Genesis({Alice, Bob, Carol}))
+/// last_ancestors: {Alice: 1}
+
+  "A_2" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_2</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 2, Carol: 2}
+
+  "A_3" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_3</td></tr>
+<tr><td colspan="6">[Genesis({Alice, Bob, Carol})]</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 3, Bob: 3, Carol: 2}
+
+  "B_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_0</td></tr>
+</table>>]
+/// cause: Initial
+/// last_ancestors: {Bob: 0}
+
+  "B_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_1</td></tr>
+<tr><td colspan="6">Genesis({Alice, Bob, Carol})</td></tr>
+</table>>]
+/// cause: Observation(Genesis({Alice, Bob, Carol}))
+/// last_ancestors: {Bob: 1}
+
+  "B_2" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_2</td></tr>
+</table>>]
+/// cause: Request
+/// last_ancestors: {Bob: 2, Carol: 2}
+
+  "B_3" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_3</td></tr>
+</table>>]
+/// cause: Requesting(Alice)
+/// last_ancestors: {Bob: 3, Carol: 2}
+
+  "C_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_0</td></tr>
+</table>>]
+/// cause: Initial
+/// last_ancestors: {Carol: 0}
+
+  "C_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_1</td></tr>
+<tr><td colspan="6">Genesis({Alice, Bob, Carol})</td></tr>
+</table>>]
+/// cause: Observation(Genesis({Alice, Bob, Carol}))
+/// last_ancestors: {Carol: 1}
+
+  "C_2,0" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_2,0</td></tr>
+</table>>]
+/// cause: Requesting(Alice)
+/// last_ancestors: {Carol: 2}
+
+  "C_2,1" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_2,1</td></tr>
+</table>>]
+/// cause: Requesting(Bob)
+/// last_ancestors: {Carol: 2}
+
+}
+
+/// ===== meta-elections =====
+/// consensus_history:
+
+/// round_hashes: {
+///   Alice -> [
+///     RoundHash { round: 0, latest_block_hash: 0000000000000000000000000000000000000000000000000000000000000000 }
+///   ]
+///   Bob -> [
+///     RoundHash { round: 0, latest_block_hash: 0000000000000000000000000000000000000000000000000000000000000000 }
+///   ]
+///   Carol -> [
+///     RoundHash { round: 0, latest_block_hash: 0000000000000000000000000000000000000000000000000000000000000000 }
+///   ]
+/// }
+/// interesting_events: {
+///   Alice -> ["A_3"]
+/// }
+/// all_voters: {Alice, Bob, Carol}
+/// unconsensused_events: {"A_1", "B_1", "C_1"}
+/// meta_events: {
+///   A_2 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   A_3 -> {
+///     observees: {}
+///     interesting_content: [Genesis({Alice, Bob, Carol})]
+///   }
+///   B_2 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   B_3 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+///   C_2,1 -> {
+///     observees: {}
+///     interesting_content: []
+///   }
+/// }

--- a/src/dev_utils/macros.rs
+++ b/src/dev_utils/macros.rs
@@ -1,0 +1,37 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+#[cfg(all(test, feature = "mock"))]
+macro_rules! btree_set {
+    () => {
+        BTreeSet::new()
+    };
+
+    ($($item:expr),*) => {{
+        let mut set = BTreeSet::new();
+        $(
+            let _ = set.insert($item);
+        )*
+        set
+    }}
+}
+
+#[cfg(test)]
+macro_rules! btree_map {
+    () => {
+        BTreeMap::new()
+    };
+
+    ($($key:expr => $value:expr),*) => {{
+        let mut map = BTreeMap::new();
+        $(
+            let _ = map.insert($key, $value);
+        )*
+        map
+    }}
+}

--- a/src/dev_utils/misc.rs
+++ b/src/dev_utils/misc.rs
@@ -1,0 +1,49 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use std::{cmp::Ordering, fmt::Debug};
+
+/// Testing related extensions to `Iterator`.
+pub trait TestIterator: Iterator {
+    /// Returns the only element in the iterator. Panics if the iterator yields less or more than
+    /// one element.
+    fn only(mut self) -> Self::Item
+    where
+        Self: Sized,
+        Self::Item: Debug,
+    {
+        let item = unwrap!(self.next(), "Expected one element - got none.");
+        assert!(
+            self.by_ref().peekable().peek().is_none(),
+            "Expected one element - got more (excess: {:?}).",
+            self.collect::<Vec<_>>()
+        );
+        item
+    }
+
+    fn is_sorted(mut self) -> bool
+    where
+        Self: Sized,
+        Self::Item: PartialOrd,
+    {
+        if let Some(mut first) = self.next() {
+            for second in self {
+                match first.partial_cmp(&second) {
+                    Some(Ordering::Less) | Some(Ordering::Equal) => {
+                        first = second;
+                    }
+                    _ => return false,
+                }
+            }
+        }
+
+        true
+    }
+}
+
+impl<I: Iterator> TestIterator for I {}

--- a/src/dev_utils/mod.rs
+++ b/src/dev_utils/mod.rs
@@ -6,6 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#[macro_use]
+mod macros;
+
 /// This is used to read a dumped dot file and rebuild the event graph and associated info.
 #[cfg(any(test, feature = "testing"))]
 mod dot_parser;

--- a/src/dev_utils/mod.rs
+++ b/src/dev_utils/mod.rs
@@ -10,6 +10,7 @@
 #[cfg(any(test, feature = "testing"))]
 mod dot_parser;
 mod environment;
+mod misc;
 mod network;
 mod peer;
 mod peer_statuses;
@@ -29,6 +30,7 @@ pub(crate) use self::dot_parser::ParsedContents;
 pub use self::record::Record;
 pub use self::{
     environment::{Environment, RngChoice},
+    misc::TestIterator,
     network::{ConsensusError, Network},
     peer::{NetworkView, Peer, PeerStatus},
     peer_statuses::PeerStatuses,

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -134,11 +134,9 @@ impl MaliciousComponents {
         let _ = unwrap!(self.test_parsec.create_gossip(&dummy_recipient_id));
 
         // Create the forking event.
-        let forking_peers = Default::default();
         let event = unwrap!(Event::new_from_requesting(
             common_self_parent_index,
             recipient_id,
-            &forking_peers,
             self.test_parsec.event_context()
         ));
         let forked_event = ForkedEvent {

--- a/src/dev_utils/record.rs
+++ b/src/dev_utils/record.rs
@@ -351,7 +351,7 @@ mod tests {
 
     // Note: skip this test when malice-detection is enabled, because there could be a mismatch
     // between parsed and replayed graphs when the dot file contains malice (e.g.: fork). This is
-    // because parsing does not create accusation events but replaing does.
+    // because parsing does not create accusation events but replaying does.
     #[cfg(not(feature = "malice-detection"))]
     #[test]
     fn smoke_parsec() {

--- a/src/dev_utils/record.rs
+++ b/src/dev_utils/record.rs
@@ -268,8 +268,7 @@ fn collect_remaining_events_to_gossip(
 mod tests {
     use super::*;
     use crate::parsec::get_graph_snapshot;
-    use std::{fs, iter, path::PathBuf, thread};
-    use walkdir::WalkDir;
+    use std::{iter, path::PathBuf, thread};
 
     #[derive(PartialEq, Eq, Debug)]
     struct TruncatedHashes<'th> {
@@ -350,13 +349,21 @@ mod tests {
         }
     }
 
+    // Note: skip this test when malice-detection is enabled, because there could be a mismatch
+    // between parsed and replayed graphs when the dot file contains malice (e.g.: fork). This is
+    // because parsing does not create accusation events but replaing does.
+    #[cfg(not(feature = "malice-detection"))]
     #[test]
     fn smoke_parsec() {
+        use std::fs;
+        use walkdir::WalkDir;
+
         let is_dot_file = |path: &PathBuf| {
             path.extension()
                 .map(|extension| extension.to_string_lossy() == "dot")
                 .unwrap_or(false)
         };
+
         // 50kB seems to strike a reasonable balance between including quite a few dot files, while
         // not having too big of an impact on the test's running time.
         let max_file_size = 50_000;

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -398,17 +398,42 @@ mod detail {
         fn index_to_short_name(&self, index: EventIndex) -> Option<String> {
             self.gossip_graph
                 .get(index)
-                .map(|event| self.event_to_short_name(&event))
+                .map(|event| self.event_to_short_name(event))
         }
 
-        fn event_to_short_name(&self, event: &Event<S::PublicId>) -> String {
+        fn event_to_short_name(&self, event: IndexedEventRef<S::PublicId>) -> String {
             let peer_short_name: &str = self
                 .short_peer_ids
                 .get(event.creator())
                 .map(|id| id.as_str())
                 .unwrap_or("???");
 
-            format!("{}_{}", peer_short_name, event.index_by_creator())
+            if let Some(fork_index) = self.fork_index(event) {
+                format!(
+                    "{}_{},{}",
+                    peer_short_name,
+                    event.index_by_creator(),
+                    fork_index
+                )
+            } else {
+                format!("{}_{}", peer_short_name, event.index_by_creator())
+            }
+        }
+
+        fn fork_index(&self, event: IndexedEventRef<S::PublicId>) -> Option<usize> {
+            if self
+                .peer_list
+                .events_by_index(event.creator(), event.index_by_creator())
+                .take(2)
+                .count()
+                <= 1
+            {
+                return None;
+            }
+
+            self.peer_list
+                .events_by_index(event.creator(), event.index_by_creator())
+                .position(|event_index| event_index == event.event_index())
         }
 
         fn writeln(&mut self, args: fmt::Arguments) -> io::Result<()> {
@@ -557,7 +582,7 @@ mod detail {
                 lines.push(format!(
                     "    {} -> \"{}\" {}",
                     before_arrow,
-                    self.event_to_short_name(&event),
+                    self.event_to_short_name(event),
                     suffix
                 ));
             }
@@ -580,8 +605,8 @@ mod detail {
                 {
                     lines.push(format!(
                         "  \"{}\" -> \"{}\" [constraint=false]",
-                        self.event_to_short_name(&other_parent),
-                        self.event_to_short_name(&event)
+                        self.event_to_short_name(other_parent),
+                        self.event_to_short_name(event)
                     ));
                 }
             }
@@ -623,14 +648,14 @@ mod detail {
                 if let Some(event) = self.gossip_graph.get(event_index) {
                     let attr = EventAttributes::new(
                         event.inner(),
-                        self.event_to_short_name(event.inner()),
+                        self.event_to_short_name(event),
                         meta_events.get(&event_index),
                         self.observations,
                         &self.short_peer_ids,
                     );
                     self.writeln(format_args!(
                         "  \"{}\" {}",
-                        self.event_to_short_name(&event),
+                        self.event_to_short_name(event),
                         attr.to_string()
                     ))?;
 
@@ -798,7 +823,7 @@ mod detail {
                     let creator_id = self.peer_ids.get(event.creator())?;
 
                     let creator_and_index = (creator_id, event.index_by_creator());
-                    let short_name_and_mev = (self.event_to_short_name(&event), mev);
+                    let short_name_and_mev = (self.event_to_short_name(event), mev);
                     Some((creator_and_index, short_name_and_mev))
                 })
                 .collect::<BTreeMap<_, _>>();
@@ -894,7 +919,7 @@ mod detail {
             observations: &DotObservationStore,
             short_peer_ids: &PeerIndexMap<String>,
         ) -> Self {
-            let mut attr = EventAttributes {
+            let mut attr = Self {
                 fillcolor: "fillcolor=white",
                 is_rectangle: false,
                 label: event_short_name,

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -636,7 +636,8 @@ mod detail {
 
                     self.write_cause_to_dot_format(&event)?;
 
-                    let last_ancestors = self.convert_peer_index_map(event.last_ancestors());
+                    let last_ancestors = event.last_ancestors().collect();
+                    let last_ancestors = self.convert_peer_index_map(&last_ancestors);
                     writeln!(&mut self.file, "/// last_ancestors: {:?}", last_ancestors)?;
 
                     self.writeln(format_args!(""))?;

--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     block::Block,
-    dev_utils::{parse_test_dot_file, Record},
+    dev_utils::{parse_test_dot_file, Record, TestIterator},
     error::Error,
     gossip::{Event, Graph, GraphSnapshot},
     id::{Proof, PublicId},
@@ -18,7 +18,7 @@ use crate::{
     parsec::TestParsec,
     peer_list::{PeerListSnapshot, PeerState},
 };
-use std::{collections::BTreeSet, fmt::Debug};
+use std::collections::BTreeSet;
 
 macro_rules! assert_matches {
     ($actual:expr, $expected:pat) => {
@@ -65,27 +65,6 @@ impl Snapshot {
 fn nth_event<P: PublicId>(graph: &Graph<P>, n: usize) -> &Event<P> {
     unwrap!(graph.iter_from(n).next()).inner()
 }
-
-/// Testing related extensions to `Iterator`.
-trait TestIterator: Iterator {
-    /// Returns the only element in the iterator. Panics if the iterator yields less or more than
-    /// one element.
-    fn only(mut self) -> Self::Item
-    where
-        Self: Sized,
-        Self::Item: Debug,
-    {
-        let item = unwrap!(self.next(), "Expected one element - got none.");
-        assert!(
-            self.by_ref().peekable().peek().is_none(),
-            "Expected one element - got more (excess: {:?}).",
-            self.collect::<Vec<_>>()
-        );
-        item
-    }
-}
-
-impl<I: Iterator> TestIterator for I {}
 
 #[test]
 fn from_existing() {

--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -504,6 +504,7 @@ fn gossip_after_fork() {
 
 #[test]
 fn sees() {
+    // This graph contains fork.
     let record = Record::from(parse_test_dot_file("alice.dot"));
     let alice = TestParsec::from(record.play());
 
@@ -514,14 +515,23 @@ fn sees() {
     let c2_0 = unwrap!(alice.graph().find_by_short_name("C_2,0"));
     let c2_1 = unwrap!(alice.graph().find_by_short_name("C_2,1"));
 
+    // Simple no fork cases:
+    assert!(a3.sees(a3));
+    assert!(a3.sees(a2));
+    assert!(a3.sees(b2));
+
+    // A2 cannot prove the fork because it has only the first side of it in its ancestry.
     assert!(a2.sees(c1));
     assert!(a2.sees(c2_0));
     assert!(!a2.sees(c2_1));
 
+    // Similarly, B2 has only the second side of the fork in its ancestry and so cannot prove it
+    // either.
     assert!(b2.sees(c1));
     assert!(!b2.sees(c2_0));
     assert!(b2.sees(c2_1));
 
+    // A3, on the other hand, has both sides of the fork in its ancestry and so can prove it.
     assert!(!a3.sees(c1));
     assert!(!a3.sees(c2_0));
     assert!(!a3.sees(c2_1));

--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -29,16 +29,6 @@ macro_rules! assert_matches {
     };
 }
 
-macro_rules! btree_set {
-    ($($item:expr),*) => {{
-        let mut set = BTreeSet::new();
-        $(
-            let _ = set.insert($item);
-        )*
-        set
-    }}
-}
-
 #[derive(Debug, PartialEq, Eq)]
 struct Snapshot {
     peer_list: PeerListSnapshot<PeerId>,

--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -10,7 +10,7 @@ use crate::{
     block::Block,
     dev_utils::{parse_test_dot_file, Record},
     error::Error,
-    gossip::{Event, EventContext, Graph, GraphSnapshot, Request},
+    gossip::{Event, Graph, GraphSnapshot},
     id::{Proof, PublicId},
     meta_voting::MetaElectionSnapshot,
     mock::{self, PeerId, Transaction},
@@ -504,93 +504,8 @@ fn gossip_after_fork() {
 
 #[test]
 fn sees() {
-    //
-    // Construct gossip graph like this and then verify the sees relation between various pairs of
-    // events.
-    //
-    // (A3)---------+                           - request
-    //  |           |
-    //  |           |
-    //  |          (B3)                         - requesting
-    //  |           |
-    //  |           |
-    // (A2)----+   (B2)--------------+          - request
-    //  |      |    |                |
-    //  |      |    |                |
-    //  |      +---------(C2,0)    (C2,1)       - requesting
-    //  |           |      |         |
-    //  |           |      +----+----+
-    //  |           |           |
-    // (A1)        (B1)        (C1)             - genesis
-    //  |           |           |
-    // (A0)        (B0)        (C0)             - initial
-    //
-
-    let alice_id = PeerId::new("Alice");
-    let bob_id = PeerId::new("Bob");
-    let carol_id = PeerId::new("Carol");
-    let genesis = btree_set![alice_id.clone(), bob_id.clone(), carol_id.clone()];
-
-    let mut alice =
-        TestParsec::from_genesis(alice_id.clone(), &genesis, ConsensusMode::Supermajority);
-    let mut bob = TestParsec::from_genesis(bob_id.clone(), &genesis, ConsensusMode::Supermajority);
-
-    // Create Carol's events outside of Parsec, because we need to create a fork.
-    let mut carol_ctx = EventContext::new(carol_id.clone());
-    let _ = carol_ctx
-        .peer_list
-        .add_peer(alice_id.clone(), PeerState::active());
-    let _ = carol_ctx
-        .peer_list
-        .add_peer(bob_id.clone(), PeerState::active());
-
-    let c0 = Event::new_initial(carol_ctx.as_ref());
-    let c0_packed = unwrap!(c0.pack(carol_ctx.as_ref()));
-    let c0_index = carol_ctx.graph.insert(c0).event_index();
-
-    let (c1, obs) = unwrap!(Event::new_from_observation(
-        c0_index,
-        Observation::Genesis(genesis.clone()),
-        carol_ctx.as_ref()
-    ));
-    let (obs_key, obs_info) = unwrap!(obs);
-    let _ = carol_ctx.observations.insert(obs_key, obs_info);
-    let c1_packed = unwrap!(c1.pack(carol_ctx.as_ref()));
-    let c1_index = carol_ctx.graph.insert(c1).event_index();
-
-    let c2_0 = unwrap!(Event::new_from_requesting(
-        c1_index,
-        &alice_id,
-        carol_ctx.as_ref()
-    ));
-    let c2_0_packed = unwrap!(c2_0.pack(carol_ctx.as_ref()));
-    let _ = carol_ctx.graph.insert(c2_0).event_index();
-
-    let c2_1 = unwrap!(Event::new_from_requesting(
-        c1_index,
-        &bob_id,
-        carol_ctx.as_ref()
-    ));
-    let c2_1_packed = unwrap!(c2_1.pack(carol_ctx.as_ref()));
-    let _ = carol_ctx.graph.insert(c2_1).event_index();
-
-    // Send one side of the fork to Alice...
-    let request = Request {
-        packed_events: vec![c0_packed.clone(), c1_packed.clone(), c2_0_packed],
-    };
-    let _ = unwrap!(alice.handle_request(&carol_id, request));
-
-    // ...and the other to Bob.
-    let request = Request {
-        packed_events: vec![c0_packed, c1_packed, c2_1_packed],
-    };
-    let _ = unwrap!(bob.handle_request(&carol_id, request));
-
-    // Send gossip from Bob to Alice, so Alice will have all the events.
-    let request = unwrap!(bob.create_gossip(&alice_id));
-    let _ = unwrap!(alice.handle_request(&bob_id, request));
-
-    // Verify the sees relations
+    let record = Record::from(parse_test_dot_file("alice.dot"));
+    let alice = TestParsec::from(record.play());
 
     let a2 = unwrap!(alice.graph().find_by_short_name("A_2"));
     let a3 = unwrap!(alice.graph().find_by_short_name("A_3"));

--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -6,8 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(feature = "malice-detection")]
-use crate::peer_list::PeerIndexSet;
 use crate::{
     block::Block,
     dev_utils::{parse_test_dot_file, Record},
@@ -1157,7 +1155,6 @@ mod handle_malice {
         let b_2 = unwrap!(Event::new_from_request(
             b_1_index,
             b_0_index,
-            &PeerIndexSet::default(),
             bob_contents.event_context()
         ));
         let b_2_hash = *b_2.hash();
@@ -1273,7 +1270,6 @@ mod handle_malice {
         let a_1 = unwrap!(Event::new_from_requesting(
             a_0_index,
             &bob_id,
-            &PeerIndexSet::new(),
             alice.as_ref(),
         ));
         let a_1_hash = *a_1.hash();
@@ -1314,18 +1310,12 @@ mod handle_malice {
 
         let b_0 = Event::new_initial(bob.as_ref());
         let b_0 = unwrap!(b_0.pack(bob.as_ref()));
-        let b_0 = unwrap!(unwrap!(Event::unpack(
-            b_0,
-            &PeerIndexSet::new(),
-            alice.as_ref()
-        )))
-        .event;
+        let b_0 = unwrap!(unwrap!(Event::unpack(b_0, alice.as_ref()))).event;
         let b_0_index = alice.graph.insert(b_0).event_index();
 
         let a_1 = unwrap!(Event::new_from_request(
             a_0_index,
             b_0_index,
-            &PeerIndexSet::new(),
             alice.as_ref()
         ));
         let a_1_hash = *a_1.hash();

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -261,7 +261,7 @@ impl<P: PublicId> Event<P> {
 
         if let Some(self_forks) = self_info.forks.get(&other.index_by_creator()) {
             if let Some(other_forks) = other.fork_set() {
-                self_forks.intersects(other_forks)
+                !self_forks.is_disjoint(other_forks)
             } else {
                 self_forks.contains(0)
             }

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -274,8 +274,8 @@ impl<P: PublicId> Event<P> {
     }
 
     // Returns whether this event sees `other`, i.e. whether there's a directed path from `other`
-    // to `self` in the graph, and there doesn't exists any pair of events by `other`'s creator
-    // such that they are ancestors of this event but one is neither ancestor not descendant of the
+    // to `self` in the graph, and there doesn't exist any pair of events by `other`'s creator
+    // such that they are ancestors of this event but one is neither ancestor nor descendant of the
     // other.
     pub fn sees<E: AsRef<Event<P>>>(&self, other: E) -> bool {
         !self.sees_fork_by(other.as_ref().creator()) && self.is_descendant_of(other)
@@ -294,6 +294,12 @@ impl<P: PublicId> Event<P> {
     }
 
     // Fork set that this event is a member of.
+    //
+    // ("fork set" is a set of events from the same creator that have the same `index_by_creator`.
+    // This can be events that have the same self-parent, or the same self-grand-parent, etc...)
+    //
+    // If this event is not member of a fork set (it's not forking) or is the first member of its
+    // fork set (in the insertion order), this function returns `None`.
     pub fn fork_set(&self) -> Option<&IndexSet> {
         self.cache
             .ancestor_info

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -660,7 +660,7 @@ where
     let short_name = short_name.to_uppercase();
     events
         .into_iter()
-        .find(|event| event.short_name().to_string() == short_name)
+        .find(move |event| event.short_name().to_string() == short_name)
 }
 
 #[cfg(any(test, feature = "testing"))]

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -6,12 +6,17 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#[cfg(any(test, feature = "testing"))]
+use super::event_utils::ForkMap;
+#[cfg(test)]
+use super::graph::IndexedEventRef;
 use super::{
     cause::{self, Cause},
     content::Content,
     event_context::EventContextRef,
     event_hash::EventHash,
-    graph::{EventIndex, Graph, IndexedEventRef},
+    event_utils::{compute_ancestor_info, AncestorInfo, IndexSet},
+    graph::{EventIndex, Graph},
     packed_event::PackedEvent,
 };
 use crate::{
@@ -20,7 +25,7 @@ use crate::{
     id::{PublicId, SecretId},
     network_event::NetworkEvent,
     observation::{Observation, ObservationForStore, ObservationKey, ObservationStore},
-    peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet, PeerList},
+    peer_list::{PeerIndex, PeerIndexMap, PeerList},
     serialise,
     vote::{Vote, VoteKey},
 };
@@ -29,12 +34,10 @@ use crate::{
     mock::{PeerId, Transaction},
     observation::ConsensusMode,
 };
+use itertools::Itertools;
 #[cfg(any(test, feature = "testing"))]
 use std::collections::BTreeMap;
-use std::{
-    cmp,
-    fmt::{self, Debug, Display, Formatter},
-};
+use std::fmt::{self, Debug, Display, Formatter};
 
 pub(crate) struct Event<P: PublicId> {
     content: Content<VoteKey<P>, EventIndex, PeerIndex>,
@@ -244,40 +247,60 @@ impl<P: PublicId> Event<P> {
         })
     }
 
-    // Returns whether this event can see `other`, i.e. whether there's a directed path from `other`
-    // to `self` in the graph, and no two events created by `other`'s creator are ancestors to
-    // `self` (fork).
-    pub fn sees<E: AsRef<Event<P>>>(&self, other: E) -> bool {
-        self.is_descendant_of(other).unwrap_or(false)
-    }
+    // Returns whether this event is descendant of `other`.
+    pub fn is_descendant_of<E: AsRef<Event<P>>>(&self, other: E) -> bool {
+        let other = other.as_ref();
 
-    // Returns whether this event is descendant of `other`. If there are forks between this event
-    // and `other` the answer cannot be determined from the events themselves and graph traversal
-    // is required. `None` is returned in that case. Otherwise returns `Some` with the correct
-    // answer.
-    pub fn is_descendant_of<E: AsRef<Event<P>>>(&self, other: E) -> Option<bool> {
-        match self.last_ancestor_by(other.as_ref().creator()) {
-            LastAncestor::Some(last_index) => Some(last_index >= other.as_ref().index_by_creator()),
-            LastAncestor::None => Some(false),
-            LastAncestor::Fork => None,
-        }
-    }
-
-    // Returns the index-by-creator of the last ancestor of this event created by the given peer.
-    pub fn last_ancestor_by(&self, peer_index: PeerIndex) -> LastAncestor {
-        if self.is_forking_peer(peer_index) {
-            LastAncestor::Fork
+        let self_info = if let Some(info) = self.cache.ancestor_info.get(other.creator()) {
+            info
         } else {
-            self.cache
-                .last_ancestors
-                .get(peer_index)
-                .map(|last_index| LastAncestor::Some(*last_index))
-                .unwrap_or(LastAncestor::None)
+            return false;
+        };
+
+        if self_info.last < other.index_by_creator() {
+            return false;
+        }
+
+        if let Some(self_forks) = self_info.forks.get(&other.index_by_creator()) {
+            if let Some(other_forks) = other.fork_set() {
+                self_forks.intersects(other_forks)
+            } else {
+                self_forks.contains(0)
+            }
+        } else {
+            other
+                .fork_set()
+                .map(|other_forks| other_forks.contains(0))
+                .unwrap_or(true)
         }
     }
 
-    pub(crate) fn is_forking_peer(&self, peer_index: PeerIndex) -> bool {
-        self.cache.forking_peers.contains(peer_index)
+    // Returns whether this event sees `other`, i.e. whether there's a directed path from `other`
+    // to `self` in the graph, and there doesn't exists any pair of events by `other`'s creator
+    // such that they are ancestors of this event but one is neither ancestor not descendant of the
+    // other.
+    pub fn sees<E: AsRef<Event<P>>>(&self, other: E) -> bool {
+        !self.sees_fork_by(other.as_ref().creator()) && self.is_descendant_of(other)
+    }
+
+    // Is this event aware of a fork by the given peer?
+    // Note this method returns true only if the fork is provable by every node that has reached
+    // this event. That means this event must have ancestors from at least two sides of the same
+    // fork.
+    pub fn sees_fork_by(&self, creator: PeerIndex) -> bool {
+        self.cache
+            .ancestor_info
+            .get(creator)
+            .map(|info| info.forks.values().any(|fork_set| fork_set.len() > 1))
+            .unwrap_or(false)
+    }
+
+    // Fork set that this event is a member of.
+    fn fork_set(&self) -> Option<&IndexSet> {
+        self.cache
+            .ancestor_info
+            .get(self.creator())
+            .and_then(|info| info.forks.get(&self.index_by_creator()))
     }
 
     pub fn payload_key(&self) -> Option<&ObservationKey> {
@@ -323,8 +346,19 @@ impl<P: PublicId> Event<P> {
         self.cache.index_by_creator
     }
 
-    pub fn last_ancestors(&self) -> &PeerIndexMap<usize> {
-        &self.cache.last_ancestors
+    pub fn last_ancestors<'a>(&'a self) -> impl Iterator<Item = (PeerIndex, usize)> + 'a {
+        self.cache
+            .ancestor_info
+            .iter()
+            .map(|(peer_index, info)| (peer_index, info.last))
+    }
+
+    pub fn last_ancestor_by(&self, creator: PeerIndex) -> Option<usize> {
+        self.cache.ancestor_info.get(creator).map(|info| info.last)
+    }
+
+    pub(super) fn ancestor_info(&self) -> &PeerIndexMap<AncestorInfo> {
+        &self.cache.ancestor_info
     }
 
     pub fn is_sync_event(&self) -> bool {
@@ -375,10 +409,6 @@ impl<P: PublicId> Event<P> {
         }
     }
 
-    pub fn sees_fork(&self) -> bool {
-        !self.cache.forking_peers.is_empty()
-    }
-
     /// Returns the first char of the creator's ID, followed by an underscore and the event's index.
     #[cfg(any(test, feature = "testing"))]
     pub fn short_name(&self) -> ShortName {
@@ -420,9 +450,21 @@ impl<P: PublicId> Debug for Event<P> {
         write!(
             formatter,
             ", last_ancestors: {:?}",
-            self.cache.last_ancestors
+            self.cache
+                .ancestor_info
+                .iter()
+                .map(|(peer_id, info)| EntryDebug(peer_id, info.last))
+                .format(", ")
         )?;
         write!(formatter, " }}")
+    }
+}
+
+struct EntryDebug<K: Debug, V: Debug>(K, V);
+
+impl<K: Debug, V: Debug> Debug for EntryDebug<K, V> {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "{:?}: {:?}", self.0, self.1)
     }
 }
 
@@ -475,18 +517,23 @@ impl Event<PeerId> {
         );
         let content = Content { creator, cause };
 
-        let last_ancestors = last_ancestors
+        let ancestor_info = last_ancestors
             .into_iter()
             .map(|(peer_id, index_by_creator)| {
-                (unwrap!(peer_list.get_index(&peer_id)), index_by_creator)
+                let peer_index = unwrap!(peer_list.get_index(&peer_id));
+                let ancestor_info = AncestorInfo {
+                    last: index_by_creator,
+                    forks: ForkMap::new(),
+                };
+
+                (peer_index, ancestor_info)
             })
             .collect();
 
         let cache = Cache {
             hash,
             index_by_creator,
-            last_ancestors,
-            forking_peers: PeerIndexSet::default(),
+            ancestor_info,
             creator_initial: get_creator_initial(peer_list, creator),
         };
 
@@ -502,15 +549,6 @@ impl Event<PeerId> {
 pub(crate) struct UnpackedEvent<T: NetworkEvent, P: PublicId> {
     pub event: Event<P>,
     pub observation_for_store: ObservationForStore<T, P>,
-}
-
-pub(crate) enum LastAncestor {
-    // There are no forks and the ancestor exists.
-    Some(usize),
-    // Ancestor doesn't exist.
-    None,
-    // Fork detected. Ancestor cannot be determined from the events only. Graph traversal required.
-    Fork,
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -529,10 +567,8 @@ struct Cache {
     hash: EventHash,
     // Index of this event relative to other events by the same creator.
     index_by_creator: usize,
-    // Index of each peer's latest event that is an ancestor of this event.
-    last_ancestors: PeerIndexMap<usize>,
-    // Peers with a fork having both sides seen by this event.
-    forking_peers: PeerIndexSet,
+    // Info about events that are ancestors of this event keyed by their creators.
+    ancestor_info: PeerIndexMap<AncestorInfo>,
     // First letter of the creator name.
     #[cfg(any(test, feature = "testing"))]
     creator_initial: char,
@@ -545,92 +581,44 @@ impl Cache {
         graph: &Graph<S::PublicId>,
         peer_list: &PeerList<S>,
     ) -> Self {
-        let self_parent = content.self_parent().and_then(|index| graph.get(*index));
-        let other_parent = content.other_parent().and_then(|index| graph.get(*index));
+        let self_parent = get_event(graph, content.self_parent());
+        let other_parent = get_event(graph, content.other_parent());
 
-        let (index_by_creator, last_ancestors) = index_by_creator_and_last_ancestors(
+        let index_by_creator = compute_index_by_creator(self_parent);
+        let ancestor_info = compute_ancestor_info(
             content.creator,
-            self_parent.map(|e| e.inner()),
-            other_parent.map(|e| e.inner()),
+            index_by_creator,
+            self_parent,
+            other_parent,
             peer_list,
         );
-        let forking_peers = join_forking_peers(self_parent, other_parent, peer_list);
 
         Self {
             hash,
             index_by_creator,
-            last_ancestors,
-            forking_peers,
+            ancestor_info,
             #[cfg(any(test, feature = "testing"))]
             creator_initial: get_creator_initial(peer_list, content.creator),
         }
     }
 }
 
-fn index_by_creator_and_last_ancestors<S: SecretId>(
-    creator: PeerIndex,
-    self_parent: Option<&Event<S::PublicId>>,
-    other_parent: Option<&Event<S::PublicId>>,
-    peer_list: &PeerList<S>,
-) -> (usize, PeerIndexMap<usize>) {
-    let (index_by_creator, mut last_ancestors) = if let Some(self_parent) = self_parent {
-        (
-            self_parent.index_by_creator() + 1,
-            self_parent.last_ancestors().clone(),
-        )
+fn get_event<'a, P: PublicId>(
+    graph: &'a Graph<P>,
+    event_index: Option<&EventIndex>,
+) -> Option<&'a Event<P>> {
+    event_index
+        .and_then(|index| graph.get(*index))
+        .map(|event| event.inner())
+}
+
+fn compute_index_by_creator<P: PublicId>(self_parent: Option<&Event<P>>) -> usize {
+    if let Some(self_parent) = self_parent {
+        self_parent.index_by_creator() + 1
     } else {
         // Initial event
-        (0, PeerIndexMap::default())
-    };
-
-    if let Some(other_parent) = other_parent {
-        for (peer_index, _) in peer_list.iter() {
-            if let Some(other_index) = other_parent.last_ancestors().get(peer_index) {
-                let existing_index = last_ancestors.entry(peer_index).or_insert(*other_index);
-                *existing_index = cmp::max(*existing_index, *other_index);
-            }
-        }
+        0
     }
-
-    let _ = last_ancestors.insert(creator, index_by_creator);
-
-    (index_by_creator, last_ancestors)
-}
-
-// An event's forking_peers list is a union inherited from its self_parent and other_parent.
-// The event shall only put forking peer into the list when have direct path to both sides of
-// the fork.
-fn join_forking_peers<S: SecretId>(
-    self_parent: Option<IndexedEventRef<S::PublicId>>,
-    other_parent: Option<IndexedEventRef<S::PublicId>>,
-    peer_list: &PeerList<S>,
-) -> PeerIndexSet {
-    let mut forking_peers = PeerIndexSet::default();
-
-    if let Some(self_parent) = self_parent {
-        if has_fork(&*self_parent, peer_list) {
-            let _ = forking_peers.insert(self_parent.creator());
-        }
-        forking_peers.extend(self_parent.cache.forking_peers.iter());
-    }
-
-    if let Some(other_parent) = other_parent {
-        if has_fork(&*other_parent, peer_list) {
-            let _ = forking_peers.insert(other_parent.creator());
-        }
-
-        forking_peers.extend(other_parent.cache.forking_peers.iter());
-    }
-
-    forking_peers
-}
-
-fn has_fork<S: SecretId>(event: &Event<S::PublicId>, peer_list: &PeerList<S>) -> bool {
-    peer_list
-        .events_by_index(event.creator(), event.index_by_creator())
-        .take(2)
-        .count()
-        > 1
 }
 
 fn compute_event_hash_and_signature<T: NetworkEvent, S: SecretId>(

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -8,8 +8,6 @@
 
 #[cfg(any(test, feature = "testing"))]
 use super::event_utils::ForkMap;
-#[cfg(test)]
-use super::graph::IndexedEventRef;
 use super::{
     cause::{self, Cause},
     content::Content,
@@ -208,7 +206,7 @@ impl<P: PublicId> Event<P> {
     //   - `Err(Error::SignatureFailure)` if signature validation fails
     //   - `Err(Error::UnknownParent)` if the event indicates it should have an ancestor, but the
     //     ancestor isn't in `events`.
-    pub(crate) fn unpack<T: NetworkEvent, S: SecretId<PublicId = P>>(
+    pub fn unpack<T: NetworkEvent, S: SecretId<PublicId = P>>(
         packed_event: PackedEvent<T, P>,
         ctx: EventContextRef<T, S>,
     ) -> Result<Option<UnpackedEvent<T, P>>, Error> {
@@ -237,7 +235,7 @@ impl<P: PublicId> Event<P> {
     }
 
     // Creates a `PackedEvent` from this `Event`.
-    pub(crate) fn pack<T: NetworkEvent, S: SecretId<PublicId = P>>(
+    pub fn pack<T: NetworkEvent, S: SecretId<PublicId = P>>(
         &self,
         ctx: EventContextRef<T, S>,
     ) -> Result<PackedEvent<T, P>, Error> {
@@ -296,7 +294,7 @@ impl<P: PublicId> Event<P> {
     }
 
     // Fork set that this event is a member of.
-    fn fork_set(&self) -> Option<&IndexSet> {
+    pub fn fork_set(&self) -> Option<&IndexSet> {
         self.cache
             .ancestor_info
             .get(self.creator())
@@ -645,22 +643,6 @@ fn compute_event_hash_and_verify_signature<T: NetworkEvent, P: PublicId>(
     } else {
         Err(Error::SignatureFailure)
     }
-}
-
-/// Finds the first event which has the `short_name` provided.
-#[cfg(test)]
-pub(crate) fn find_event_by_short_name<'a, I, P>(
-    events: I,
-    short_name: &str,
-) -> Option<IndexedEventRef<'a, P>>
-where
-    I: IntoIterator<Item = IndexedEventRef<'a, P>>,
-    P: PublicId,
-{
-    let short_name = short_name.to_uppercase();
-    events
-        .into_iter()
-        .find(move |event| event.short_name().to_string() == short_name)
 }
 
 #[cfg(any(test, feature = "testing"))]

--- a/src/gossip/event_utils.rs
+++ b/src/gossip/event_utils.rs
@@ -1,0 +1,186 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::Event;
+use crate::{
+    id::SecretId,
+    peer_list::{PeerIndex, PeerIndexMap, PeerList},
+};
+use itertools::{EitherOrBoth, Itertools};
+use std::{cmp, collections::BTreeMap, iter};
+
+// Map of forks created by a single peer that are in the ancestry of an event.
+pub(super) type ForkMap = BTreeMap<usize, IndexSet>;
+
+// Immutable set of integer indices
+#[derive(Clone)]
+pub(super) struct IndexSet(Vec<usize>);
+
+impl IndexSet {
+    pub fn new(index: usize) -> Self {
+        IndexSet(vec![index])
+    }
+
+    pub fn union(&self, other: &Self) -> Self {
+        IndexSet(
+            self.0
+                .iter()
+                .merge(other.0.iter())
+                .dedup()
+                .cloned()
+                .collect(),
+        )
+    }
+
+    pub fn insert(&self, index: usize) -> Self {
+        IndexSet(
+            self.0
+                .iter()
+                .cloned()
+                .merge(iter::once(index))
+                .dedup()
+                .collect(),
+        )
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn contains(&self, index: usize) -> bool {
+        self.0.binary_search(&index).is_ok()
+    }
+
+    pub fn intersects(&self, other: &Self) -> bool {
+        self.0
+            .iter()
+            .merge_join_by(other.0.iter(), |x, y| x.cmp(y))
+            .any(|either| match either {
+                EitherOrBoth::Both(..) => true,
+                _ => false,
+            })
+    }
+}
+
+// Information about ancestor events.
+#[derive(Clone)]
+pub(super) struct AncestorInfo {
+    // index-by-creator of the last event by the current peer that is ancestor of the current
+    // event.
+    pub last: usize,
+
+    // Info about forks in the ancestry of the current event.
+    // Key is the index-by-creator of the forked events, value is a list of indices of the fork
+    // branches that the current event in on.
+    pub forks: ForkMap,
+}
+
+impl AncestorInfo {
+    pub fn new() -> Self {
+        Self {
+            last: 0,
+            forks: ForkMap::new(),
+        }
+    }
+}
+
+pub(super) fn compute_ancestor_info<S: SecretId>(
+    creator: PeerIndex,
+    index_by_creator: usize,
+    self_parent: Option<&Event<S::PublicId>>,
+    other_parent: Option<&Event<S::PublicId>>,
+    peer_list: &PeerList<S>,
+) -> PeerIndexMap<AncestorInfo> {
+    let mut result = match (self_parent, other_parent) {
+        (Some(self_parent), Some(other_parent)) => {
+            merge_ancestor_info_maps(self_parent.ancestor_info(), other_parent.ancestor_info())
+        }
+        (Some(self_parent), None) => self_parent.ancestor_info().clone(),
+        (None, Some(other_parent)) => other_parent.ancestor_info().clone(),
+        (None, None) => PeerIndexMap::new(),
+    };
+
+    let info = result.entry(creator).or_insert_with(AncestorInfo::new);
+    info.last = index_by_creator;
+
+    let fork_index = peer_list.events_by_index(creator, index_by_creator).count();
+    if fork_index > 0 {
+        let _ = info
+            .forks
+            .insert(index_by_creator, IndexSet::new(fork_index));
+    }
+
+    result
+}
+
+fn merge_ancestor_info_maps(
+    map0: &PeerIndexMap<AncestorInfo>,
+    map1: &PeerIndexMap<AncestorInfo>,
+) -> PeerIndexMap<AncestorInfo> {
+    // Merge the two maps: if an entry exists in only one of the map, copy it over,
+    // if it exists in both, merge them by calling `AncestorInfo::merge`.
+    // We can use `merge_join_by` from `itertools` because `PeerIndexMap::iter` yields the entries
+    // in lexicographically ascending order.
+    map0.iter()
+        .merge_join_by(map1.iter(), |(peer_index0, _), (peer_index1, _)| {
+            peer_index0.cmp(peer_index1)
+        })
+        .map(|either| match either {
+            EitherOrBoth::Left((peer_index, info)) | EitherOrBoth::Right((peer_index, info)) => {
+                (peer_index, info.clone())
+            }
+            EitherOrBoth::Both((peer_index, info0), (_, info1)) => {
+                (peer_index, merge_ancestor_infos(info0, info1))
+            }
+        })
+        .collect()
+}
+
+fn merge_ancestor_infos(info0: &AncestorInfo, info1: &AncestorInfo) -> AncestorInfo {
+    AncestorInfo {
+        last: cmp::max(info0.last, info1.last),
+        forks: merge_fork_maps(info0, info1),
+    }
+}
+
+fn merge_fork_maps(info0: &AncestorInfo, info1: &AncestorInfo) -> ForkMap {
+    info0
+        .forks
+        .iter()
+        .merge_join_by(info1.forks.iter(), |(key0, _), (key1, _)| key0.cmp(key1))
+        .map(|either| match either {
+            EitherOrBoth::Left((&index_by_creator, fork_set)) => (
+                index_by_creator,
+                merge_with_implicit_fork_set(fork_set, index_by_creator, info1.last),
+            ),
+            EitherOrBoth::Right((&index_by_creator, fork_set)) => (
+                index_by_creator,
+                merge_with_implicit_fork_set(fork_set, index_by_creator, info0.last),
+            ),
+            EitherOrBoth::Both((&index_by_creator, fork_set0), (_, fork_set1)) => {
+                (index_by_creator, fork_set0.union(fork_set1))
+            }
+        })
+        .collect()
+}
+
+fn merge_with_implicit_fork_set(
+    forks: &IndexSet,
+    index_by_creator: usize,
+    last_ancestor: usize,
+) -> IndexSet {
+    if last_ancestor >= index_by_creator {
+        // The second event is ancestor of the first event of the fork. Merge the fork set of the
+        // first event with the implicit fork set [0].
+        forks.insert(0)
+    } else {
+        // The second event is not an ancestor of any event of the fork - just clone the first fork
+        // set.
+        forks.clone()
+    }
+}

--- a/src/gossip/event_utils.rs
+++ b/src/gossip/event_utils.rs
@@ -19,7 +19,7 @@ pub(super) type ForkMap = BTreeMap<usize, IndexSet>;
 
 // Immutable set of integer indices
 #[derive(Clone)]
-pub(super) struct IndexSet(Vec<usize>);
+pub(crate) struct IndexSet(Vec<usize>);
 
 impl IndexSet {
     pub fn new(index: usize) -> Self {

--- a/src/gossip/graph/mod.rs
+++ b/src/gossip/graph/mod.rs
@@ -268,6 +268,10 @@ impl<P: PublicId> Graph<P> {
         let _ = self.indices.remove(event.hash());
         Some((index, event))
     }
+
+    pub fn get_by_hash<'a>(&'a self, hash: &EventHash) -> Option<IndexedEventRef<'a, P>> {
+        self.get_index(hash).and_then(|index| self.get(index))
+    }
 }
 
 impl<P: PublicId> IntoIterator for Graph<P> {

--- a/src/gossip/graph/mod.rs
+++ b/src/gossip/graph/mod.rs
@@ -101,6 +101,11 @@ impl<P: PublicId> Graph<P> {
             .map(|event| IndexedEventRef { index, event })
     }
 
+    /// Gets `Event` by the given `hash`, if it exists.
+    pub fn get_by_hash<'a>(&'a self, hash: &EventHash) -> Option<IndexedEventRef<'a, P>> {
+        self.get_index(hash).and_then(|index| self.get(index))
+    }
+
     /// Number of events in this graph.
     pub fn len(&self) -> usize {
         self.events.len()
@@ -258,10 +263,6 @@ impl<P: PublicId> Graph<P> {
         let event = self.events.pop()?;
         let _ = self.indices.remove(event.hash());
         Some((index, event))
-    }
-
-    pub fn get_by_hash<'a>(&'a self, hash: &EventHash) -> Option<IndexedEventRef<'a, P>> {
-        self.get_index(hash).and_then(|index| self.get(index))
     }
 }
 

--- a/src/gossip/graph/mod.rs
+++ b/src/gossip/graph/mod.rs
@@ -176,15 +176,6 @@ impl<P: PublicId> Graph<P> {
             visited: vec![false; event.topological_index() + 1],
         }
     }
-
-    /// Returns whether `x` is descendant of `y`.
-    pub fn is_descendant(&self, x: IndexedEventRef<P>, y: IndexedEventRef<P>) -> bool {
-        x.is_descendant_of(y).unwrap_or_else(|| {
-            self.ancestors(x)
-                .take_while(|e| e.topological_index() >= y.topological_index())
-                .any(|e| e.topological_index() == y.topological_index())
-        })
-    }
 }
 
 #[cfg(feature = "malice-detection")]

--- a/src/gossip/mod.rs
+++ b/src/gossip/mod.rs
@@ -12,6 +12,7 @@ mod content;
 mod event;
 mod event_context;
 mod event_hash;
+mod event_utils;
 mod graph;
 mod messages;
 mod packed_event;

--- a/src/gossip/mod.rs
+++ b/src/gossip/mod.rs
@@ -21,7 +21,7 @@ mod packed_event;
 pub(super) use self::cause::Cause;
 #[cfg(any(test, feature = "testing"))]
 pub(super) use self::event::CauseInput;
-#[cfg(all(test, feature = "mock"))]
+#[cfg(all(test, feature = "mock", feature = "malice-detection"))]
 pub(super) use self::event_context::EventContext;
 #[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
 pub(super) use self::graph::snapshot::GraphSnapshot;

--- a/src/gossip/mod.rs
+++ b/src/gossip/mod.rs
@@ -19,8 +19,6 @@ mod packed_event;
 
 #[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
 pub(super) use self::cause::Cause;
-#[cfg(test)]
-pub(super) use self::event::find_event_by_short_name;
 #[cfg(any(test, feature = "testing"))]
 pub(super) use self::event::CauseInput;
 #[cfg(all(test, feature = "mock"))]

--- a/src/gossip/mod.rs
+++ b/src/gossip/mod.rs
@@ -22,7 +22,7 @@ pub(super) use self::cause::Cause;
 pub(super) use self::event::find_event_by_short_name;
 #[cfg(any(test, feature = "testing"))]
 pub(super) use self::event::CauseInput;
-#[cfg(all(test, feature = "mock", feature = "malice-detection"))]
+#[cfg(all(test, feature = "mock"))]
 pub(super) use self::event_context::EventContext;
 #[cfg(any(all(test, feature = "mock"), feature = "dump-graphs"))]
 pub(super) use self::graph::snapshot::GraphSnapshot;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,11 @@ extern crate serde_derive;
 #[macro_use]
 extern crate unwrap;
 
+#[doc(hidden)]
+#[cfg(any(test, feature = "testing"))]
+#[macro_use]
+pub mod dev_utils;
+
 mod block;
 mod dump_graph;
 mod error;
@@ -189,10 +194,6 @@ mod vote;
 
 #[cfg(all(test, feature = "mock"))]
 mod functional_tests;
-
-#[doc(hidden)]
-#[cfg(any(test, feature = "testing"))]
-pub mod dev_utils;
 
 #[doc(hidden)]
 /// **NOT FOR PRODUCTION USE**: Mock types which trivially implement the required Parsec traits.

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -2332,6 +2332,13 @@ impl TestParsec<Transaction, PeerId> {
 }
 
 #[cfg(any(test, feature = "testing"))]
+impl<T: NetworkEvent, S: SecretId> From<Parsec<T, S>> for TestParsec<T, S> {
+    fn from(parsec: Parsec<T, S>) -> Self {
+        TestParsec(parsec)
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
 impl<T: NetworkEvent, S: SecretId> Deref for TestParsec<T, S> {
     type Target = Parsec<T, S>;
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -1924,28 +1924,24 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             | Malice::InvalidAccusation(hash)
             | Malice::Accomplice(hash, _) => self
                 .graph
-                .get_index(hash)
-                .and_then(|index| self.graph.get(index))
+                .get_by_hash(hash)
                 .map(|malicious_event| event.is_descendant_of(malicious_event))
                 .unwrap_or(false),
 
             Malice::DuplicateVote(hash0, hash1) => {
                 self.graph
-                    .get_index(hash0)
-                    .and_then(|index| self.graph.get(index))
+                    .get_by_hash(hash0)
                     .map(|malicious_event0| event.is_descendant_of(malicious_event0))
                     .unwrap_or(false)
                     && self
                         .graph
-                        .get_index(hash1)
-                        .and_then(|index| self.graph.get(index))
+                        .get_by_hash(hash1)
                         .map(|malicious_event1| event.is_descendant_of(malicious_event1))
                         .unwrap_or(false)
             }
             Malice::Fork(hash) => self
                 .graph
-                .get_index(hash)
-                .and_then(|index| self.graph.get(index))
+                .get_by_hash(hash)
                 .map(|malicious_event| {
                     event.is_descendant_of(malicious_event)
                         && event.sees_fork_by(malicious_event.creator())
@@ -1956,8 +1952,7 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             | Malice::InvalidRequest(packed_event)
             | Malice::InvalidResponse(packed_event) => self
                 .graph
-                .get_index(&packed_event.compute_hash())
-                .and_then(|index| self.graph.get(index))
+                .get_by_hash(&packed_event.compute_hash())
                 .map(|malicious_event| event.is_descendant_of(malicious_event))
                 .unwrap_or(false),
             Malice::Unprovable(_) => false,

--- a/src/peer_list/peer_index.rs
+++ b/src/peer_list/peer_index.rs
@@ -363,3 +363,33 @@ impl IntoIterator for PeerIndexSet {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dev_utils::TestIterator;
+
+    #[test]
+    fn peer_index_map_iter_is_sorted() {
+        let p0 = PeerIndex(0);
+        let p1 = PeerIndex(1);
+        let p2 = PeerIndex(2);
+
+        let orderings = [
+            [p0, p1, p2],
+            [p0, p2, p1],
+            [p1, p0, p2],
+            [p1, p2, p0],
+            [p2, p0, p1],
+            [p2, p1, p0],
+        ];
+
+        for ordering in &orderings {
+            let mut map = PeerIndexMap::new();
+            for peer_id in ordering {
+                let _ = map.insert(*peer_id, ());
+            }
+            assert!(map.iter().is_sorted())
+        }
+    }
+}


### PR DESCRIPTION
This PR makes Parsec resilient to forks. The bulk of the PR deals with making sure the `sees` function gives consistent results that depend only on the structure of the graph and not on the order in which events are received. The PR also improves the DOT parser and dumper to support graphs with forks.