### PR TITLE
Add related_info to Observation::Genesis

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -107,7 +107,12 @@ impl Peer {
     fn from_genesis(our_id: PeerId, genesis_group: &BTreeSet<PeerId>) -> Self {
         Self {
             id: our_id.clone(),
-            parsec: Parsec::from_genesis(our_id, genesis_group, ConsensusMode::Supermajority),
+            parsec: Parsec::from_genesis(
+                our_id,
+                genesis_group,
+                vec![],
+                ConsensusMode::Supermajority,
+            ),
             observations: vec![],
             blocks: vec![],
         }

--- a/input_graphs/benches/minimal.dot
+++ b/input_graphs/benches/minimal.dot
@@ -914,7 +914,7 @@ digraph GossipGraph {
 
 /// ===== meta-elections =====
 /// consensus_history:
-/// a137c1b54c5895b13a1e204869f650636920286bd5b903e0576a9a15a2f58c2c
+/// d98f8abc4ba966aadc391bb857a6879a122602074766f19fadf22ce59dd0410e
 /// c93ff2cda7e9dd6a49b12c4fccdbaa0fe1b25b1e92421f288b06bfe53122be0f
 
 /// interesting_events: {

--- a/input_graphs/dev_utils_record_tests_smoke_other_peer_names/annie.dot
+++ b/input_graphs/dev_utils_record_tests_smoke_other_peer_names/annie.dot
@@ -5,6 +5,7 @@
 ///   Carol: PeerState(VOTE|SEND|RECV)
 ///   Claire: PeerState(VOTE|SEND|RECV)
 /// }
+/// consensus_mode: Supermajority
 digraph GossipGraph {
   splines=false
   rankdir=BT
@@ -1163,7 +1164,7 @@ digraph GossipGraph {
 
 /// ===== meta-elections =====
 /// consensus_history:
-/// ece3eaf86a7f7396aed2e4bdd0c67cf7b67df5aabbd5eced04924b154d0f3841
+/// 5d1bc22c2cce50873bffc1ba00ecbecce52085dc3bd15e8b43f5167bf72962cd
 
 /// interesting_events: {
 ///   Annie -> ["An_19"]
@@ -1174,10 +1175,6 @@ digraph GossipGraph {
 /// all_voters: {Annie, B, Carol, Claire}
 /// unconsensused_events: {"An_13", "B_9", "Ca_6", "Cl_10"}
 /// meta_events: {
-///   An_13 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
 ///   An_14 -> {
 ///     observees: {}
 ///     interesting_content: []
@@ -1353,10 +1350,6 @@ digraph GossipGraph {
 ///     observees: {}
 ///     interesting_content: []
 ///   }
-///   B_9 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
 ///   B_10 -> {
 ///     observees: {}
 ///     interesting_content: []
@@ -1466,10 +1459,6 @@ digraph GossipGraph {
 ///       Ca: 0/0   t   t   t   t
 ///       Cl: 0/0   t   t   t   t
 ///     }
-///   }
-///   Ca_6 -> {
-///     observees: {}
-///     interesting_content: []
 ///   }
 ///   Ca_7 -> {
 ///     observees: {}
@@ -1617,10 +1606,6 @@ digraph GossipGraph {
 ///     }
 ///   }
 ///   Cl_9 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   Cl_10 -> {
 ///     observees: {}
 ///     interesting_content: []
 ///   }

--- a/input_graphs/functional_tests_unpolled_observations/alice.dot
+++ b/input_graphs/functional_tests_unpolled_observations/alice.dot
@@ -827,7 +827,7 @@ digraph GossipGraph {
 
 /// ===== meta-elections =====
 /// consensus_history:
-/// a137c1b54c5895b13a1e204869f650636920286bd5b903e0576a9a15a2f58c2c
+/// d98f8abc4ba966aadc391bb857a6879a122602074766f19fadf22ce59dd0410e
 
 /// interesting_events: {
 ///   Alice -> ["A_14"]

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -526,7 +526,10 @@ fn parse_invalid() -> Parser<u8, MaliceInput> {
 }
 
 fn parse_genesis() -> Parser<u8, Observation<Transaction, PeerId>> {
-    (seq(b"Genesis(") * parse_peers() - seq(b")")).map(Observation::Genesis)
+    (seq(b"Genesis(") * parse_peers() - seq(b")")).map(|group| Observation::Genesis {
+        group,
+        related_info: vec![],
+    })
 }
 
 fn parse_add() -> Parser<u8, Observation<Transaction, PeerId>> {

--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -425,8 +425,8 @@ impl Network {
 
         for block_group in block_groups {
             for block in block_group {
-                if let ParsecObservation::Genesis(ref g) = *block.payload() {
-                    valid_voters = g.clone();
+                if let ParsecObservation::Genesis { ref group, .. } = *block.payload() {
+                    valid_voters = group.clone();
                 }
 
                 self.check_block_signatories(block, &valid_voters)?;
@@ -434,7 +434,7 @@ impl Network {
 
             for block in block_group {
                 match *block.payload() {
-                    ParsecObservation::Genesis(_) => (),
+                    ParsecObservation::Genesis { .. } => (),
                     ParsecObservation::Add { ref peer_id, .. } => {
                         let _ = valid_voters.insert(peer_id.clone());
                     }

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -248,6 +248,7 @@ impl Peer {
         Self::new(WrappedParsec::Good(Parsec::from_genesis(
             id,
             genesis_group,
+            vec![],
             consensus_mode,
         )))
     }

--- a/src/dev_utils/record.rs
+++ b/src/dev_utils/record.rs
@@ -41,8 +41,12 @@ impl Record {
     }
 
     pub fn play(self) -> Parsec<Transaction, PeerId> {
-        let mut parsec =
-            Parsec::from_genesis(self.our_id, &self.genesis_group, self.consensus_mode);
+        let mut parsec = Parsec::from_genesis(
+            self.our_id,
+            &self.genesis_group,
+            vec![],
+            self.consensus_mode,
+        );
 
         for action in self.actions {
             action.run(&mut parsec)
@@ -213,8 +217,8 @@ fn extract_genesis_group<'a>(
         .and_then(|key| observations.get(key))
         .map(|info| &info.observation)
         .and_then(|observation| {
-            if let Observation::Genesis(ref genesis_group) = *observation {
-                Some(genesis_group)
+            if let Observation::Genesis { ref group, .. } = *observation {
+                Some(group)
             } else {
                 None
             }

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -979,7 +979,7 @@ mod detail {
             short_peer_ids: &PeerIndexMap<String>,
         ) -> Self {
             let value = match observation {
-                Observation::Genesis(group) => format!(
+                Observation::Genesis { group, .. } => format!(
                     "Genesis({:?})",
                     group.iter().map(sanitise_peer_id).collect::<BTreeSet<_>>()
                 ),

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -27,7 +27,14 @@ use std::{
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Observation<T: NetworkEvent, P: PublicId> {
     /// Genesis group
-    Genesis(BTreeSet<P>),
+    Genesis {
+        /// Members of the genesis group.
+        group: BTreeSet<P>,
+        /// Extra arbitrary information for use by the client.
+        /// Note: this can be set through the `genesis_related_info` argument of
+        /// `Parsec::from_genesis`.
+        related_info: Vec<u8>,
+    },
     /// Vote to add the indicated peer to the network.
     Add {
         /// Public id of the peer to be added
@@ -67,7 +74,7 @@ impl<T: NetworkEvent, P: PublicId> Observation<T, P> {
 impl<T: NetworkEvent, P: PublicId> Debug for Observation<T, P> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
-            Observation::Genesis(group) => write!(formatter, "Genesis({:?})", group),
+            Observation::Genesis { group, .. } => write!(formatter, "Genesis({:?})", group),
             Observation::Add { peer_id, .. } => write!(formatter, "Add({:?})", peer_id),
             Observation::Remove { peer_id, .. } => write!(formatter, "Remove({:?})", peer_id),
             Observation::Accusation { offender, malice } => {


### PR DESCRIPTION
- Add a new `genesis_info` parameter to `Parsec::from_genesis` for specifying the related_info on the genesis event.
- Some dot files had to be modified/regenerated because the hash of `Observation::Genesis` changed.
- A bogus clippy lint silenced by slightly reshuffling the code (clippy issue: https://github.com/rust-lang/rust-clippy/issues/4133)