### PR TITLE
chore/test: remove macro

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 /// Parsec error
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum Error {
     /// Payload of a `Vote` doesn't match the payload of a `Block`.
     MismatchedPayload,

--- a/src/gossip/messages.rs
+++ b/src/gossip/messages.rs
@@ -10,7 +10,7 @@ use crate::{gossip::packed_event::PackedEvent, id::PublicId, network_event::Netw
 
 /// A gossip request message.
 #[serde(bound = "")]
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct Request<T: NetworkEvent, P: PublicId> {
     pub(crate) packed_events: Vec<PackedEvent<T, P>>,
 }
@@ -23,7 +23,7 @@ impl<T: NetworkEvent, P: PublicId> Request<T, P> {
 
 /// A gossip response message.
 #[serde(bound = "")]
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct Response<T: NetworkEvent, P: PublicId> {
     pub(crate) packed_events: Vec<PackedEvent<T, P>>,
 }


### PR DESCRIPTION
This removes a macro used by the functional tests which could easily be misused, an example being highlighted by [this comment thread](https://github.com/maidsafe/parsec/pull/300#discussion_r276644857).