### PR TITLE
DKG bring up: integrating code imported for HBBFT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ serde_derive = "~1.0.66"
 tiny-keccak = "~1.4.2"
 unwrap = "~1.2.1"
 threshold_crypto = "~0.3.1"
-bincode = "~1.0.1"
 failure = "~0.1.5"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,15 @@ maidsafe_utilities = "~0.18.0"
 pom = { version = "~1.1.0", optional = true }
 proptest = { version = "~0.8.6", optional = true }
 rand = "~0.4.2"
+rand_core = "0.2.1"
 safe_crypto = { version = "~0.7.0", optional = true }
 serde = "~1.0.66"
 serde_derive = "~1.0.66"
 tiny-keccak = "~1.4.2"
 unwrap = "~1.2.1"
+threshold_crypto = "~0.3.1"
+bincode = "~1.0.1"
+failure = "~0.1.5"
 
 [dev-dependencies]
 clap = "~2.32.0"

--- a/src/id.rs
+++ b/src/id.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use rand::Rng;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{fmt::Debug, hash::Hash};
 
@@ -17,9 +16,6 @@ pub trait PublicId: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned + Deb
     type Signature: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned + Debug;
     /// Verifies `signature` against `data` using this `PublicId`.  Returns `true` if valid.
     fn verify_signature(&self, signature: &Self::Signature, data: &[u8]) -> bool;
-    /// Encrypts the message using the OS random number generator.
-    /// TODO: this is currently borrowed from threshold_crypto. We will have to sort this out
-    fn encrypt_with_rng<R: Rng, M: AsRef<[u8]>>(&self, rng: &mut R, msg: M) -> Vec<u8>;
 }
 
 /// The secret identity of a node.  It provides functionality to allow it to be used as an
@@ -42,8 +38,10 @@ pub trait SecretId {
         }
     }
 
-    /// TODO: this is currently borrowed from threshold_crypto. We will have to sort this out
-    fn decrypt(&self, ct: &[u8]) -> Option<Vec<u8>>;
+    /// Encrypts the message using own Rng to `to`
+    fn encrypt<M: AsRef<[u8]>>(&self, to: &Self::PublicId, msg: M) -> Option<Vec<u8>>;
+    /// Decrypt message from `from`.
+    fn decrypt(&self, from: &Self::PublicId, ct: &[u8]) -> Option<Vec<u8>>;
 }
 
 /// A basic helper to carry a given [`Signature`](trait.PublicId.html#associatedtype.Signature)

--- a/src/id.rs
+++ b/src/id.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use rand::Rng;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{fmt::Debug, hash::Hash};
 
@@ -16,6 +17,9 @@ pub trait PublicId: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned + Deb
     type Signature: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned + Debug;
     /// Verifies `signature` against `data` using this `PublicId`.  Returns `true` if valid.
     fn verify_signature(&self, signature: &Self::Signature, data: &[u8]) -> bool;
+    /// Encrypts the message using the OS random number generator.
+    /// TODO: this is currently borrowed from threshold_crypto. We will have to sort this out
+    fn encrypt_with_rng<R: Rng, M: AsRef<[u8]>>(&self, rng: &mut R, msg: M) -> Vec<u8>;
 }
 
 /// The secret identity of a node.  It provides functionality to allow it to be used as an
@@ -37,6 +41,9 @@ pub trait SecretId {
             signature: self.sign_detached(data),
         }
     }
+
+    /// TODO: this is currently borrowed from threshold_crypto. We will have to sort this out
+    fn decrypt(&self, ct: &[u8]) -> Option<Vec<u8>>;
 }
 
 /// A basic helper to carry a given [`Signature`](trait.PublicId.html#associatedtype.Signature)

--- a/src/key_gen/LICENSE-APACHE
+++ b/src/key_gen/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/key_gen/LICENSE-MIT
+++ b/src/key_gen/LICENSE-MIT
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2018, POA Networks, Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/key_gen/mod.rs
+++ b/src/key_gen/mod.rs
@@ -1,0 +1,601 @@
+
+// https://raw.githubusercontent.com/poanetwork/hbbft/520083de2e32e5fac75aff506a0d46044bf6a49d/COPYRIGHT
+
+hbbft is copyright 2018, POA Networks, Ltd.
+
+Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+http://opensource.org/licenses/MIT>, at your option. All files in the project
+carrying such notice may not be copied, modified, or distributed except
+according to those terms.
+
+// https://raw.githubusercontent.com/poanetwork/hbbft/10dbf705e4ce9c43e5263f2e1c5227e02d2d20f7/src/sync_key_gen.rs
+
+//! A _synchronous_ algorithm for dealerless distributed key generation.
+//!
+//! This protocol is meant to run in a _completely synchronous_ setting where each node handles all
+//! messages in the same order. It can e.g. exchange messages as transactions on top of
+//! `HoneyBadger`, or it can run "on-chain", i.e. committing its messages to a blockchain.
+//!
+//! Its messages are encrypted where necessary, so they can be publicly broadcast.
+//!
+//! When the protocol completes, every node receives a secret key share suitable for threshold
+//! signatures and encryption. The secret master key is not known by anyone. The protocol succeeds
+//! if up to _t_ nodes are faulty, where _t_ is the `threshold` parameter. The number of nodes must
+//! be at least _2 t + 1_.
+//!
+//! ## Usage
+//!
+//! Before beginning the threshold key generation process, each validator needs to generate a
+//! regular (non-threshold) key pair and multicast its public key. `SyncKeyGen::new` returns the
+//! instance itself and a `Part` message, containing a contribution to the new threshold keys.
+//! It needs to be sent to all nodes. `SyncKeyGen::handle_part` in turn produces an `Ack`
+//! message, which is also multicast.
+//!
+//! All nodes must handle the exact same set of `Part` and `Ack` messages. In this sense the
+//! algorithm is synchronous: If Alice's `Ack` was handled by Bob but not by Carol, Bob and
+//! Carol could receive different public key sets, and secret key shares that don't match. One way
+//! to ensure this is to commit the messages to a public ledger before handling them, e.g. by
+//! feeding them to a preexisting instance of Honey Badger. The messages will then appear in the
+//! same order for everyone.
+//!
+//! To complete the process, call `SyncKeyGen::generate`. It produces your secret key share and the
+//! public key set.
+//!
+//! While not asynchronous, the algorithm is fault tolerant: It is not necessary to handle a
+//! `Part` and all `Ack` messages from every validator. A `Part` is _complete_ if it
+//! received at least _2 t + 1_ valid `Ack`s. Only complete `Part`s are used for key
+//! generation in the end, and as long as at least one complete `Part` is from a correct node,
+//! the new key set is secure. You can use `SyncKeyGen::is_ready` to check whether at least
+//! _t + 1_ `Part`s are complete. So all nodes can call `generate` as soon as `is_ready` returns
+//! `true`.
+//!
+//! Alternatively, you can use any stronger criterion, too, as long as all validators call
+//! `generate` at the same point, i.e. after handling the same set of messages.
+//! `SyncKeyGen::count_complete` returns the number of complete `Part` messages. And
+//! `SyncKeyGen::is_node_ready` can be used to check whether a particluar node's `Part` is
+//! complete.
+//!
+//! The `Part` and `Ack` messages alone contain all the information needed for anyone to compute
+//! the public key set, and for anyone owning one of the participating secret keys to compute
+//! their own secret key share. In particular:
+//! * Observer nodes can also use `SyncKeyGen`. For observers, no `Part` and `Ack`
+//! messages will be created and they do not need to send anything. On completion, they will only
+//! receive the public key set, but no secret key share.
+//! * If a participant crashed and lost its `SyncKeyGen` instance, but still has its original
+//! key pair, and if the key generation messages were committed to some public ledger, it can
+//! create a new `SyncKeyGen`, handle all the messages in order, and compute its secret key share.
+//!
+//! ## Example
+//!
+//! ```
+//! use std::collections::BTreeMap;
+//!
+//! use threshold_crypto::{PublicKey, SecretKey, SignatureShare};
+//! use hbbft::sync_key_gen::{AckOutcome, PartOutcome, SyncKeyGen};
+//!
+//! // Use the OS random number generator for any randomness:
+//! let mut rng = rand::OsRng::new().expect("Could not open OS random number generator.");
+//!
+//! // Two out of four shares will suffice to sign or encrypt something.
+//! let (threshold, node_num) = (1, 4);
+//!
+//! // Generate individual key pairs for encryption. These are not suitable for threshold schemes.
+//! let sec_keys: Vec<SecretKey> = (0..node_num).map(|_| rand::random()).collect();
+//! let pub_keys: BTreeMap<usize, PublicKey> = sec_keys
+//!     .iter()
+//!     .map(SecretKey::public_key)
+//!     .enumerate()
+//!     .collect();
+//!
+//! // Create the `SyncKeyGen` instances. The constructor also outputs the part that needs to
+//! // be sent to all other participants, so we save the parts together with their sender ID.
+//! let mut nodes = BTreeMap::new();
+//! let mut parts = Vec::new();
+//! for (id, sk) in sec_keys.into_iter().enumerate() {
+//!     let (sync_key_gen, opt_part) = SyncKeyGen::new(
+//!         id,
+//!         sk,
+//!         pub_keys.clone(),
+//!         threshold,
+//!         &mut rng,
+//! ).unwrap_or_else(|_| panic!("Failed to create `SyncKeyGen` instance for node #{}", id));
+//!     nodes.insert(id, sync_key_gen);
+//!     parts.push((id, opt_part.unwrap())); // Would be `None` for observer nodes.
+//! }
+//!
+//! // All nodes now handle the parts and send the resulting `Ack` messages.
+//! let mut acks = Vec::new();
+//! for (sender_id, part) in parts {
+//!     for (&id, node) in &mut nodes {
+//!         match node
+//!             .handle_part(&sender_id, part.clone(), &mut rng)
+//!             .expect("Failed to handle Part")
+//!         {
+//!             PartOutcome::Valid(Some(ack)) => acks.push((id, ack)),
+//!             PartOutcome::Invalid(fault) => panic!("Invalid Part: {:?}", fault),
+//!             PartOutcome::Valid(None) => {
+//!                 panic!("We are not an observer, so we should send Ack.")
+//!             }
+//!         }
+//!     }
+//! }
+//!
+//! // Finally, we handle all the `Ack`s.
+//! for (sender_id, ack) in acks {
+//!     for node in nodes.values_mut() {
+//!         match node.handle_ack(&sender_id, ack.clone()).expect("Failed to handle Ack") {
+//!             AckOutcome::Valid => (),
+//!             AckOutcome::Invalid(fault) => panic!("Invalid Ack: {:?}", fault),
+//!         }
+//!     }
+//! }
+//!
+//! // We have all the information and can generate the key sets.
+//! // Generate the public key set; which is identical for all nodes.
+//! let pub_key_set = nodes[&0].generate().expect("Failed to create `PublicKeySet` from node #0").0;
+//! let mut secret_key_shares = BTreeMap::new();
+//! for (&id, node) in &mut nodes {
+//!     assert!(node.is_ready());
+//!     let (pks, opt_sks) = node.generate().unwrap_or_else(|_|
+//!         panic!("Failed to create `PublicKeySet` and `SecretKeyShare` for node #{}", id)
+//!     );
+//!     assert_eq!(pks, pub_key_set); // All nodes now know the public keys and public key shares.
+//!     let sks = opt_sks.expect("Not an observer node: We receive a secret key share.");
+//!     secret_key_shares.insert(id, sks);
+//! }
+//!
+//! // Two out of four nodes can now sign a message. Each share can be verified individually.
+//! let msg = "Nodes 0 and 1 does not agree with this.";
+//! let mut sig_shares: BTreeMap<usize, SignatureShare> = BTreeMap::new();
+//! for (&id, sks) in &secret_key_shares {
+//!     if id != 0 && id != 1 {
+//!         let sig_share = sks.sign(msg);
+//!         let pks = pub_key_set.public_key_share(id);
+//!         assert!(pks.verify(&sig_share, msg));
+//!         sig_shares.insert(id, sig_share);
+//!     }
+//! }
+//!
+//! // Two signatures are over the threshold. They are enough to produce a signature that matches
+//! // the public master key.
+//! let sig = pub_key_set
+//!     .combine_signatures(&sig_shares)
+//!     .expect("The shares can be combined.");
+//! assert!(pub_key_set.public_key().verify(&sig, msg));
+//! ```
+//!
+//! ## How it works
+//!
+//! The algorithm is based on ideas from
+//! [Distributed Key Generation in the Wild](https://eprint.iacr.org/2012/377.pdf) and
+//! [A robust threshold elliptic curve digital signature providing a new verifiable secret sharing scheme](https://www.researchgate.net/profile/Ihab_Ali/publication/4205262_A_robust_threshold_elliptic_curve_digital_signature_providing_a_new_verifiable_secret_sharing_scheme/links/02e7e538f15726323a000000/A-robust-threshold-elliptic-curve-digital-signature-providing-a-new-verifiable-secret-sharing-scheme.pdf?origin=publication_detail).
+//!
+//! In a trusted dealer scenario, the following steps occur:
+//!
+//! 1. Dealer generates a `BivarPoly` of degree _t_ and publishes the `BivarCommitment` which is
+//!    used to publicly verify the polynomial's values.
+//! 2. Dealer sends _row_ _m > 0_ to node number _m_.
+//! 3. Node _m_, in turn, sends _value_ number _s_ to node number _s_.
+//! 4. This process continues until _2 t + 1_ nodes confirm they have received a valid row. If
+//!    there are at most _t_ faulty nodes, we know that at least _t + 1_ correct nodes sent on an
+//!    entry of every other node's column to that node.
+//! 5. This means every node can reconstruct its column, and the value at _0_ of its column.
+//! 6. These values all lie on a univariate polynomial of degree _t_ and can be used as secret keys.
+//!
+//! In our _dealerless_ environment, at least _t + 1_ nodes each generate a polynomial using the
+//! method above. The sum of the secret keys we received from each node is then used as our secret
+//! key. No single node knows the secret master key.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::{self, Debug, Formatter};
+
+use crate::crypto::{
+    error::Error as CryptoError,
+    poly::{BivarCommitment, BivarPoly, Poly},
+    serde_impl::FieldWrap,
+    Ciphertext, Fr, G1Affine, PublicKey, PublicKeySet, SecretKey, SecretKeyShare,
+};
+use crate::pairing::{CurveAffine, Field};
+use bincode;
+use failure::Fail;
+use rand;
+use serde::{Deserialize, Serialize};
+
+use crate::{NetworkInfo, NodeIdT};
+
+/// A local error while handling an `Ack` or `Part` message, that was not caused by that message
+/// being invalid.
+#[derive(Clone, Eq, PartialEq, Debug, Fail)]
+pub enum Error {
+    /// Error creating `SyncKeyGen`.
+    #[fail(display = "Error creating SyncKeyGen: {}", _0)]
+    Creation(CryptoError),
+    /// Error generating keys.
+    #[fail(display = "Error generating keys: {}", _0)]
+    Generation(CryptoError),
+    /// Unknown sender.
+    #[fail(display = "Unknown sender")]
+    UnknownSender,
+    /// Failed to serialize message.
+    #[fail(display = "Serialization error: {}", _0)]
+    Serialize(String),
+}
+
+impl From<bincode::Error> for Error {
+    fn from(err: bincode::Error) -> Error {
+        Error::Serialize(format!("{:?}", err))
+    }
+}
+
+/// A submission by a validator for the key generation. It must to be sent to all participating
+/// nodes and handled by all of them, including the one that produced it.
+///
+/// The message contains a commitment to a bivariate polynomial, and for each node, an encrypted
+/// row of values. If this message receives enough `Ack`s, it will be used as summand to produce
+/// the the key set in the end.
+#[derive(Deserialize, Serialize, Clone, Hash, Eq, PartialEq)]
+pub struct Part(BivarCommitment, Vec<Ciphertext>);
+
+impl Debug for Part {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Part")
+            .field(&format!("<degree {}>", self.0.degree()))
+            .field(&format!("<{} rows>", self.1.len()))
+            .finish()
+    }
+}
+
+/// A confirmation that we have received and verified a validator's part. It must be sent to
+/// all participating nodes and handled by all of them, including ourselves.
+///
+/// The message is only produced after we verified our row against the commitment in the `Part`.
+/// For each node, it contains one encrypted value of that row.
+#[derive(Deserialize, Serialize, Clone, Hash, Eq, PartialEq)]
+pub struct Ack(u64, Vec<Ciphertext>);
+
+impl Debug for Ack {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Ack")
+            .field(&self.0)
+            .field(&format!("<{} values>", self.1.len()))
+            .finish()
+    }
+}
+
+/// The information needed to track a single proposer's secret sharing process.
+#[derive(Debug, PartialEq, Eq)]
+struct ProposalState {
+    /// The proposer's commitment.
+    commit: BivarCommitment,
+    /// The verified values we received from `Ack` messages.
+    values: BTreeMap<u64, Fr>,
+    /// The nodes which have acked this part, valid or not.
+    acks: BTreeSet<u64>,
+}
+
+impl ProposalState {
+    /// Creates a new part state with a commitment.
+    fn new(commit: BivarCommitment) -> ProposalState {
+        ProposalState {
+            commit,
+            values: BTreeMap::new(),
+            acks: BTreeSet::new(),
+        }
+    }
+
+    /// Returns `true` if at least `2 * threshold + 1` nodes have acked.
+    fn is_complete(&self, threshold: usize) -> bool {
+        self.acks.len() > 2 * threshold
+    }
+}
+
+/// The outcome of handling and verifying a `Part` message.
+pub enum PartOutcome {
+    /// The message was valid: the part of it that was encrypted to us matched the public
+    /// commitment, so we can multicast an `Ack` message for it. If we are an observer or we have
+    /// already handled the same `Part` before, this contains `None` instead.
+    Valid(Option<Ack>),
+    /// The message was invalid: We now know that the proposer is faulty, and dont' send an `Ack`.
+    Invalid(PartFault),
+}
+
+/// The outcome of handling and verifying an `Ack` message.
+pub enum AckOutcome {
+    /// The message was valid.
+    Valid,
+    /// The message was invalid: The sender is faulty.
+    Invalid(AckFault),
+}
+
+/// A synchronous algorithm for dealerless distributed key generation.
+///
+/// It requires that all nodes handle all messages in the exact same order.
+#[derive(Debug)]
+pub struct SyncKeyGen<N> {
+    /// Our node ID.
+    our_id: N,
+    /// Our node index.
+    our_idx: Option<u64>,
+    /// Our secret key.
+    sec_key: SecretKey,
+    /// The public keys of all nodes, by node ID.
+    pub_keys: BTreeMap<N, PublicKey>,
+    /// Proposed bivariate polynomials.
+    parts: BTreeMap<u64, ProposalState>,
+    /// The degree of the generated polynomial.
+    threshold: usize,
+}
+
+impl<N: NodeIdT> SyncKeyGen<N> {
+    /// Creates a new `SyncKeyGen` instance, together with the `Part` message that should be
+    /// multicast to all nodes.
+    ///
+    /// If we are not a validator but only an observer, no `Part` message is produced and no
+    /// messages need to be sent.
+    pub fn new<R: rand::Rng>(
+        our_id: N,
+        sec_key: SecretKey,
+        pub_keys: BTreeMap<N, PublicKey>,
+        threshold: usize,
+        rng: &mut R,
+    ) -> Result<(SyncKeyGen<N>, Option<Part>), Error> {
+        let our_idx = pub_keys
+            .keys()
+            .position(|id| *id == our_id)
+            .map(|idx| idx as u64);
+        let key_gen = SyncKeyGen {
+            our_id,
+            our_idx,
+            sec_key,
+            pub_keys,
+            parts: BTreeMap::new(),
+            threshold,
+        };
+        if our_idx.is_none() {
+            return Ok((key_gen, None)); // No part: we are an observer.
+        }
+
+        let our_part = BivarPoly::random(threshold, rng);
+        let commit = our_part.commitment();
+        let encrypt = |(i, pk): (usize, &PublicKey)| {
+            let row = our_part.row(i + 1);
+            Ok(pk.encrypt_with_rng(rng, &bincode::serialize(&row)?))
+        };
+        let rows = key_gen
+            .pub_keys
+            .values()
+            .enumerate()
+            .map(encrypt)
+            .collect::<Result<Vec<_>, Error>>()?;
+        Ok((key_gen, Some(Part(commit, rows))))
+    }
+
+    /// Returns the map of participating nodes and their public keys.
+    pub fn public_keys(&self) -> &BTreeMap<N, PublicKey> {
+        &self.pub_keys
+    }
+
+    /// Handles a `Part` message. If it is valid, returns an `Ack` message to be broadcast.
+    ///
+    /// If we are only an observer, `None` is returned instead and no messages need to be sent.
+    ///
+    /// All participating nodes must handle the exact same sequence of messages.
+    /// Note that `handle_part` also needs to explicitly be called with this instance's own `Part`.
+    pub fn handle_part<R: rand::Rng>(
+        &mut self,
+        sender_id: &N,
+        part: Part,
+        rng: &mut R,
+    ) -> Result<PartOutcome, Error> {
+        let sender_idx = self.node_index(sender_id).ok_or(Error::UnknownSender)?;
+        let row = match self.handle_part_or_fault(sender_idx, part) {
+            Ok(Some(row)) => row,
+            Ok(None) => return Ok(PartOutcome::Valid(None)),
+            Err(fault) => return Ok(PartOutcome::Invalid(fault)),
+        };
+        // The row is valid. Encrypt one value for each node and broadcast an `Ack`.
+        let mut values = Vec::new();
+        for (idx, pk) in self.pub_keys.values().enumerate() {
+            let val = row.evaluate(idx + 1);
+            let ser_val = bincode::serialize(&FieldWrap(val))?;
+            values.push(pk.encrypt_with_rng(rng, ser_val));
+        }
+        Ok(PartOutcome::Valid(Some(Ack(sender_idx, values))))
+    }
+
+    /// Handles an `Ack` message.
+    ///
+    /// All participating nodes must handle the exact same sequence of messages.
+    /// Note that `handle_ack` also needs to explicitly be called with this instance's own `Ack`s.
+    pub fn handle_ack(&mut self, sender_id: &N, ack: Ack) -> Result<AckOutcome, Error> {
+        let sender_idx = self.node_index(sender_id).ok_or(Error::UnknownSender)?;
+        Ok(match self.handle_ack_or_fault(sender_idx, ack) {
+            Ok(()) => AckOutcome::Valid,
+            Err(fault) => AckOutcome::Invalid(fault),
+        })
+    }
+
+    /// Returns the index of the node, or `None` if it is unknown.
+    fn node_index(&self, node_id: &N) -> Option<u64> {
+        self.pub_keys
+            .keys()
+            .position(|id| id == node_id)
+            .map(|idx| idx as u64)
+    }
+
+    /// Returns the number of complete parts. If this is at least `threshold + 1`, the keys can
+    /// be generated, but it is possible to wait for more to increase security.
+    pub fn count_complete(&self) -> usize {
+        self.parts
+            .values()
+            .filter(|part| part.is_complete(self.threshold))
+            .count()
+    }
+
+    /// Returns `true` if the part of the given node is complete.
+    pub fn is_node_ready(&self, proposer_id: &N) -> bool {
+        self.node_index(proposer_id)
+            .and_then(|proposer_idx| self.parts.get(&proposer_idx))
+            .map_or(false, |part| part.is_complete(self.threshold))
+    }
+
+    /// Returns `true` if enough parts are complete to safely generate the new key.
+    pub fn is_ready(&self) -> bool {
+        self.count_complete() > self.threshold
+    }
+
+    /// Returns the new secret key share and the public key set.
+    ///
+    /// These are only secure if `is_ready` returned `true`. Otherwise it is not guaranteed that
+    /// none of the nodes knows the secret master key.
+    ///
+    /// If we are only an observer node, no secret key share is returned.
+    ///
+    /// All participating nodes must have handled the exact same sequence of `Part` and `Ack`
+    /// messages before calling this method. Otherwise their key shares will not match.
+    pub fn generate(&self) -> Result<(PublicKeySet, Option<SecretKeyShare>), Error> {
+        let mut pk_commit = Poly::zero().commitment();
+        let mut opt_sk_val = self.our_idx.map(|_| Fr::zero());
+        let is_complete = |part: &&ProposalState| part.is_complete(self.threshold);
+        for part in self.parts.values().filter(is_complete) {
+            pk_commit += part.commit.row(0);
+            if let Some(sk_val) = opt_sk_val.as_mut() {
+                let row = Poly::interpolate(part.values.iter().take(self.threshold + 1));
+                sk_val.add_assign(&row.evaluate(0));
+            }
+        }
+        let opt_sk = if let Some(mut fr) = opt_sk_val {
+            let sk = SecretKeyShare::from_mut(&mut fr);
+            Some(sk)
+        } else {
+            None
+        };
+        Ok((pk_commit.into(), opt_sk))
+    }
+
+    /// Consumes the instance, generates the key set and returns a new `NetworkInfo` with the new
+    /// keys.
+    ///
+    /// All participating nodes must have handled the exact same sequence of `Part` and `Ack`
+    /// messages before calling this method. Otherwise their key shares will not match.
+    pub fn into_network_info(self) -> Result<NetworkInfo<N>, Error> {
+        let (pk_set, sk_share) = self.generate()?;
+        let netinfo = NetworkInfo::new(self.our_id, sk_share, pk_set, self.sec_key, self.pub_keys);
+        Ok(netinfo)
+    }
+
+    /// Returns the number of nodes participating in the key generation.
+    pub fn num_nodes(&self) -> usize {
+        self.pub_keys.len()
+    }
+
+    /// Handles a `Part` message, or returns a `PartFault` if it is invalid.
+    fn handle_part_or_fault(
+        &mut self,
+        sender_idx: u64,
+        Part(commit, rows): Part,
+    ) -> Result<Option<Poly>, PartFault> {
+        if rows.len() != self.pub_keys.len() {
+            return Err(PartFault::RowCount);
+        }
+        if let Some(state) = self.parts.get(&sender_idx) {
+            if state.commit != commit {
+                return Err(PartFault::MultipleParts);
+            }
+            return Ok(None); // We already handled this `Part` before.
+        }
+        // Retrieve our own row's commitment, and store the full commitment.
+        let opt_idx_commit_row = self.our_idx.map(|idx| (idx, commit.row(idx + 1)));
+        self.parts.insert(sender_idx, ProposalState::new(commit));
+        let (our_idx, commit_row) = match opt_idx_commit_row {
+            Some((idx, row)) => (idx, row),
+            None => return Ok(None), // We are only an observer. Nothing to send or decrypt.
+        };
+        // We are a validator: Decrypt and deserialize our row and compare it to the commitment.
+        let ser_row = self
+            .sec_key
+            .decrypt(&rows[our_idx as usize])
+            .ok_or(PartFault::DecryptRow)?;
+        let row: Poly = bincode::deserialize(&ser_row).map_err(|_| PartFault::DeserializeRow)?;
+        if row.commitment() != commit_row {
+            return Err(PartFault::RowCommitment);
+        }
+        Ok(Some(row))
+    }
+
+    /// Handles an `Ack` message, or returns an `AckFault` if it is invalid.
+    fn handle_ack_or_fault(
+        &mut self,
+        sender_idx: u64,
+        Ack(proposer_idx, values): Ack,
+    ) -> Result<(), AckFault> {
+        if values.len() != self.pub_keys.len() {
+            return Err(AckFault::ValueCount);
+        }
+        let part = self
+            .parts
+            .get_mut(&proposer_idx)
+            .ok_or(AckFault::MissingPart)?;
+        if !part.acks.insert(sender_idx) {
+            return Ok(()); // We already handled this `Ack` before.
+        }
+        let our_idx = match self.our_idx {
+            Some(our_idx) => our_idx,
+            None => return Ok(()), // We are only an observer. Nothing to decrypt for us.
+        };
+        // We are a validator: Decrypt and deserialize our value and compare it to the commitment.
+        let ser_val = self
+            .sec_key
+            .decrypt(&values[our_idx as usize])
+            .ok_or(AckFault::DecryptValue)?;
+        let val = bincode::deserialize::<FieldWrap<Fr>>(&ser_val)
+            .map_err(|_| AckFault::DeserializeValue)?
+            .into_inner();
+        if part.commit.evaluate(our_idx + 1, sender_idx + 1) != G1Affine::one().mul(val) {
+            return Err(AckFault::ValueCommitment);
+        }
+        part.values.insert(sender_idx + 1, val);
+        Ok(())
+    }
+}
+
+/// An error in an `Ack` message sent by a faulty node.
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Fail)]
+pub enum AckFault {
+    /// The number of values differs from the number of nodes.
+    #[fail(display = "The number of values differs from the number of nodes")]
+    ValueCount,
+    /// No corresponding Part received.
+    #[fail(display = "No corresponding Part received")]
+    MissingPart,
+    /// Value decryption failed.
+    #[fail(display = "Value decryption failed")]
+    DecryptValue,
+    /// Value deserialization failed.
+    #[fail(display = "Value deserialization failed")]
+    DeserializeValue,
+    /// Value doesn't match the commitment.
+    #[fail(display = "Value doesn't match the commitment")]
+    ValueCommitment,
+}
+
+/// An error in a `Part` message sent by a faulty node.
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Fail)]
+pub enum PartFault {
+    /// The number of rows differs from the number of nodes.
+    #[fail(display = "The number of rows differs from the number of nodes")]
+    RowCount,
+    /// Received multiple different Part messages from the same sender.
+    #[fail(display = "Received multiple different Part messages from the same sender")]
+    MultipleParts,
+    /// Could not decrypt our row in the Part message.
+    #[fail(display = "Could not decrypt our row in the Part message")]
+    DecryptRow,
+    /// Could not deserialize our row in the Part message.
+    #[fail(display = "Could not deserialize our row in the Part message")]
+    DeserializeRow,
+    /// Row does not match the commitment.
+    #[fail(display = "Row does not match the commitment")]
+    RowCommitment,
+}

--- a/src/key_gen/rng_adapter.rs
+++ b/src/key_gen/rng_adapter.rs
@@ -1,0 +1,38 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use rand::Rng;
+use rand_core::RngCore;
+
+pub(super) struct RngAdapter<'a, T>(pub &'a mut T);
+
+impl<'a, T> RngCore for RngAdapter<'a, T>
+where
+    T: Rng,
+{
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, bytes: &mut [u8]) {
+        self.0.fill_bytes(bytes);
+    }
+
+    #[inline]
+    fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.0.fill_bytes(bytes);
+        Ok(())
+    }
+}

--- a/src/key_gen/tests.rs
+++ b/src/key_gen/tests.rs
@@ -39,7 +39,7 @@ fn test_key_gen_with(threshold: usize, node_num: usize) {
     let mut proposals = Vec::new();
     peer_ids.iter().for_each(|peer_id| {
         let (key_gen, proposal) = KeyGen::new(
-            peer_id.clone(),
+            peer_id,
             pub_keys.clone(),
             threshold,
             &mut rand::thread_rng(),

--- a/src/key_gen/tests.rs
+++ b/src/key_gen/tests.rs
@@ -26,8 +26,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use super::{KeyGen, Part, PartOutcome};
 use crate::id::{PublicId, SecretId};
 use crate::mock::PeerId;
+use crate::dev_utils::{Environment, RngChoice};
+
+// Alter the seed here to reproduce failures
+static SEED: RngChoice = RngChoice::SeededRandom;
 
 fn test_key_gen_with(threshold: usize, node_num: usize) {
+    let mut env = Environment::new(SEED);
+
     // Generate individual key pairs for encryption. These are not suitable for threshold schemes.
     let peer_ids: Vec<PeerId> = (0..node_num)
         .map(|idx| unwrap!(PeerId::from_index(idx)))
@@ -42,7 +48,7 @@ fn test_key_gen_with(threshold: usize, node_num: usize) {
             peer_id,
             pub_keys.clone(),
             threshold,
-            &mut rand::thread_rng(),
+            &mut env.rng,
         )
         .unwrap_or_else(|_err| panic!("Failed to create `KeyGen` instance {:?}", &peer_id));
         nodes.push(key_gen);
@@ -59,7 +65,7 @@ fn test_key_gen_with(threshold: usize, node_num: usize) {
                     &peer_ids[node_id],
                     &peer_ids[sender_id],
                     proposal,
-                    &mut rand::thread_rng(),
+                    &mut env.rng,
                 )
                 .expect("failed to handle part")
             {

--- a/src/key_gen/tests.rs
+++ b/src/key_gen/tests.rs
@@ -1,0 +1,115 @@
+// https://raw.githubusercontent.com/poanetwork/hbbft/520083de2e32e5fac75aff506a0d46044bf6a49d/COPYRIGHT
+
+hbbft is copyright 2018, POA Networks, Ltd.
+
+Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+http://opensource.org/licenses/MIT>, at your option. All files in the project
+carrying such notice may not be copied, modified, or distributed except
+according to those terms.
+
+// https://raw.githubusercontent.com/poanetwork/hbbft/eafa77d5fcbdaf549e09f101d618923d408b3468/tests/sync_key_gen.rs
+
+#![deny(unused_must_use)]
+//! Tests for synchronous distributed key generation.
+
+use std::collections::BTreeMap;
+
+use hbbft::crypto::{PublicKey, SecretKey};
+use hbbft::sync_key_gen::{PartOutcome, SyncKeyGen};
+use hbbft::util;
+
+fn test_sync_key_gen_with(threshold: usize, node_num: usize) {
+    // Generate individual key pairs for encryption. These are not suitable for threshold schemes.
+    let sec_keys: Vec<SecretKey> = (0..node_num).map(|_| SecretKey::random()).collect();
+    let pub_keys: BTreeMap<usize, PublicKey> = sec_keys
+        .iter()
+        .map(SecretKey::public_key)
+        .enumerate()
+        .collect();
+
+    // Create the `SyncKeyGen` instances and initial proposals.
+    let mut nodes = Vec::new();
+    let proposals: Vec<_> = sec_keys
+        .into_iter()
+        .enumerate()
+        .map(|(id, sk)| {
+            let (sync_key_gen, proposal) =
+                SyncKeyGen::new(id, sk, pub_keys.clone(), threshold, &mut rand::thread_rng())
+                    .unwrap_or_else(|_err| {
+                        panic!("Failed to create `SyncKeyGen` instance #{}", id)
+                    });
+            nodes.push(sync_key_gen);
+            proposal
+        })
+        .collect();
+
+    // Handle the first `threshold + 1` proposals. Those should suffice for key generation.
+    let mut acks = Vec::new();
+    for (sender_id, proposal) in proposals[..=threshold].iter().enumerate() {
+        for (node_id, node) in nodes.iter_mut().enumerate() {
+            let proposal = proposal.clone().expect("proposal");
+            let ack = match node
+                .handle_part(&sender_id, proposal, &mut rand::thread_rng())
+                .expect("failed to handle part")
+            {
+                PartOutcome::Valid(Some(ack)) => ack,
+                PartOutcome::Valid(None) => panic!("missing ack message"),
+                PartOutcome::Invalid(fault) => panic!("invalid proposal: {:?}", fault),
+            };
+            // Only the first `threshold + 1` manage to commit their `Ack`s.
+            if node_id <= 2 * threshold {
+                acks.push((node_id, ack));
+            }
+        }
+    }
+
+    // Handle the `Ack`s from `2 * threshold + 1` nodes.
+    for (sender_id, ack) in acks {
+        for node in &mut nodes {
+            assert!(!node.is_ready()); // Not enough `Ack`s yet.
+            node.handle_ack(&sender_id, ack.clone())
+                .expect("error handling ack");
+        }
+    }
+
+    // Compute the keys and test a threshold signature.
+    let msg = "Help I'm trapped in a unit test factory";
+    let pub_key_set = nodes[0]
+        .generate()
+        .expect("Failed to generate `PublicKeySet` for node #0")
+        .0;
+    let sig_shares: BTreeMap<_, _> = nodes
+        .iter()
+        .enumerate()
+        .map(|(idx, node)| {
+            assert!(node.is_ready());
+            let (pks, opt_sk) = node.generate().unwrap_or_else(|_| {
+                panic!(
+                    "Failed to generate `PublicKeySet` and `SecretKeyShare` for node #{}",
+                    idx
+                )
+            });
+            let sk = opt_sk.expect("new secret key");
+            assert_eq!(pks, pub_key_set);
+            let sig = sk.sign(msg);
+            assert!(pks.public_key_share(idx).verify(&sig, msg));
+            (idx, sig)
+        })
+        .collect();
+    let sig = pub_key_set
+        .combine_signatures(sig_shares.iter().take(threshold + 1))
+        .expect("signature shares match");
+    assert!(pub_key_set.public_key().verify(&sig, msg));
+}
+
+#[test]
+fn test_sync_key_gen() {
+    // This returns an error in all but the first test.
+    let _ = env_logger::try_init();
+
+    for &node_num in &[1, 2, 3, 4, 8, 15] {
+        let threshold = util::max_faulty(node_num);
+        test_sync_key_gen_with(threshold, node_num);
+    }
+}

--- a/src/key_gen/tests.rs
+++ b/src/key_gen/tests.rs
@@ -24,9 +24,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use super::{KeyGen, Part, PartOutcome};
+use crate::dev_utils::{Environment, RngChoice};
 use crate::id::{PublicId, SecretId};
 use crate::mock::PeerId;
-use crate::dev_utils::{Environment, RngChoice};
 
 // Alter the seed here to reproduce failures
 static SEED: RngChoice = RngChoice::SeededRandom;
@@ -44,13 +44,8 @@ fn test_key_gen_with(threshold: usize, node_num: usize) {
     let mut nodes = Vec::new();
     let mut proposals = Vec::new();
     peer_ids.iter().for_each(|peer_id| {
-        let (key_gen, proposal) = KeyGen::new(
-            peer_id,
-            pub_keys.clone(),
-            threshold,
-            &mut env.rng,
-        )
-        .unwrap_or_else(|_err| panic!("Failed to create `KeyGen` instance {:?}", &peer_id));
+        let (key_gen, proposal) = KeyGen::new(peer_id, pub_keys.clone(), threshold, &mut env.rng)
+            .unwrap_or_else(|_err| panic!("Failed to create `KeyGen` instance {:?}", &peer_id));
         nodes.push(key_gen);
         proposals.push(proposal);
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,8 @@ mod error;
 mod gossip;
 mod hash;
 mod id;
+#[allow(unused)]
+mod key_gen;
 mod meta_voting;
 mod network_event;
 mod observation;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -138,6 +138,9 @@ impl PublicId for PeerId {
     fn verify_signature(&self, signature: &Self::Signature, data: &[u8]) -> bool {
         self.pub_sign.verify_detached(&signature.0, data)
     }
+    fn encrypt_with_rng<R: Rng, M: AsRef<[u8]>>(&self, _rng: &mut R, msg: M) -> Vec<u8> {
+        msg.as_ref().to_vec()
+    }
 }
 
 impl SecretId for PeerId {
@@ -147,6 +150,9 @@ impl SecretId for PeerId {
     }
     fn sign_detached(&self, data: &[u8]) -> Signature {
         Signature(self.sec_sign.sign_detached(data))
+    }
+    fn decrypt(&self, ct: &[u8]) -> Option<Vec<u8>> {
+        Some(ct.to_vec())
     }
 }
 


### PR DESCRIPTION
Bring up the code that allow doing DKG:
- Copy files from github.com/poanetwork/hbbft for DKG
- Integrate/update to fix our own infrastructure and ensure test pass.
- Clean up API to work well with routing.

Notes:
- We could imagine splitting that into its own crate but that may create friction at this point.
- threshold_crypto as rand 6.5 in its API. To avoid tight coupling now and in the future make an adapter inspired by similar code in HBBFT that was used before they synced their dependencies.
