### PR TITLE
complete DKG as part of Parsec gossip graph.

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -12,6 +12,7 @@ use crate::{
     network_event::NetworkEvent,
     observation::Observation,
     vote::Vote,
+    DkgResult,
 };
 use std::{
     collections::{vec_deque, BTreeMap, BTreeSet, VecDeque},
@@ -27,6 +28,14 @@ pub struct Block<T: NetworkEvent, P: PublicId> {
 }
 
 impl<T: NetworkEvent, P: PublicId> Block<T, P> {
+    /// Create a `Block` with no signatures for a single DkgResult
+    pub fn new_dkg_block(result: DkgResult) -> Self {
+        Self {
+            payload: Observation::DkgResult(result),
+            proofs: BTreeSet::new(),
+        }
+    }
+
     /// Creates a `Block` from `votes`.
     pub fn new(votes: &BTreeMap<P, Vote<T, P>>) -> Result<Self, Error> {
         let payload = if let Some(vote) = votes.values().next() {

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -322,6 +322,10 @@ impl Peer {
             .retain(|obs| !parsec.have_voted_for(obs) && parsec.vote_for(obs.clone()).is_err());
     }
 
+    pub fn dkg_start_consensus(&mut self, rng: &mut Rng) {
+        let _ = self.parsec.handle_dkg_start_consensus(rng);
+    }
+
     pub fn gossip_recipients(&self) -> impl Iterator<Item = &PeerId> {
         self.parsec.gossip_recipients()
     }

--- a/src/dev_utils/schedule.rs
+++ b/src/dev_utils/schedule.rs
@@ -120,6 +120,8 @@ pub enum ScheduleEvent {
     /// It is similar to Fail in that the peer will stop responding; however, this will also
     /// cause the other peers to vote for removal
     RemovePeer(PeerId),
+    /// Start Dkg process: place-holder for Dkg participant to avoid clippy::large_enum_variant
+    StartDkg(BTreeSet<PeerId>),
 }
 
 impl ScheduleEvent {
@@ -139,6 +141,7 @@ impl ScheduleEvent {
             ScheduleEvent::AddPeer(ref peer) => peer,
             ScheduleEvent::RemovePeer(ref peer) => peer,
             ScheduleEvent::Genesis(_) => panic!("ScheduleEvent::get_peer called on Genesis!"),
+            ScheduleEvent::StartDkg(_) => panic!("ScheduleEvent::get_peer called on StartDkg!"),
         }
     }
 }
@@ -340,6 +343,7 @@ pub enum ObservationEvent {
     AddPeer(PeerId),
     RemovePeer(PeerId),
     Fail(PeerId),
+    StartDkg,
 }
 
 impl ObservationEvent {
@@ -687,6 +691,9 @@ impl Schedule {
                     ObservationEvent::Fail(peer) => {
                         peers.fail_peer(&peer);
                         schedule.push(ScheduleEvent::Fail(peer));
+                    }
+                    ObservationEvent::StartDkg => {
+                        schedule.push(ScheduleEvent::StartDkg(Default::default()));
                     }
                 }
             }

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -992,6 +992,8 @@ mod detail {
                     sanitise_peer_id(offender),
                     write_malice_to_string(malice, graph, peer_list, short_peer_ids),
                 ),
+                Observation::DkgResult(result) => format!("DkgResult({:?})", result),
+                Observation::DkgMessage(msg) => format!("DkgMessage({:?})", msg),
                 Observation::OpaquePayload(payload) => {
                     let max_length = 16;
                     let mut payload_str = sanitise_string(format!("{:?}", payload));

--- a/src/key_gen/dkg_result.rs
+++ b/src/key_gen/dkg_result.rs
@@ -1,0 +1,84 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    cmp::Ordering,
+    fmt::{self, Debug, Formatter},
+};
+use threshold_crypto::{PublicKeySet, SecretKeyShare};
+
+#[derive(Clone)]
+/// DKG result
+pub struct DkgResult {
+    /// Public key set to verify threshold signatures
+    pub public_key_set: PublicKeySet,
+    /// Secret Key share: None if the node was not participating in the DKG and did not receive
+    /// encrypted shares.
+    pub secret_key_share: Option<SecretKeyShare>,
+}
+
+impl DkgResult {
+    /// Create DkgResult from components
+    pub fn new(public_key_set: PublicKeySet, secret_key_share: Option<SecretKeyShare>) -> Self {
+        Self {
+            public_key_set,
+            secret_key_share,
+        }
+    }
+
+    fn comparison_value(&self) -> (&PublicKeySet, bool) {
+        (&self.public_key_set, self.secret_key_share.is_some())
+    }
+}
+
+impl Debug for DkgResult {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "DkgResult({:?}, {})",
+            self.public_key_set,
+            self.secret_key_share.is_some()
+        )
+    }
+}
+
+impl PartialEq for DkgResult {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.comparison_value().eq(&rhs.comparison_value())
+    }
+}
+
+impl Eq for DkgResult {}
+
+impl PartialOrd for DkgResult {
+    fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
+        self.comparison_value().partial_cmp(&rhs.comparison_value())
+    }
+}
+
+impl Ord for DkgResult {
+    fn cmp(&self, rhs: &Self) -> Ordering {
+        self.comparison_value().cmp(&rhs.comparison_value())
+    }
+}
+
+impl Serialize for DkgResult {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.public_key_set.serialize(s)
+    }
+}
+
+impl<'a> Deserialize<'a> for DkgResult {
+    fn deserialize<D: Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error> {
+        PublicKeySet::deserialize(deserializer).map(|public_key_set| Self {
+            public_key_set,
+            secret_key_share: None,
+        })
+    }
+}

--- a/src/key_gen/message.rs
+++ b/src/key_gen/message.rs
@@ -1,0 +1,28 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{Ack, Part};
+use crate::parsec::KeyGenId;
+use std::fmt;
+
+/// Messages used for running BLS DKG.
+#[serde(bound = "")]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum DkgMessage {
+    Part { key_gen_id: KeyGenId, part: Part },
+    Ack { key_gen_id: KeyGenId, ack: Ack },
+}
+
+impl fmt::Debug for DkgMessage {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            DkgMessage::Part { key_gen_id, .. } => write!(formatter, "DkgPart({})", key_gen_id),
+            DkgMessage::Ack { key_gen_id, .. } => write!(formatter, "DkgAck({})", key_gen_id),
+        }
+    }
+}

--- a/src/key_gen/mod.rs
+++ b/src/key_gen/mod.rs
@@ -96,6 +96,7 @@
 //! key. No single node knows the secret master key.
 
 pub mod dkg_result;
+pub mod message;
 mod rng_adapter;
 
 #[cfg(test)]

--- a/src/key_gen/mod.rs
+++ b/src/key_gen/mod.rs
@@ -95,12 +95,13 @@
 //! method above. The sum of the secret keys we received from each node is then used as our secret
 //! key. No single node knows the secret master key.
 
+pub mod dkg_result;
 mod rng_adapter;
 
 #[cfg(test)]
 mod tests;
 
-use crate::{PublicId, SecretId};
+use crate::{DkgResult, SecretId};
 use failure::Fail;
 use maidsafe_utilities::serialisation;
 use rand;
@@ -109,22 +110,15 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug, Formatter};
 use threshold_crypto::pairing::{CurveAffine, Field};
 use threshold_crypto::{
-    error::Error as CryptoError,
     poly::{BivarCommitment, BivarPoly, Poly},
     serde_impl::FieldWrap,
-    Fr, G1Affine, PublicKeySet, SecretKeyShare,
+    Fr, G1Affine, SecretKeyShare,
 };
 
 /// A local error while handling an `Ack` or `Part` message, that was not caused by that message
 /// being invalid.
 #[derive(Clone, Eq, PartialEq, Debug, Fail)]
 pub enum Error {
-    /// Error creating `KeyGen`.
-    #[fail(display = "Error creating KeyGen: {}", _0)]
-    Creation(CryptoError),
-    /// Error generating keys.
-    #[fail(display = "Error generating keys: {}", _0)]
-    Generation(CryptoError),
     /// Unknown sender.
     #[fail(display = "Unknown sender")]
     UnknownSender,
@@ -245,11 +239,11 @@ impl<S: SecretId> KeyGen<S> {
     ///
     /// If we are not a validator but only an observer, no `Part` message is produced and no
     /// messages need to be sent.
-    pub fn new<R: rand::Rng>(
+    pub fn new(
         sec_key: &S,
         pub_keys: BTreeSet<S::PublicId>,
         threshold: usize,
-        rng: &mut R,
+        rng: &mut rand::Rng,
     ) -> Result<(KeyGen<S>, Option<Part>), Error> {
         let our_id = sec_key.public_id().clone();
         let our_idx = pub_keys
@@ -267,7 +261,8 @@ impl<S: SecretId> KeyGen<S> {
             return Ok((key_gen, None)); // No part: we are an observer.
         }
 
-        let our_part = BivarPoly::random(threshold, &mut rng_adapter::RngAdapter(rng));
+        let mut rng = rng_adapter::RngAdapter(&mut *rng);
+        let our_part = BivarPoly::random(threshold, &mut rng);
         let commit = our_part.commitment();
         let encrypt = |(i, pk): (usize, &S::PublicId)| {
             let row = our_part.row(i + 1);
@@ -296,12 +291,11 @@ impl<S: SecretId> KeyGen<S> {
     ///
     /// All participating nodes must handle the exact same sequence of messages.
     /// Note that `handle_part` also needs to explicitly be called with this instance's own `Part`.
-    pub fn handle_part<R: rand::Rng>(
+    pub fn handle_part(
         &mut self,
         sec_key: &S,
         sender_id: &S::PublicId,
         part: Part,
-        rng: &mut R,
     ) -> Result<PartOutcome, Error> {
         let sender_idx = self.node_index(sender_id).ok_or(Error::UnknownSender)?;
         let row = match self.handle_part_or_fault(sec_key, sender_idx, sender_id, part) {
@@ -369,7 +363,7 @@ impl<S: SecretId> KeyGen<S> {
     ///
     /// All participating nodes must have handled the exact same sequence of `Part` and `Ack`
     /// messages before calling this method. Otherwise their key shares will not match.
-    pub fn generate(&self) -> Result<(PublicKeySet, Option<SecretKeyShare>), Error> {
+    pub fn generate(&self) -> Result<DkgResult, Error> {
         let mut pk_commit = Poly::zero().commitment();
         let mut opt_sk_val = self.our_idx.map(|_| Fr::zero());
         let is_complete = |part: &&ProposalState| part.is_complete(self.threshold);
@@ -386,7 +380,7 @@ impl<S: SecretId> KeyGen<S> {
         } else {
             None
         };
-        Ok((pk_commit.into(), opt_sk))
+        Ok(DkgResult::new(pk_commit.into(), opt_sk))
     }
 
     /// Handles a `Part` message, or returns a `PartFault` if it is invalid.

--- a/src/key_gen/rng_adapter.rs
+++ b/src/key_gen/rng_adapter.rs
@@ -9,11 +9,11 @@
 use rand::Rng;
 use rand_core::RngCore;
 
-pub(super) struct RngAdapter<'a, T>(pub &'a mut T);
+pub(super) struct RngAdapter<'a, T: ?Sized>(pub &'a mut T);
 
 impl<'a, T> RngCore for RngAdapter<'a, T>
 where
-    T: Rng,
+    T: Rng + ?Sized,
 {
     #[inline]
     fn next_u32(&mut self) -> u32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,6 @@ mod error;
 mod gossip;
 mod hash;
 mod id;
-#[allow(unused)]
 mod key_gen;
 mod meta_voting;
 mod network_event;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,7 @@ pub use crate::{
     error::{Error, Result},
     gossip::{EventHash, PackedEvent, Request, Response},
     id::{Proof, PublicId, SecretId},
+    key_gen::dkg_result::*,
     network_event::NetworkEvent,
     observation::{ConsensusMode, Malice, Observation},
     parsec::Parsec,

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -10,9 +10,10 @@ use crate::{
     gossip::{EventHash, PackedEvent},
     hash::Hash,
     id::{PublicId, SecretId},
+    key_gen::message::DkgMessage,
     network_event::NetworkEvent,
     peer_list::{Peer, PeerIndex, PeerList},
-    serialise,
+    serialise, DkgResult,
 };
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -49,6 +50,7 @@ pub enum Observation<T: NetworkEvent, P: PublicId> {
         /// Extra arbitrary information for use by the client
         related_info: Vec<u8>,
     },
+    /// Output only: Do not vote for it.
     /// Vote to accuse a peer of malicious behaviour.
     Accusation {
         /// Public id of the peer committing the malice.
@@ -58,6 +60,16 @@ pub enum Observation<T: NetworkEvent, P: PublicId> {
     },
     /// Vote for an event which is opaque to Parsec.
     OpaquePayload(T),
+    /// Output only: Do not vote for it.
+    /// Will have empty proof set.
+    /// public_key_set will be shared state.
+    /// secret_key_share will be unique to each peers: all participating peers will
+    /// have one assuming less than 1/3 malicious.
+    DkgResult(DkgResult),
+    /// Internal only: Do not vote for it or expect it to come in blocks.
+    /// Vote for the next message (Part or Ack) to be handled for the Distributed Key Generation
+    /// algorithm used by our common coin.
+    DkgMessage(DkgMessage),
 }
 
 impl<T: NetworkEvent, P: PublicId> Observation<T, P> {
@@ -67,6 +79,22 @@ impl<T: NetworkEvent, P: PublicId> Observation<T, P> {
             true
         } else {
             false
+        }
+    }
+
+    /// Is this observation an internal `DkgMessage`
+    pub fn is_dkg_message(&self) -> bool {
+        match *self {
+            Observation::DkgMessage(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Is this observation a result only `DkgResult`
+    pub fn is_dkg_result(&self) -> bool {
+        match *self {
+            Observation::DkgResult(_) => true,
+            _ => false,
         }
     }
 }
@@ -80,6 +108,8 @@ impl<T: NetworkEvent, P: PublicId> Debug for Observation<T, P> {
             Observation::Accusation { offender, malice } => {
                 write!(formatter, "Accusation {{ {:?}, {:?} }}", offender, malice)
             }
+            Observation::DkgResult(result) => write!(formatter, "{:?}", result),
+            Observation::DkgMessage(msg) => write!(formatter, "{:?}", msg),
             Observation::OpaquePayload(payload) => {
                 write!(formatter, "OpaquePayload({:?})", payload)
             }
@@ -345,6 +375,8 @@ impl ConsensusMode {
     pub(crate) fn of<T: NetworkEvent, P: PublicId>(self, observation: &Observation<T, P>) -> Self {
         if observation.is_opaque() {
             self
+        } else if observation.is_dkg_message() {
+            ConsensusMode::Single
         } else {
             ConsensusMode::Supermajority
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -255,6 +255,28 @@ fn add_few_peers_and_vote() {
 }
 
 #[test]
+fn run_dkg() {
+    use parsec::dev_utils::ObservationEvent;
+
+    let mut names = NAMES.iter();
+    let mut env = Environment::new(SEED);
+
+    let obs_schedule = ObservationSchedule {
+        genesis: Genesis::new(names.by_ref().take(4).cloned().map(PeerId::new).collect()),
+        schedule: vec![(50, ObservationEvent::StartDkg)],
+    };
+
+    let options = ScheduleOptions::default();
+    let schedule = Schedule::from_observation_schedule(&mut env, &options, obs_schedule);
+
+    unwrap!(env.network.execute_schedule(&mut env.rng, schedule));
+
+    let peer = unwrap!(env.network.active_non_malicious_peers().next());
+    let block = unwrap!(peer.blocks().last());
+    assert!(block.payload().is_dkg_result());
+}
+
+#[test]
 fn add_many_peers_and_vote() {
     let mut env = Environment::new(SEED);
     let options = ScheduleOptions {


### PR DESCRIPTION
Execute DKG adding DkgMessages to the gossip graph:
 - All the DkgMessages are internal and do not come out as blocks when
   consensused. They still need consensus as order is critical.
 - A function `handle_dkg_start_consensus` start the DKG process.
   This is a place holder as we need all node to start the dkg at the
   same block, so it will need to be triggered by a consensus event.
 - A new `Block` is created when a Dkg complete. It is a strange block
   as it does not have any proofs, and while all participant will get
   that block, the DkgResult will not be shared:
   => The PublicKeySet will be shared by all
   => The SecretKeyShare will be unique to each participants, and
      observers will have None for it.
 - Using a block like this does provide benefit for the initial bring up:
   => It does fit with the infrastructure and test.
   => Consumer will likely want to use the result inlined with the
      other blocks, as it need to be used at the same point in the
      collection of blocks by all nodes.

Still missing items:
- Confirm how we want to handle DKG as per RFC.
- Start DKG from a consensus event.
- Support gossip and DKG by specified, not yet full members, peers.
- Play nicely with some existing form of Malice handling
  => This mean handling when a malice detection stop us from creating
     a sync event. This may be tricky as Dkg start is not based on an
     event like accusation, but on a consensused block.
- Possibly add malice detection and handling for DKG.

Test:
New test run DKG and verify we get a DkgResult block.
clippy & test pass