### PR TITLE
MAID-3301: Fix failures in the consensus_with_fork test when malice-detection is enabled

### DIFF
--- a/src/dev_utils/schedule.rs
+++ b/src/dev_utils/schedule.rs
@@ -465,6 +465,16 @@ impl ObservationSchedule {
             })
             .count()
     }
+
+    fn count_expected_accusations(&self) -> usize {
+        if cfg!(feature = "malice-detection") {
+            // One accusation per malicious peer as currently the malicious peers commit only one
+            // malice each.
+            self.genesis.ids_of_malicious_peers.len()
+        } else {
+            0
+        }
+    }
 }
 
 pub struct StepObservationSchedule {
@@ -556,7 +566,8 @@ impl Schedule {
         let mut pending = PendingObservations::new(options);
 
         // the +1 below is to account for genesis
-        let max_observations = obs_schedule.count_observations() + 1;
+        let max_observations =
+            obs_schedule.count_observations() + obs_schedule.count_expected_accusations() + 1;
 
         let mut peers = PeerStatuses::new(&obs_schedule.genesis.all_ids());
         let mut step = 0;

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -495,8 +495,8 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             .and_then(|event_index| self.graph.get(event_index))
         {
             // If the creator of the event has been removed but they are not yet aware of the
-            // removal (they haven't reached the consensus on removing themselves), accept
-            // the event.
+            // removal (that is, we don't know for sure that reached consensus on removing
+            // themselves), accept the event.
             if !event.is_descendant_of(removal_event) {
                 return Ok(());
             }

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -485,9 +485,12 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             .peer_list
             .get(event.creator())
             .ok_or(Error::UnknownPeer)?;
+
         if event.creator() == PeerIndex::OUR || peer.state().can_send() {
             return Ok(());
-        } else if let Some(removal_event) = peer
+        }
+
+        if let Some(removal_event) = peer
             .removal_event()
             .and_then(|event_index| self.graph.get(event_index))
         {

--- a/src/peer_list/mod.rs
+++ b/src/peer_list/mod.rs
@@ -115,18 +115,18 @@ impl<S: SecretId> PeerList<S> {
 
     /// Returns an iterator of peers that can vote.
     pub fn voters(&self) -> impl Iterator<Item = (PeerIndex, &Peer<S::PublicId>)> {
-        self.iter().filter(|(_, peer)| peer.state.can_vote())
+        self.iter().filter(|(_, peer)| peer.state().can_vote())
     }
 
     /// Returns an iterator of peers that we can send gossip to.
     pub fn gossip_recipients<'a>(
         &'a self,
     ) -> impl Iterator<Item = (PeerIndex, &Peer<S::PublicId>)> + 'a {
-        let iter = if self.our_peer.state.can_send() {
+        let iter = if self.our_peer.state().can_send() {
             let iter = self
                 .iter()
                 .skip(1)
-                .filter(|(_, peer)| peer.state.can_vote() && peer.state.can_recv());
+                .filter(|(_, peer)| peer.state().can_vote() && peer.state().can_recv());
             Some(iter)
         } else {
             None
@@ -147,12 +147,12 @@ impl<S: SecretId> PeerList<S> {
 
     pub fn peer_state(&self, index: PeerIndex) -> PeerState {
         self.get(index)
-            .map(|peer| peer.state)
+            .map(|peer| peer.state())
             .unwrap_or_else(PeerState::inactive)
     }
 
     pub fn our_state(&self) -> PeerState {
-        self.our_peer.state
+        self.our_peer.state()
     }
 
     /// Adds a peer in the given state into the map.
@@ -191,14 +191,13 @@ impl<S: SecretId> PeerList<S> {
     /// at `deciding_event_index`.
     pub fn remove_peer(&mut self, peer_index: PeerIndex, deciding_event_index: EventIndex) {
         if let Some(peer) = self.get_known_mut(peer_index) {
-            peer.state = PeerState::inactive();
-            peer.removal_event = Some(deciding_event_index);
+            peer.set_removed(deciding_event_index)
         }
     }
 
     pub fn change_peer_state(&mut self, index: PeerIndex, state: PeerState) {
         if let Some(peer) = self.get_known_mut(index) {
-            peer.state |= state;
+            peer.set_state(peer.state() | state);
         }
     }
 
@@ -404,7 +403,7 @@ pub(crate) mod snapshot {
                             })
                             .collect();
 
-                        (peer.id().clone(), (peer.state, events))
+                        (peer.id().clone(), (peer.state(), events))
                     })
                     .collect(),
             )

--- a/src/peer_list/mod.rs
+++ b/src/peer_list/mod.rs
@@ -197,7 +197,7 @@ impl<S: SecretId> PeerList<S> {
 
     pub fn change_peer_state(&mut self, index: PeerIndex, state: PeerState) {
         if let Some(peer) = self.get_known_mut(index) {
-            peer.set_state(peer.state() | state);
+            peer.change_state(state);
         }
     }
 

--- a/src/peer_list/peer.rs
+++ b/src/peer_list/peer.rs
@@ -107,6 +107,7 @@ impl<P: PublicId> Peer<P> {
 #[derive(Debug)]
 enum Presence {
     Present(PeerState),
+    // Contains the index of the event at which we reached the consensus on the removal.
     Removed(EventIndex),
 }
 

--- a/src/peer_list/peer.rs
+++ b/src/peer_list/peer.rs
@@ -62,8 +62,10 @@ impl<P: PublicId> Peer<P> {
         }
     }
 
-    pub(super) fn set_state(&mut self, state: PeerState) {
-        self.presence = Presence::Present(state);
+    pub(super) fn change_state(&mut self, new_state: PeerState) {
+        if let Presence::Present(ref mut old_state) = self.presence {
+            *old_state |= new_state;
+        }
     }
 
     pub(super) fn set_removed(&mut self, deciding_event_index: EventIndex) {

--- a/src/peer_list/peer.rs
+++ b/src/peer_list/peer.rs
@@ -26,6 +26,9 @@ pub(crate) struct Peer<P: PublicId> {
     pub(super) state: PeerState,
     pub(super) events: Events,
     pub(super) last_gossiped_event: Option<EventIndex>,
+    // If this peer has been removed, contains the event at which the removal consensus has
+    // been reached.
+    pub(super) removal_event: Option<EventIndex>,
     // As a performance optimisation we keep track of which events we've cleared for Accomplice
     // accusations.
     #[cfg(feature = "malice-detection")]
@@ -42,6 +45,7 @@ impl<P: PublicId> Peer<P> {
             state,
             events: Events::new(),
             last_gossiped_event: None,
+            removal_event: None,
             #[cfg(feature = "malice-detection")]
             accomplice_event_checkpoint: None,
         }
@@ -72,6 +76,10 @@ impl<P: PublicId> Peer<P> {
 
     pub fn events_by_index<'a>(&'a self, index: usize) -> impl Iterator<Item = EventIndex> + 'a {
         self.events.by_index(index)
+    }
+
+    pub fn removal_event(&self) -> Option<EventIndex> {
+        self.removal_event
     }
 
     pub(super) fn add_event(&mut self, index_by_creator: usize, event_index: EventIndex) {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -407,10 +407,6 @@ fn extensive_dynamic_membership() {
     unwrap!(env.network.execute_schedule(&mut env.rng, schedule));
 }
 
-// This test encounters performance problems when malice-detection is enabled, hence we only
-// execute it when the feature is disabled.
-// TODO: remove this after MAID-3270 is completed.
-#[cfg(not(feature = "malice-detection"))]
 #[test]
 fn consensus_with_fork() {
     let mut env = Environment::new(SEED);


### PR DESCRIPTION
This PR fixes issues that caused the `consensus_with_fork` test to fail:

1. Update the test framework to account for raised accusations when calculating expected number of blocks.
2. Modify parsec so that it accepts events even from removed peers if those peers haven't yet reached the consensus on their own removal. 