### PR TITLE
fix/meta-election: decide if others already did

### DIFF
--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -703,18 +703,14 @@ fn parse_meta_vote() -> Parser<u8, MetaVote> {
         + parse_opt_bool()
         - spaces()
         + parse_opt_bool())
-    .map(|(((((round, step), est), bin), aux), dec)| MetaVote {
-        round,
-        step: match step {
+    .map(|(((((round, step), est), bin), aux), dec)| {
+        let step = match step {
             0 => Step::ForcedTrue,
             1 => Step::ForcedFalse,
             2 => Step::GenuineFlip,
             _ => unreachable!(),
-        },
-        estimates: est,
-        bin_values: bin,
-        aux_value: aux,
-        decision: dec,
+        };
+        MetaVote::new(round, step, est, bin, aux, dec)
     })
 }
 

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -310,14 +310,6 @@ mod detail {
         fs::remove_dir(path)
     }
 
-    fn as_short_string(value: Option<bool>) -> &'static str {
-        match value {
-            None => "-",
-            Some(true) => "t",
-            Some(false) => "f",
-        }
-    }
-
     fn dump_meta_votes(
         short_peer_ids: &PeerIndexMap<String>,
         meta_votes: &PeerIndexMap<Vec<MetaVote>>,
@@ -347,10 +339,7 @@ mod detail {
 
             let mut prefix: &str = prefix.as_str();
             for mv in meta_votes {
-                let est = mv.estimates.as_short_string();
-                let bin = mv.bin_values.as_short_string();
-                let aux = as_short_string(mv.aux_value);
-                let dec = as_short_string(mv.decision);
+                let (est, bin, aux, dec) = mv.values.as_chars();
                 let line = if comment {
                     format!(
                         "{}{}/{:?}   {}   {}   {}   {} ",

--- a/src/meta_voting/bool_set.rs
+++ b/src/meta_voting/bool_set.rs
@@ -42,10 +42,6 @@ impl BoolSet {
         }
     }
 
-    pub fn clear(&mut self) {
-        *self = BoolSet::Empty
-    }
-
     pub fn len(self) -> usize {
         match self {
             BoolSet::Empty => 0,
@@ -56,15 +52,5 @@ impl BoolSet {
 
     pub fn from_bool(val: bool) -> Self {
         BoolSet::Single(val)
-    }
-
-    #[cfg(feature = "dump-graphs")]
-    pub(crate) fn as_short_string(self) -> &'static str {
-        match self {
-            BoolSet::Empty => "-",
-            BoolSet::Single(true) => "t",
-            BoolSet::Single(false) => "f",
-            BoolSet::Both => "b",
-        }
     }
 }

--- a/src/meta_voting/meta_vote.rs
+++ b/src/meta_voting/meta_vote.rs
@@ -73,28 +73,16 @@ impl Debug for MetaVote {
 }
 
 impl MetaVote {
-    pub fn new(
-        initial_estimate: bool,
-        others: &[&[MetaVote]],
-        total_peers: usize,
-        is_voter: bool,
-    ) -> Vec<Self> {
+    pub fn new(initial_estimate: bool, others: &[&[MetaVote]], total_peers: usize) -> Vec<Self> {
         let mut initial = Self::default();
-        if is_voter {
-            initial.estimates = BoolSet::from_bool(initial_estimate);
-        }
-        Self::next_votes(&[initial], others, &BTreeMap::new(), total_peers, is_voter)
+        initial.estimates = BoolSet::from_bool(initial_estimate);
+        Self::next_votes(&[initial], others, &BTreeMap::new(), total_peers)
     }
 
     /// Create temporary next meta-votes. They must be finalized by calling `next_final` before
     /// passing them to `MetaEvent`.
-    pub fn next_temp(
-        parent: &[MetaVote],
-        others: &[&[MetaVote]],
-        total_peers: usize,
-        is_voter: bool,
-    ) -> Vec<Self> {
-        Self::next_votes(parent, others, &BTreeMap::new(), total_peers, is_voter)
+    pub fn next_temp(parent: &[MetaVote], others: &[&[MetaVote]], total_peers: usize) -> Vec<Self> {
+        Self::next_votes(parent, others, &BTreeMap::new(), total_peers)
     }
 
     /// Finalize temporary meta-votes.
@@ -103,9 +91,8 @@ impl MetaVote {
         others: &[&[MetaVote]],
         coin_tosses: &BTreeMap<usize, bool>,
         total_peers: usize,
-        is_voter: bool,
     ) -> Vec<Self> {
-        Self::next_votes(temp, others, coin_tosses, total_peers, is_voter)
+        Self::next_votes(temp, others, coin_tosses, total_peers)
     }
 
     fn next_votes(
@@ -113,12 +100,11 @@ impl MetaVote {
         others: &[&[MetaVote]],
         coin_tosses: &BTreeMap<usize, bool>,
         total_peers: usize,
-        is_voter: bool,
     ) -> Vec<Self> {
         let mut next = Vec::new();
         for vote in prev {
-            let counts = MetaVoteCounts::new(vote, others, total_peers, is_voter);
-            let updated = vote.update(counts, &coin_tosses, is_voter);
+            let counts = MetaVoteCounts::new(vote, others, total_peers);
+            let updated = vote.update(counts, &coin_tosses);
             let decided = updated.decision.is_some();
             next.push(updated);
             if decided {
@@ -127,7 +113,7 @@ impl MetaVote {
         }
 
         while let Some(next_meta_vote) =
-            Self::next_vote(next.last(), others, &coin_tosses, total_peers, is_voter)
+            Self::next_vote(next.last(), others, &coin_tosses, total_peers)
         {
             next.push(next_meta_vote);
         }
@@ -139,21 +125,16 @@ impl MetaVote {
         (self.round, self.step)
     }
 
-    fn update(
-        &self,
-        mut counts: MetaVoteCounts,
-        coin_tosses: &BTreeMap<usize, bool>,
-        is_voter: bool,
-    ) -> MetaVote {
+    fn update(&self, mut counts: MetaVoteCounts, coin_tosses: &BTreeMap<usize, bool>) -> MetaVote {
         if self.decision.is_some() {
             return *self;
         }
         let coin_toss = coin_tosses.get(&self.round);
         let mut updated = *self;
-        updated.calculate_new_estimates(&mut counts, coin_toss, is_voter);
+        updated.calculate_new_estimates(&mut counts, coin_toss);
         let bin_values_was_empty = updated.bin_values.is_empty();
-        updated.calculate_new_bin_values(&mut counts, is_voter);
-        updated.calculate_new_auxiliary_value(&mut counts, bin_values_was_empty, is_voter);
+        updated.calculate_new_bin_values(&mut counts);
+        updated.calculate_new_auxiliary_value(&mut counts, bin_values_was_empty);
         counts.check_exceeding();
         updated.calculate_new_decision(&counts);
         updated
@@ -164,69 +145,49 @@ impl MetaVote {
         others: &[&[MetaVote]],
         coin_tosses: &BTreeMap<usize, bool>,
         total_peers: usize,
-        is_voter: bool,
     ) -> Option<MetaVote> {
         let parent = parent?;
 
         if parent.decision.is_some() {
             return None;
         }
-        let counts = MetaVoteCounts::new(parent, others, total_peers, is_voter);
+        let counts = MetaVoteCounts::new(parent, others, total_peers);
         if counts.is_supermajority(counts.aux_values_set()) {
             let coin_toss = coin_tosses.get(&parent.round);
             let next = parent.increase_step(&counts, coin_toss.cloned());
-            let new_counts = MetaVoteCounts::new(&next, others, total_peers, is_voter);
-            let updated = next.update(new_counts, &coin_tosses, is_voter);
+            let new_counts = MetaVoteCounts::new(&next, others, total_peers);
+            let updated = next.update(new_counts, &coin_tosses);
             Some(updated)
         } else {
             None
         }
     }
 
-    fn calculate_new_estimates(
-        &mut self,
-        counts: &mut MetaVoteCounts,
-        coin_toss: Option<&bool>,
-        is_voter: bool,
-    ) {
+    fn calculate_new_estimates(&mut self, counts: &mut MetaVoteCounts, coin_toss: Option<&bool>) {
         if self.estimates.is_empty() {
             if let Some(toss) = coin_toss {
-                if is_voter {
-                    if *toss {
-                        counts.estimates_true += 1;
-                    } else {
-                        counts.estimates_false += 1;
-                    }
+                if *toss {
+                    counts.estimates_true += 1;
+                } else {
+                    counts.estimates_false += 1;
                 }
                 self.estimates = BoolSet::from_bool(*toss);
             }
         } else {
-            if counts.at_least_one_third(counts.estimates_true)
-                && self.estimates.insert(true)
-                && is_voter
-            {
+            if counts.at_least_one_third(counts.estimates_true) && self.estimates.insert(true) {
                 counts.estimates_true += 1;
             }
-            if counts.at_least_one_third(counts.estimates_false)
-                && self.estimates.insert(false)
-                && is_voter
-            {
+            if counts.at_least_one_third(counts.estimates_false) && self.estimates.insert(false) {
                 counts.estimates_false += 1;
             }
         }
     }
 
-    fn calculate_new_bin_values(&mut self, counts: &mut MetaVoteCounts, is_voter: bool) {
-        if counts.is_supermajority(counts.estimates_true)
-            && self.bin_values.insert(true)
-            && is_voter
-        {
+    fn calculate_new_bin_values(&mut self, counts: &mut MetaVoteCounts) {
+        if counts.is_supermajority(counts.estimates_true) && self.bin_values.insert(true) {
             counts.bin_values_true += 1;
         }
-        if counts.is_supermajority(counts.estimates_false)
-            && self.bin_values.insert(false)
-            && is_voter
-        {
+        if counts.is_supermajority(counts.estimates_false) && self.bin_values.insert(false) {
             counts.bin_values_false += 1;
         }
     }
@@ -235,7 +196,6 @@ impl MetaVote {
         &mut self,
         counts: &mut MetaVoteCounts,
         bin_values_was_empty: bool,
-        is_voter: bool,
     ) {
         if self.aux_value.is_some() {
             return;
@@ -244,20 +204,14 @@ impl MetaVote {
             if self.bin_values.len() == 1 {
                 if self.bin_values.contains(true) {
                     self.aux_value = Some(true);
-                    if is_voter {
-                        counts.aux_values_true += 1;
-                    }
+                    counts.aux_values_true += 1;
                 } else {
                     self.aux_value = Some(false);
-                    if is_voter {
-                        counts.aux_values_false += 1;
-                    }
+                    counts.aux_values_false += 1;
                 }
             } else if self.bin_values.len() == 2 {
                 self.aux_value = Some(true);
-                if is_voter {
-                    counts.aux_values_true += 1;
-                }
+                counts.aux_values_true += 1;
             }
         }
     }

--- a/src/meta_voting/meta_vote.rs
+++ b/src/meta_voting/meta_vote.rs
@@ -12,15 +12,339 @@ use std::{
     fmt::{self, Debug, Formatter},
 };
 
+#[derive(Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct Estimates(BoolSet);
+impl Debug for Estimates {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write_multiple_bool_values(f, "est", self.0)
+    }
+}
+impl Estimates {
+    fn from_initial_value(value: bool) -> Self {
+        Estimates(BoolSet::from_bool(value))
+    }
+    fn calculate(&mut self, counts: &mut MetaVoteCounts, coin_toss: Option<bool>) {
+        if self.0.is_empty() {
+            if let Some(toss) = coin_toss {
+                if toss {
+                    counts.estimates_true += 1;
+                } else {
+                    counts.estimates_false += 1;
+                }
+                self.0 = BoolSet::from_bool(toss);
+            }
+        } else {
+            if counts.at_least_one_third(counts.estimates_true) && self.0.insert(true) {
+                counts.estimates_true += 1;
+            }
+            if counts.at_least_one_third(counts.estimates_false) && self.0.insert(false) {
+                counts.estimates_false += 1;
+            }
+        }
+    }
+    pub fn is_empty(self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+#[derive(Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct BinValues(BoolSet);
+impl Debug for BinValues {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write_multiple_bool_values(f, "bin", self.0)
+    }
+}
+
+impl BinValues {
+    fn calculate(&mut self, counts: &mut MetaVoteCounts) {
+        if counts.is_supermajority(counts.estimates_true) && self.0.insert(true) {
+            counts.bin_values_true += 1;
+        }
+        if counts.is_supermajority(counts.estimates_false) && self.0.insert(false) {
+            counts.bin_values_false += 1;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct AuxValue(Option<bool>);
+impl Debug for AuxValue {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write_optional_single_bool_value(f, "aux", self.0)
+    }
+}
+
+impl AuxValue {
+    fn calculate(
+        &mut self,
+        counts: &mut MetaVoteCounts,
+        bin_values_before_update: BinValues,
+        bin_values_now: BinValues,
+    ) {
+        if self.0.is_some() {
+            return;
+        }
+        let bin_values_was_empty = bin_values_before_update.0.is_empty();
+        if bin_values_was_empty {
+            if bin_values_now.0.len() == 1 {
+                if bin_values_now.0.contains(true) {
+                    self.0 = Some(true);
+                    counts.aux_values_true += 1;
+                } else {
+                    self.0 = Some(false);
+                    counts.aux_values_false += 1;
+                }
+            } else if bin_values_now.0.len() == 2 {
+                self.0 = Some(true);
+                counts.aux_values_true += 1;
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UndecidedMetaVoteValues {
+    estimates: Estimates,
+    bin_values: BinValues,
+    aux_value: AuxValue,
+}
+impl Debug for UndecidedMetaVoteValues {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{:?}{:?}{:?}",
+            self.estimates, self.bin_values, self.aux_value
+        )
+    }
+}
+impl UndecidedMetaVoteValues {
+    fn from_decided_meta_vote(value: bool) -> Self {
+        Self {
+            estimates: Estimates(BoolSet::from_bool(value)),
+            bin_values: BinValues(BoolSet::from_bool(value)),
+            aux_value: AuxValue(Some(value)),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum MetaVoteValues {
+    Decided(bool),
+    Undecided(UndecidedMetaVoteValues),
+}
+impl Debug for MetaVoteValues {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            MetaVoteValues::Decided(value) => {
+                write!(
+                    f,
+                    "{:?}",
+                    UndecidedMetaVoteValues::from_decided_meta_vote(*value)
+                )?;
+                write_optional_single_bool_value(f, "dec", Some(*value))
+            }
+            MetaVoteValues::Undecided(values) => {
+                write!(f, "{:?}", values)?;
+                write_optional_single_bool_value(f, "dec", None)
+            }
+        }
+    }
+}
+
+impl MetaVoteValues {
+    fn from_initial_estimate(value: bool) -> Self {
+        let mut values = UndecidedMetaVoteValues::default();
+        values.estimates = Estimates::from_initial_value(value);
+        MetaVoteValues::Undecided(values)
+    }
+    pub(crate) fn count(self) -> MetaVoteCounts {
+        // Counts the contribution of these MetaVoteValues
+        let mut counts = MetaVoteCounts::default();
+        match self {
+            MetaVoteValues::Decided(value) => {
+                counts.decision = Some(value);
+                if value {
+                    counts.estimates_true = 1;
+                    counts.bin_values_true = 1;
+                    counts.aux_values_true = 1;
+                } else {
+                    counts.estimates_false = 1;
+                    counts.bin_values_false = 1;
+                    counts.aux_values_false = 1;
+                }
+            }
+            MetaVoteValues::Undecided(values) => {
+                if values.estimates.0.contains(true) {
+                    counts.estimates_true = 1;
+                }
+                if values.estimates.0.contains(false) {
+                    counts.estimates_false = 1;
+                }
+                if values.bin_values.0.contains(true) {
+                    counts.bin_values_true = 1;
+                }
+                if values.bin_values.0.contains(false) {
+                    counts.bin_values_false = 1;
+                }
+                match values.aux_value.0 {
+                    Some(true) => counts.aux_values_true = 1,
+                    Some(false) => counts.aux_values_false = 1,
+                    None => (),
+                }
+            }
+        }
+        counts
+    }
+    fn calculate_new_estimates(&mut self, counts: &mut MetaVoteCounts, coin_toss: Option<bool>) {
+        if let MetaVoteValues::Undecided(values) = self {
+            values.estimates.calculate(counts, coin_toss);
+        }
+    }
+    fn calculate_new_bin_values(&mut self, counts: &mut MetaVoteCounts) {
+        if let MetaVoteValues::Undecided(values) = self {
+            values.bin_values.calculate(counts);
+        }
+    }
+    fn calculate_new_auxiliary_value(
+        &mut self,
+        counts: &mut MetaVoteCounts,
+        bin_values_before_update: BinValues,
+    ) {
+        if let MetaVoteValues::Undecided(values) = self {
+            let bin_values_now = values.bin_values;
+            values
+                .aux_value
+                .calculate(counts, bin_values_before_update, bin_values_now);
+        }
+    }
+    fn calculate_new_decision(&mut self, counts: &MetaVoteCounts, step: Step) {
+        if let MetaVoteValues::Undecided(values) = *self {
+            let bin_values = values.bin_values;
+            let decision = match step {
+                Step::ForcedTrue => {
+                    if bin_values.0.contains(true)
+                        && counts.is_supermajority(counts.aux_values_true)
+                    {
+                        Some(true)
+                    } else {
+                        counts.decision
+                    }
+                }
+                Step::ForcedFalse => {
+                    if bin_values.0.contains(false)
+                        && counts.is_supermajority(counts.aux_values_false)
+                    {
+                        Some(false)
+                    } else {
+                        counts.decision
+                    }
+                }
+                Step::GenuineFlip => counts.decision,
+            };
+            if let Some(value) = decision {
+                *self = MetaVoteValues::Decided(value);
+            }
+        }
+    }
+    fn increase_step(&mut self, counts: &MetaVoteCounts, coin_toss: Option<bool>, step: Step) {
+        if let MetaVoteValues::Undecided(mut values) = *self {
+            // Set the estimates as per the concrete coin toss rules.
+            values.estimates.0 = match step {
+                Step::ForcedTrue => {
+                    if counts.is_supermajority(counts.aux_values_false) {
+                        BoolSet::from_bool(false)
+                    } else {
+                        BoolSet::from_bool(true)
+                    }
+                }
+                Step::ForcedFalse => {
+                    if counts.is_supermajority(counts.aux_values_true) {
+                        BoolSet::from_bool(true)
+                    } else {
+                        BoolSet::from_bool(false)
+                    }
+                }
+                Step::GenuineFlip => {
+                    if counts.is_supermajority(counts.aux_values_true) {
+                        BoolSet::from_bool(true)
+                    } else if counts.is_supermajority(counts.aux_values_false) {
+                        BoolSet::from_bool(false)
+                    } else if let Some(coin_toss) = coin_toss {
+                        BoolSet::from_bool(coin_toss)
+                    } else {
+                        // Clear the estimates to indicate we're waiting for further events to be
+                        // gossiped to try and get the coin toss result.
+                        BoolSet::Empty
+                    }
+                }
+            };
+            values.bin_values.0 = BoolSet::Empty;
+            values.aux_value.0 = None;
+        }
+    }
+    fn update(&mut self, mut counts: MetaVoteCounts, coin_toss: Option<bool>, step: Step) {
+        *self = match self {
+            MetaVoteValues::Decided(_) => *self,
+            MetaVoteValues::Undecided(ref values) => {
+                let mut updated = *self;
+                updated.calculate_new_estimates(&mut counts, coin_toss);
+                let bin_values_before_update = values.bin_values;
+                updated.calculate_new_bin_values(&mut counts);
+                updated.calculate_new_auxiliary_value(&mut counts, bin_values_before_update);
+                counts.check_exceeding();
+                updated.calculate_new_decision(&counts, step);
+                updated
+            }
+        }
+    }
+
+    #[cfg(feature = "dump-graphs")]
+    pub fn as_chars(self) -> (char, char, char, char) {
+        let pretty_bool = |b: bool| {
+            if b {
+                't'
+            } else {
+                'f'
+            }
+        };
+        let pretty_option_bool = |o: Option<bool>| match o {
+            Some(b) => pretty_bool(b),
+            None => '_',
+        };
+        let pretty_bool_set = |s: BoolSet| match s {
+            BoolSet::Empty => '-',
+            BoolSet::Single(b) => pretty_bool(b),
+            BoolSet::Both => 'b',
+        };
+
+        match self {
+            MetaVoteValues::Decided(value) => {
+                let dec = pretty_bool(value);
+                (dec, dec, dec, dec)
+            }
+            MetaVoteValues::Undecided(values) => {
+                let est = pretty_bool_set(values.estimates.0);
+                let bin = pretty_bool_set(values.bin_values.0);
+                let aux = pretty_option_bool(values.aux_value.0);
+                let dec = pretty_option_bool(None);
+                (est, bin, aux, dec)
+            }
+        }
+    }
+}
+
+impl Default for MetaVoteValues {
+    fn default() -> Self {
+        MetaVoteValues::Undecided(Default::default())
+    }
+}
+
 // This holds the state of a (binary) meta vote about which we're trying to achieve consensus.
 #[derive(Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct MetaVote {
     pub round: usize,
     pub step: Step,
-    pub estimates: BoolSet,
-    pub bin_values: BoolSet,
-    pub aux_value: Option<bool>,
-    pub decision: Option<bool>,
+    pub values: MetaVoteValues,
 }
 
 fn write_bool(f: &mut Formatter, a_bool: bool) -> fmt::Result {
@@ -62,20 +386,48 @@ fn write_optional_single_bool_value(
 impl Debug for MetaVote {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{{ {}/{:?}, ", self.round, self.step)?;
-
-        write_multiple_bool_values(f, "est", self.estimates)?;
-        write_multiple_bool_values(f, "bin", self.bin_values)?;
-        write_optional_single_bool_value(f, "aux", self.aux_value)?;
-        write_optional_single_bool_value(f, "dec", self.decision)?;
-
+        write!(f, "{:?}", self.values)?;
         write!(f, "}}")
     }
 }
 
 impl MetaVote {
-    pub fn new(initial_estimate: bool, others: &[&[MetaVote]], total_peers: usize) -> Vec<Self> {
-        let mut initial = Self::default();
-        initial.estimates = BoolSet::from_bool(initial_estimate);
+    #[cfg(any(test, feature = "testing"))]
+    pub fn new(
+        round: usize,
+        step: Step,
+        estimates: BoolSet,
+        bin_values: BoolSet,
+        aux_value: Option<bool>,
+        decision: Option<bool>,
+    ) -> Self {
+        let values = match decision {
+            Some(values) => MetaVoteValues::Decided(values),
+            None => {
+                let values = UndecidedMetaVoteValues {
+                    estimates: Estimates(estimates),
+                    bin_values: BinValues(bin_values),
+                    aux_value: AuxValue(aux_value),
+                };
+                MetaVoteValues::Undecided(values)
+            }
+        };
+        MetaVote {
+            round,
+            step,
+            values,
+        }
+    }
+
+    pub fn new_for_observer(
+        initial_estimate: bool,
+        others: &[&[MetaVote]],
+        total_peers: usize,
+    ) -> Vec<Self> {
+        let initial = Self {
+            values: MetaVoteValues::from_initial_estimate(initial_estimate),
+            ..Default::default()
+        };
         Self::next_votes(&[initial], others, &BTreeMap::new(), total_peers)
     }
 
@@ -95,6 +447,27 @@ impl MetaVote {
         Self::next_votes(temp, others, coin_tosses, total_peers)
     }
 
+    pub fn contains_aux_value(&self) -> bool {
+        match self.values {
+            MetaVoteValues::Decided(_) => true,
+            MetaVoteValues::Undecided(values) => values.aux_value.0.is_some(),
+        }
+    }
+
+    pub fn decision(&self) -> Option<bool> {
+        match self.values {
+            MetaVoteValues::Decided(value) => Some(value),
+            MetaVoteValues::Undecided(_) => None,
+        }
+    }
+
+    pub fn has_empty_estimates(&self) -> bool {
+        match self.values {
+            MetaVoteValues::Decided(_) => false,
+            MetaVoteValues::Undecided(values) => values.estimates.is_empty(),
+        }
+    }
+
     fn next_votes(
         prev: &[MetaVote],
         others: &[&[MetaVote]],
@@ -104,8 +477,9 @@ impl MetaVote {
         let mut next = Vec::new();
         for vote in prev {
             let counts = MetaVoteCounts::new(vote, others, total_peers);
-            let updated = vote.update(counts, &coin_tosses);
-            let decided = updated.decision.is_some();
+            let mut updated = *vote;
+            updated.update(counts, &coin_tosses);
+            let decided = vote.is_decided();
             next.push(updated);
             if decided {
                 break;
@@ -125,19 +499,17 @@ impl MetaVote {
         (self.round, self.step)
     }
 
-    fn update(&self, mut counts: MetaVoteCounts, coin_tosses: &BTreeMap<usize, bool>) -> MetaVote {
-        if self.decision.is_some() {
-            return *self;
+    fn is_decided(&self) -> bool {
+        if let MetaVoteValues::Decided(_) = self.values {
+            true
+        } else {
+            false
         }
-        let coin_toss = coin_tosses.get(&self.round);
-        let mut updated = *self;
-        updated.calculate_new_estimates(&mut counts, coin_toss);
-        let bin_values_was_empty = updated.bin_values.is_empty();
-        updated.calculate_new_bin_values(&mut counts);
-        updated.calculate_new_auxiliary_value(&mut counts, bin_values_was_empty);
-        counts.check_exceeding();
-        updated.calculate_new_decision(&counts);
-        updated
+    }
+
+    fn update(&mut self, counts: MetaVoteCounts, coin_tosses: &BTreeMap<usize, bool>) {
+        let coin_toss = coin_tosses.get(&self.round).cloned();
+        self.values.update(counts, coin_toss, self.step);
     }
 
     fn next_vote(
@@ -148,145 +520,36 @@ impl MetaVote {
     ) -> Option<MetaVote> {
         let parent = parent?;
 
-        if parent.decision.is_some() {
+        if parent.is_decided() {
             return None;
         }
         let counts = MetaVoteCounts::new(parent, others, total_peers);
         if counts.is_supermajority(counts.aux_values_set()) {
             let coin_toss = coin_tosses.get(&parent.round);
-            let next = parent.increase_step(&counts, coin_toss.cloned());
+            let mut next = parent.increase_step(&counts, coin_toss.cloned());
             let new_counts = MetaVoteCounts::new(&next, others, total_peers);
-            let updated = next.update(new_counts, &coin_tosses);
-            Some(updated)
+            next.update(new_counts, &coin_tosses);
+            Some(next)
         } else {
             None
         }
     }
 
-    fn calculate_new_estimates(&mut self, counts: &mut MetaVoteCounts, coin_toss: Option<&bool>) {
-        if self.estimates.is_empty() {
-            if let Some(toss) = coin_toss {
-                if *toss {
-                    counts.estimates_true += 1;
-                } else {
-                    counts.estimates_false += 1;
-                }
-                self.estimates = BoolSet::from_bool(*toss);
-            }
-        } else {
-            if counts.at_least_one_third(counts.estimates_true) && self.estimates.insert(true) {
-                counts.estimates_true += 1;
-            }
-            if counts.at_least_one_third(counts.estimates_false) && self.estimates.insert(false) {
-                counts.estimates_false += 1;
-            }
-        }
-    }
-
-    fn calculate_new_bin_values(&mut self, counts: &mut MetaVoteCounts) {
-        if counts.is_supermajority(counts.estimates_true) && self.bin_values.insert(true) {
-            counts.bin_values_true += 1;
-        }
-        if counts.is_supermajority(counts.estimates_false) && self.bin_values.insert(false) {
-            counts.bin_values_false += 1;
-        }
-    }
-
-    fn calculate_new_auxiliary_value(
-        &mut self,
-        counts: &mut MetaVoteCounts,
-        bin_values_was_empty: bool,
-    ) {
-        if self.aux_value.is_some() {
-            return;
-        }
-        if bin_values_was_empty {
-            if self.bin_values.len() == 1 {
-                if self.bin_values.contains(true) {
-                    self.aux_value = Some(true);
-                    counts.aux_values_true += 1;
-                } else {
-                    self.aux_value = Some(false);
-                    counts.aux_values_false += 1;
-                }
-            } else if self.bin_values.len() == 2 {
-                self.aux_value = Some(true);
-                counts.aux_values_true += 1;
-            }
-        }
-    }
-
-    fn calculate_new_decision(&mut self, counts: &MetaVoteCounts) {
-        let opt_decision = match self.step {
-            Step::ForcedTrue => {
-                if self.bin_values.contains(true) && counts.is_supermajority(counts.aux_values_true)
-                {
-                    Some(true)
-                } else {
-                    counts.decision
-                }
-            }
-            Step::ForcedFalse => {
-                if self.bin_values.contains(false)
-                    && counts.is_supermajority(counts.aux_values_false)
-                {
-                    Some(false)
-                } else {
-                    counts.decision
-                }
-            }
-            Step::GenuineFlip => counts.decision,
-        };
-        if let Some(decision) = opt_decision {
-            self.estimates = BoolSet::from_bool(decision);
-            self.bin_values = BoolSet::from_bool(decision);
-            self.aux_value = Some(decision);
-            self.decision = Some(decision);
-        }
-    }
-
     fn increase_step(&self, counts: &MetaVoteCounts, coin_toss: Option<bool>) -> Self {
-        let mut next = Self {
-            bin_values: BoolSet::Empty,
-            aux_value: None,
-            ..*self
-        };
-
-        // Set the estimates as per the concrete coin toss rules.
+        let mut next = *self;
+        next.values.increase_step(counts, coin_toss, self.step);
         match next.step {
             Step::ForcedTrue => {
-                if counts.is_supermajority(counts.aux_values_false) {
-                    next.estimates = BoolSet::from_bool(false);
-                } else if !counts.is_supermajority(counts.aux_values_true) {
-                    next.estimates = BoolSet::from_bool(true);
-                }
                 next.step = Step::ForcedFalse;
             }
             Step::ForcedFalse => {
-                if counts.is_supermajority(counts.aux_values_true) {
-                    next.estimates = BoolSet::from_bool(true);
-                } else if !counts.is_supermajority(counts.aux_values_false) {
-                    next.estimates = BoolSet::from_bool(false);
-                }
                 next.step = Step::GenuineFlip;
             }
             Step::GenuineFlip => {
-                if counts.is_supermajority(counts.aux_values_true) {
-                    next.estimates = BoolSet::from_bool(true);
-                } else if counts.is_supermajority(counts.aux_values_false) {
-                    next.estimates = BoolSet::from_bool(false);
-                } else if let Some(coin_toss_result) = coin_toss {
-                    next.estimates = BoolSet::from_bool(coin_toss_result);
-                } else {
-                    // Clear the estimates to indicate we're waiting for further events to be
-                    // gossiped to try and get the coin toss result.
-                    next.estimates.clear();
-                }
                 next.step = Step::ForcedTrue;
                 next.round += 1;
             }
         }
-
         next
     }
 }

--- a/src/meta_voting/meta_vote.rs
+++ b/src/meta_voting/meta_vote.rs
@@ -100,11 +100,12 @@ impl MetaVote {
     /// Finalize temporary meta-votes.
     pub fn next_final(
         temp: &[MetaVote],
+        others: &[&[MetaVote]],
         coin_tosses: &BTreeMap<usize, bool>,
         total_peers: usize,
         is_voter: bool,
     ) -> Vec<Self> {
-        Self::next_votes(temp, &[], coin_tosses, total_peers, is_voter)
+        Self::next_votes(temp, others, coin_tosses, total_peers, is_voter)
     }
 
     fn next_votes(

--- a/src/meta_voting/meta_vote_counts.rs
+++ b/src/meta_voting/meta_vote_counts.rs
@@ -26,13 +26,8 @@ pub(crate) struct MetaVoteCounts {
 impl MetaVoteCounts {
     // Construct a `MetaVoteCounts` by collecting details from all meta votes which are for the
     // given `parent`'s `round` and `step`.  These results will include info from our own `parent`
-    // meta vote, if `is_voter` is true.
-    pub fn new(
-        parent: &MetaVote,
-        others: &[&[MetaVote]],
-        total_peers: usize,
-        is_voter: bool,
-    ) -> Self {
+    // meta vote.
+    pub fn new(parent: &MetaVote, others: &[&[MetaVote]], total_peers: usize) -> Self {
         let mut counts = MetaVoteCounts::default();
         counts.total_peers = total_peers;
         for vote in others
@@ -43,7 +38,7 @@ impl MetaVoteCounts {
                     .filter(|vote| vote.round_and_step() == parent.round_and_step())
                     .last()
             })
-            .chain(if is_voter { Some(parent) } else { None })
+            .chain(Some(parent))
         {
             if vote.estimates.contains(true) {
                 counts.estimates_true += 1;

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -1093,9 +1093,15 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             };
 
             for (peer_index, temp_votes) in &context.temp_votes {
+                let other_votes = Self::peer_meta_votes(&ancestors_meta_votes, peer_index);
                 let coin_tosses = self.toss_coins(&voters, peer_index, temp_votes, &context)?;
-                let final_meta_votes =
-                    MetaVote::next_final(temp_votes, &coin_tosses, voters.len(), is_voter);
+                let final_meta_votes = MetaVote::next_final(
+                    temp_votes,
+                    &other_votes,
+                    &coin_tosses,
+                    voters.len(),
+                    is_voter,
+                );
 
                 builder.add_meta_votes(peer_index, final_meta_votes);
             }


### PR DESCRIPTION
Most of the logic for picking up a decision from other nodes is already
in-place:
In `MetaVoteCounts::new`, we pick any decision from any other voter and
apply it to ourselves.
In `MetaVotes::calculate_new_decision`, we use this decision from the
counts as the default value for a meta_vote.

Where the logic stopped working was in the multi-stage calculation of
the estimates:
* We first evaluate a temporary value for the meta-election that
  doesn't take into account the coin toss
* We then evaluate the coin toss value
* We then finalise the meta-election evaluation using the coin toss

Prior to this change, we wouldn't pass the other meta-votes when
finalising the meta-election evaluation. This would mean that
MetaVoteCounts::new wouldn't actually pick up on the decision that other
voter made anymore. This would mean that the decision reached in our
temp meta-vote would actually be discarded and we wouldn't shortcut the
decision process.

This bug caused issues in soak testings of the routing crate with the
real Parsec.