### PR TITLE
Fix the most obvious performance pessimization caused by malice detection

### DIFF
--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -1879,8 +1879,8 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
     // observation by the same creator.
     fn detect_duplicate_vote(&mut self, event: &Event<S::PublicId>) {
         let other_hash = {
-            let payload = if let Some(payload) = self.event_payload(event) {
-                payload
+            let payload_key = if let Some(key) = event.payload_key() {
+                key
             } else {
                 return;
             };
@@ -1891,8 +1891,9 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
                 .rev()
                 .filter_map(|index| self.get_known_event(index).ok())
                 .filter(|event| {
-                    self.event_payload(event)
-                        .map_or(false, |event_payload| event_payload == payload)
+                    event
+                        .payload_key()
+                        .map_or(false, |event_payload_key| event_payload_key == payload_key)
                 })
                 .map(|event| *event.hash())
                 .take(2);


### PR DESCRIPTION
detect_duplicate_vote used to be a massive bottleneck for benchmarks
with many events as we would spend a lot of time fetching the
observations from the ObservationStore (which is a BTreeMap).
The ObservationKey uniquely identifies a given payload with its hash,
so these BTreeMap accesses were actually unnecessary.

Full benchmark results:
```
minimal - benches       time:   [1.6240 ms 1.6314 ms 1.6458 ms]                             
                        change: [+13.670% +14.565% +15.216%] (p = 0.02 < 0.05)
                        Performance has regressed.

static - benches        time:   [5.0346 ms 5.0638 ms 5.0785 ms]                           
                        change: [-0.2593% +0.1510% +0.5983%] (p = 0.64 > 0.05)
                        No change in performance detected.

dynamic - benches       time:   [3.3536 ms 3.3643 ms 3.3725 ms]                             
                        change: [-0.2088% +0.0960% +0.3737%] (p = 0.62 > 0.05)
                        No change in performance detected.

Benchmarking a_node4_opaque_evt8 - bench_section_size_evt8: Collecting 3 samples in estimated                                                                                               a_node4_opaque_evt8 - bench_section_size_evt8                        
                        time:   [1.7349 ms 1.7387 ms 1.7500 ms]
                        change: [-1.3070% -0.6258% +0.0266%] (p = 0.22 > 0.05)
                        No change in performance detected.

Benchmarking a_node4_opaque_evt8 - bench_section_size_evt8_single: Collecting 3 samples in est                                                                                              a_node4_opaque_evt8 - bench_section_size_evt8_single                        
                        time:   [1.4697 ms 1.4752 ms 1.4931 ms]
                        change: [-0.0259% +0.8202% +1.6746%] (p = 0.21 > 0.05)
                        No change in performance detected.

Benchmarking a_node8_opaque_evt8 - bench_section_size_evt8: Collecting 3 samples in estimated                                                                                               a_node8_opaque_evt8 - bench_section_size_evt8                        
                        time:   [6.7660 ms 6.7920 ms 6.8435 ms]
                        change: [-0.7658% +0.0174% +0.8071%] (p = 0.96 > 0.05)
                        No change in performance detected.

Benchmarking a_node8_opaque_evt8 - bench_section_size_evt8_single: Collecting 3 samples in est                                                                                              a_node8_opaque_evt8 - bench_section_size_evt8_single                        
                        time:   [9.4522 ms 9.4686 ms 9.5141 ms]
                        change: [-2.9547% -1.0353% +0.3133%] (p = 0.42 > 0.05)
                        No change in performance detected.

Benchmarking a_node16_opaque_evt8 - bench_section_size_evt8: Collecting 3 samples in estimated                                                                                              a_node16_opaque_evt8 - bench_section_size_evt8                        
                        time:   [32.988 ms 33.014 ms 33.125 ms]
                        change: [-0.2964% +0.0601% +0.4182%] (p = 0.79 > 0.05)
                        No change in performance detected.

Benchmarking a_node16_opaque_evt8 - bench_section_size_evt8_single: Collecting 3 samples in es                                                                                              a_node16_opaque_evt8 - bench_section_size_evt8_single                        
                        time:   [24.262 ms 24.292 ms 24.359 ms]
                        change: [-0.5515% -0.3656% -0.1535%] (p = 0.04 < 0.05)
                        Change within noise threshold.

Benchmarking a_node32_opaque_evt8 - bench_section_size_evt8: Collecting 3 samples in estimated                                                                                              a_node32_opaque_evt8 - bench_section_size_evt8                        
                        time:   [301.28 ms 301.63 ms 302.41 ms]
                        change: [+0.2332% +0.7871% +1.2369%] (p = 0.06 > 0.05)
                        No change in performance detected.

Benchmarking a_node32_opaque_evt8 - bench_section_size_evt8_single: Collecting 3 samples in es                                                                                              a_node32_opaque_evt8 - bench_section_size_evt8_single                        
                        time:   [136.29 ms 137.18 ms 137.40 ms]
                        change: [-1.3010% -0.8549% -0.4071%] (p = 0.04 < 0.05)
                        Change within noise threshold.

Benchmarking a_node48_opaque_evt8 - bench_section_size_evt8: Collecting 3 samples in estimated                                                                                              a_node48_opaque_evt8 - bench_section_size_evt8                        
                        time:   [538.60 ms 539.28 ms 539.65 ms]
                        change: [-1.1937% -0.9805% -0.6860%] (p = 0.02 < 0.05)
                        Change within noise threshold.

Benchmarking a_node48_opaque_evt8 - bench_section_size_evt8_single: Collecting 3 samples in es                                                                                              a_node48_opaque_evt8 - bench_section_size_evt8_single                        
                        time:   [447.33 ms 451.80 ms 458.15 ms]
                        change: [-1.3572% -0.3328% +1.0441%] (p = 0.66 > 0.05)
                        No change in performance detected.

Benchmarking a_node4_opaque_evt16 - bench_section_size_evt16: Collecting 3 samples in estimate                                                                                              a_node4_opaque_evt16 - bench_section_size_evt16                        
                        time:   [2.1002 ms 2.1093 ms 2.1287 ms]
                        change: [-1.3108% -0.5652% +0.1848%] (p = 0.28 > 0.05)
                        No change in performance detected.

Benchmarking a_node4_opaque_evt16 - bench_section_size_evt16_single: Collecting 3 samples in e                                                                                              a_node4_opaque_evt16 - bench_section_size_evt16_single                        
                        time:   [1.5112 ms 1.5172 ms 1.5243 ms]
                        change: [-0.4878% +0.0630% +0.6167%] (p = 0.86 > 0.05)
                        No change in performance detected.

Benchmarking a_node8_opaque_evt16 - bench_section_size_evt16: Collecting 3 samples in estimate                                                                                              a_node8_opaque_evt16 - bench_section_size_evt16                        
                        time:   [10.995 ms 11.036 ms 11.114 ms]
                        change: [-1.0793% -0.5735% -0.0788%] (p = 0.16 > 0.05)
                        No change in performance detected.

Benchmarking a_node8_opaque_evt16 - bench_section_size_evt16_single: Collecting 3 samples in e                                                                                              a_node8_opaque_evt16 - bench_section_size_evt16_single                        
                        time:   [6.1308 ms 6.1430 ms 6.1481 ms]
                        change: [-0.5497% +0.0717% +0.6024%] (p = 0.85 > 0.05)
                        No change in performance detected.

Benchmarking a_node16_opaque_evt16 - bench_section_size_evt16: Collecting 3 samples in estimat                                                                                              a_node16_opaque_evt16 - bench_section_size_evt16                        
                        time:   [44.147 ms 44.167 ms 44.360 ms]
                        change: [-1.1765% -0.8526% -0.4710%] (p = 0.03 < 0.05)
                        Change within noise threshold.

Benchmarking a_node16_opaque_evt16 - bench_section_size_evt16_single: Collecting 3 samples in                                                                                               a_node16_opaque_evt16 - bench_section_size_evt16_single                        
                        time:   [26.891 ms 26.914 ms 27.029 ms]
                        change: [-0.7833% -0.2970% +0.1544%] (p = 0.38 > 0.05)
                        No change in performance detected.

Benchmarking a_node32_opaque_evt16 - bench_section_size_evt16: Collecting 3 samples in estimat                                                                                              a_node32_opaque_evt16 - bench_section_size_evt16                        
                        time:   [214.36 ms 215.46 ms 218.09 ms]
                        change: [+0.0356% +0.8258% +1.8312%] (p = 0.20 > 0.05)
                        No change in performance detected.

Benchmarking a_node32_opaque_evt16 - bench_section_size_evt16_single: Collecting 3 samples in                                                                                               a_node32_opaque_evt16 - bench_section_size_evt16_single                        
                        time:   [236.71 ms 237.23 ms 238.23 ms]
                        change: [-0.2437% +0.1736% +0.5788%] (p = 0.55 > 0.05)
                        No change in performance detected.

Benchmarking a_node48_opaque_evt16 - bench_section_size_evt16: Collecting 3 samples in estimat                                                                                              a_node48_opaque_evt16 - bench_section_size_evt16                        
                        time:   [1.2250 s 1.2307 s 1.2346 s]
                        change: [-0.8108% -0.4402% -0.0688%] (p = 0.14 > 0.05)
                        No change in performance detected.

Benchmarking a_node48_opaque_evt16 - bench_section_size_evt16_single: Collecting 3 samples in                                                                                               a_node48_opaque_evt16 - bench_section_size_evt16_single                        
                        time:   [275.80 ms 276.77 ms 277.65 ms]
                        change: [-1.2756% -0.8994% -0.6345%] (p = 0.03 < 0.05)
                        Change within noise threshold.

Benchmarking a_node4_opaque_evt1024 - bench_section_size_evt1024_interleave: Warming up for 3.                                                                                              Benchmarking a_node4_opaque_evt1024 - bench_section_size_evt1024_interleave: Collecting 3 samp                                                                                              a_node4_opaque_evt1024 - bench_section_size_evt1024_interleave                        
                        time:   [60.335 ms 60.580 ms 62.109 ms]
                        change: [-20.161% -19.234% -17.793%] (p = 0.02 < 0.05)
                        Performance has improved.

Benchmarking a_node4_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority: War                                                                                              Benchmarking a_node4_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority: Col                                                                                              Benchmarking a_node4_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority: Ana                                                                                              a_node4_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority
                        time:   [166.73 ms 167.67 ms 167.80 ms]
                        change: [-60.508% -60.355% -60.212%] (p = 0.02 < 0.05)
                        Performance has improved.

Benchmarking a_node8_opaque_evt1024 - bench_section_size_evt1024_interleave: Warming up for 3.                                                                                              Benchmarking a_node8_opaque_evt1024 - bench_section_size_evt1024_interleave: Collecting 3 samp                                                                                              a_node8_opaque_evt1024 - bench_section_size_evt1024_interleave                        
                        time:   [98.958 ms 99.104 ms 99.214 ms]
                        change: [-10.800% -9.8775% -9.2054%] (p = 0.02 < 0.05)
                        Change within noise threshold.

Benchmarking a_node8_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority: War                                                                                              Benchmarking a_node8_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority: Col                                                                                              Benchmarking a_node8_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority: Ana                                                                                              a_node8_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority
                        time:   [607.05 ms 607.34 ms 607.93 ms]
                        change: [-49.885% -49.655% -49.497%] (p = 0.02 < 0.05)
                        Performance has improved.

Benchmarking a_node16_opaque_evt1024 - bench_section_size_evt1024_interleave: Warming up for 3                                                                                              Benchmarking a_node16_opaque_evt1024 - bench_section_size_evt1024_interleave: Collecting 3 sam                                                                                              a_node16_opaque_evt1024 - bench_section_size_evt1024_interleave                        
                        time:   [200.22 ms 200.56 ms 202.90 ms]
                        change: [-2.7877% -2.2466% -1.4375%] (p = 0.02 < 0.05)
                        Change within noise threshold.

Benchmarking a_node16_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority: Wa                                                                                              Benchmarking a_node16_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority: Co                                                                                              Benchmarking a_node16_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority: An                                                                                              a_node16_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority
                        time:   [1.9555 s 1.9634 s 1.9807 s]
                        change: [-39.936% -39.476% -39.181%] (p = 0.02 < 0.05)
                        Performance has improved.

Benchmarking a_node32_opaque_evt1024 - bench_section_size_evt1024_interleave: Warming up for 3                                                                                              Benchmarking a_node32_opaque_evt1024 - bench_section_size_evt1024_interleave: Collecting 3 sam                                                                                              a_node32_opaque_evt1024 - bench_section_size_evt1024_interleave                        
                        time:   [621.02 ms 622.22 ms 627.55 ms]
                        change: [+0.0639% +0.5480% +1.1121%] (p = 0.14 > 0.05)
                        No change in performance detected.

Benchmarking a_node32_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority: Wa                                                                                              Benchmarking a_node32_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority: Co                                                                                              Benchmarking a_node32_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority: An                                                                                              a_node32_opaque_evt1024 - bench_section_size_evt1024_interleave_supermajority
                        time:   [11.289 s 11.313 s 11.378 s]
                        change: [-19.828% -19.415% -18.999%] (p = 0.02 < 0.05)
                        Performance has improved.

Benchmarking a_node4_opaque_evt8192 - bench_section_size_evt8192_interleave: Warming up for 3.                                                                                              Benchmarking a_node4_opaque_evt8192 - bench_section_size_evt8192_interleave: Collecting 3 samp                                                                                              a_node4_opaque_evt8192 - bench_section_size_evt8192_interleave                        
                        time:   [492.30 ms 494.02 ms 494.18 ms]
                        change: [-74.109% -74.031% -73.952%] (p = 0.02 < 0.05)
                        Performance has improved.

Benchmarking a_node8_opaque_evt8192 - bench_section_size_evt8192_interleave: Warming up for 3.                                                                                              Benchmarking a_node8_opaque_evt8192 - bench_section_size_evt8192_interleave: Collecting 3 samp                                                                                              a_node8_opaque_evt8192 - bench_section_size_evt8192_interleave                        
                        time:   [775.55 ms 776.43 ms 778.26 ms]
                        change: [-51.351% -51.195% -51.001%] (p = 0.02 < 0.05)
                        Performance has improved.

Benchmarking a_node16_opaque_evt8192 - bench_section_size_evt8192_interleave: Warming up for 3                                                                                              Benchmarking a_node16_opaque_evt8192 - bench_section_size_evt8192_interleave: Collecting 3 sam                                                                                              a_node16_opaque_evt8192 - bench_section_size_evt8192_interleave                        
                        time:   [1.2646 s 1.2662 s 1.2695 s]
                        change: [-26.147% -25.910% -25.655%] (p = 0.02 < 0.05)
                        Performance has improved.

Benchmarking a_node32_opaque_evt8192 - bench_section_size_evt8192_interleave: Warming up for 3                                                                                              Benchmarking a_node32_opaque_evt8192 - bench_section_size_evt8192_interleave: Collecting 3 sam                                                                                              a_node32_opaque_evt8192 - bench_section_size_evt8192_interleave                        
                        time:   [2.2548 s 2.2600 s 2.2888 s]
                        change: [-11.017% -10.128% -9.2296%] (p = 0.02 < 0.05)
                        Change within noise threshold.

Benchmarking a_node4_opaque_evt65536 - bench_section_size_evt65536_interleave: Warming up for                                                                                               Benchmarking a_node4_opaque_evt65536 - bench_section_size_evt65536_interleave: Collecting 3 sa                                                                                              a_node4_opaque_evt65536 - bench_section_size_evt65536_interleave                        
                        time:   [8.9491 s 8.9847 s 8.9991 s]
                        change: [-93.872% -93.851% -93.835%] (p = 0.02 < 0.05)
                        Performance has improved.

Benchmarking a_node8_opaque_evt65536 - bench_section_size_evt65536_interleave: Warming up for                                                                                               Benchmarking a_node8_opaque_evt65536 - bench_section_size_evt65536_interleave: Collecting 3 sa                                                                                              a_node8_opaque_evt65536 - bench_section_size_evt65536_interleave                        
                        time:   [9.9460 s 10.418 s 10.516 s]
                        change: [-88.257% -87.887% -87.586%] (p = 0.02 < 0.05)
                        Performance has improved.

Benchmarking a_node16_opaque_evt65536 - bench_section_size_evt65536_interleave: Warming up for                                                                                              Benchmarking a_node16_opaque_evt65536 - bench_section_size_evt65536_interleave: Collecting 3 s                                                                                              a_node16_opaque_evt65536 - bench_section_size_evt65536_interleave                        
                        time:   [13.285 s 15.027 s 15.281 s]
                        change: [-73.483% -70.998% -69.580%] (p = 0.02 < 0.05)
                        Performance has improved.

Benchmarking a_node32_opaque_evt65536 - bench_section_size_evt65536_interleave: Warming up for                                                                                              Benchmarking a_node32_opaque_evt65536 - bench_section_size_evt65536_interleave: Collecting 3 s                                                                                              a_node32_opaque_evt65536 - bench_section_size_evt65536_interleave                        
                        time:   [25.362 s 25.485 s 26.192 s]
                        change: [-38.693% -37.933% -36.675%] (p = 0.02 < 0.05)
                        Performance has improved.

Benchmarking PublicIdname754598-001 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname754598-001 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname754598-001 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname754598-001 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              PublicIdname754598-001 - bench_routing/mock_crust_merge_merge_three_sections_...
                        time:   [170.76 ms 170.94 ms 172.85 ms]
                        change: [+4.0437% +4.5098% +5.3335%] (p = 0.02 < 0.05)
                        Change within noise threshold.

Benchmarking PublicIdname754598-002 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname754598-002 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname754598-002 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname754598-002 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              PublicIdname754598-002 - bench_routing/mock_crust_merge_merge_three_sections_...
                        time:   [304.25 ms 308.47 ms 309.12 ms]
                        change: [+3.8797% +4.8216% +5.7020%] (p = 0.02 < 0.05)
                        Change within noise threshold.

Benchmarking PublicIdname754598-003 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname754598-003 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname754598-003 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname754598-003 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              PublicIdname754598-003 - bench_routing/mock_crust_merge_merge_three_sections_...
                        time:   [14.703 ms 14.770 ms 14.907 ms]
                        change: [+5.1452% +5.9103% +6.5733%] (p = 0.02 < 0.05)
                        Change within noise threshold.

Benchmarking PublicIdname93b63e-001 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-001 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-001 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-001 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              PublicIdname93b63e-001 - bench_routing/mock_crust_merge_merge_three_sections_...
                        time:   [169.03 ms 169.15 ms 169.45 ms]
                        change: [+4.9682% +5.0827% +5.2130%] (p = 0.03 < 0.05)
                        Change within noise threshold.

Benchmarking PublicIdname93b63e-002 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-002 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-002 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-002 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              PublicIdname93b63e-002 - bench_routing/mock_crust_merge_merge_three_sections_...
                        time:   [296.25 ms 298.43 ms 299.44 ms]
                        change: [+5.3964% +5.9391% +6.4634%] (p = 0.02 < 0.05)
                        Change within noise threshold.

Benchmarking PublicIdname93b63e-003 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-003 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-003 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-003 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              PublicIdname93b63e-003 - bench_routing/mock_crust_merge_merge_three_sections_...
                        time:   [45.807 ms 46.091 ms 46.210 ms]
                        change: [+5.8203% +6.4414% +7.0662%] (p = 0.03 < 0.05)
                        Change within noise threshold.

Benchmarking PublicIdname93b63e-004 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-004 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-004 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-004 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              PublicIdname93b63e-004 - bench_routing/mock_crust_merge_merge_three_sections_...
                        time:   [32.478 ms 32.850 ms 33.150 ms]
                        change: [+5.0756% +6.1002% +7.2467%] (p = 0.02 < 0.05)
                        Change within noise threshold.

Benchmarking PublicIdname93b63e-005 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-005 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-005 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              Benchmarking PublicIdname93b63e-005 - bench_routing/mock_crust_merge_merge_three_sections_into                                                                                              PublicIdname93b63e-005 - bench_routing/mock_crust_merge_merge_three_sections_...
                        time:   [14.196 ms 14.227 ms 14.474 ms]
                        change: [+4.5304% +5.7220% +7.0488%] (p = 0.03 < 0.05)
                        Change within noise threshold.
```