### PR TITLE
Make dot file dumper & parser supports malice accusation

### DIFF
--- a/src/gossip/cause.rs
+++ b/src/gossip/cause.rs
@@ -174,6 +174,9 @@ impl Cause<Vote<Transaction, PeerId>, EventHash, PeerId> {
                 self_parent,
                 vote: Vote::new(creator_id, observation),
             },
+            CauseInput::Malice(_, _) => {
+                panic!("CauseInput Malice shall be replaced already");
+            }
         }
     }
 }

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -17,6 +17,8 @@ use super::{
     graph::{EventIndex, Graph},
     packed_event::PackedEvent,
 };
+#[cfg(any(test, feature = "testing"))]
+use crate::observation::MaliceInput;
 use crate::{
     error::Error,
     hash::Hash,
@@ -571,6 +573,7 @@ pub(crate) enum CauseInput {
     Request,
     Response,
     Observation(Observation<Transaction, PeerId>),
+    Malice(PeerId, MaliceInput),
 }
 
 // Properties of `Event` that can be computed from its `Content`.

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -114,6 +114,13 @@ pub enum Malice<T: NetworkEvent, P: PublicId> {
     // TODO: add other malice variants
 }
 
+#[cfg(any(test, feature = "testing"))]
+#[derive(Debug)]
+pub(crate) enum MaliceInput {
+    Fork(String),
+    InvalidAccusation(String),
+}
+
 impl<T: NetworkEvent, P: PublicId> Malice<T, P> {
     #[cfg(any(test, feature = "malice-detection", feature = "testing"))]
     pub(crate) fn is_provable(&self) -> bool {


### PR DESCRIPTION
This PR contains the work of making dot file dumper & parser supports malice accusation.
So far, there are only two malice supported: Fork and InvalidAccusation. 
As the testing case that is currently being worked on only requires these two.

To support other malice types, the main blocking point is how a `packed_event` to be dumped and parsed. This will require a further discussion.