### PR TITLE
initiate DKG using a consensused event

### DIFF
--- a/src/dev_utils/environment.rs
+++ b/src/dev_utils/environment.rs
@@ -6,43 +6,22 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{dev_utils::network::Network, observation::ConsensusMode};
-use maidsafe_utilities::SeededRng;
-use rand::{Rng, SeedableRng, XorShiftRng};
+use crate::{
+    dev_utils::network::Network, dev_utils::new_common_rng, dev_utils::RngChoice,
+    dev_utils::RngDebug, observation::ConsensusMode,
+};
 use std::fmt;
-
-pub trait RngDebug: Rng + fmt::Debug {}
-
-impl RngDebug for SeededRng {}
-impl RngDebug for XorShiftRng {}
 
 pub struct Environment {
     pub network: Network,
     pub rng: Box<RngDebug>,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub enum RngChoice {
-    SeededRandom,
-    #[allow(unused)]
-    Seeded([u32; 4]),
-    SeededXor([u32; 4]),
-}
-
 impl Environment {
     /// Initialise the test environment. The random number generator will be seeded with `seed`
     /// or randomly if this is `SeededRandom`.
     pub fn with_consensus_mode(seed: RngChoice, consensus_mode: ConsensusMode) -> Self {
-        let rng: Box<RngDebug> = match seed {
-            RngChoice::SeededRandom => Box::new(SeededRng::new()),
-            RngChoice::Seeded(seed) => Box::new(SeededRng::from_seed(seed)),
-            RngChoice::SeededXor(seed) => {
-                let rng = Box::new(XorShiftRng::from_seed(seed));
-                println!("Using {:?}", rng);
-                rng
-            }
-        };
-
+        let rng = new_common_rng(seed);
         let network = Network::new(consensus_mode);
 
         Self { network, rng }

--- a/src/dev_utils/mod.rs
+++ b/src/dev_utils/mod.rs
@@ -19,6 +19,7 @@ mod peer;
 mod peer_statuses;
 #[cfg(feature = "testing")]
 pub mod proptest;
+mod pseudo_random;
 #[cfg(any(all(test, feature = "mock"), feature = "testing"))]
 mod record;
 mod schedule;
@@ -30,11 +31,12 @@ pub(crate) use self::dot_parser::ParsedContents;
 #[cfg(any(all(test, feature = "mock"), feature = "testing"))]
 pub use self::record::Record;
 pub use self::{
-    environment::{Environment, RngChoice},
+    environment::Environment,
     misc::TestIterator,
     network::{ConsensusError, Network},
     peer::{NetworkView, Peer, PeerStatus},
     peer_statuses::PeerStatuses,
+    pseudo_random::{new_common_rng, new_rng, RngChoice, RngDebug},
     schedule::*,
 };
 

--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -642,7 +642,8 @@ impl Network {
             ScheduleEvent::StartDkg(peers) => {
                 // All valid peers should vote for new DKG.
                 for peer_id in self.running_peers_ids() {
-                    self.peer_mut(&peer_id).vote_for_new_dkg(peers.clone(), rng)
+                    self.peer_mut(&peer_id)
+                        .vote_for(&ParsecObservation::StartDkg(peers.clone()));
                 }
             }
         }

--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -639,10 +639,10 @@ impl Network {
 
                 self.peer_mut(&voting_peer_id).vote_for(&observation);
             }
-            ScheduleEvent::StartDkg(_) => {
-                // For test purpose: simulate starting DKG on all nodes at the same time.
+            ScheduleEvent::StartDkg(peers) => {
+                // All valid peers should vote for new DKG.
                 for peer_id in self.running_peers_ids() {
-                    self.peer_mut(&peer_id).dkg_start_consensus(rng)
+                    self.peer_mut(&peer_id).vote_for_new_dkg(peers.clone(), rng)
                 }
             }
         }

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -322,8 +322,8 @@ impl Peer {
             .retain(|obs| !parsec.have_voted_for(obs) && parsec.vote_for(obs.clone()).is_err());
     }
 
-    pub fn dkg_start_consensus(&mut self, rng: &mut Rng) {
-        let _ = self.parsec.handle_dkg_start_consensus(rng);
+    pub fn vote_for_new_dkg(&mut self, peers: BTreeSet<PeerId>, rng: &mut Rng) {
+        let _ = self.parsec.vote_for_new_dkg(peers, rng);
     }
 
     pub fn gossip_recipients(&self) -> impl Iterator<Item = &PeerId> {

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -244,12 +244,14 @@ impl Peer {
         id: PeerId,
         genesis_group: &BTreeSet<PeerId>,
         consensus_mode: ConsensusMode,
+        secure_rng: Box<dyn Rng>,
     ) -> Self {
         Self::new(WrappedParsec::Good(Parsec::from_genesis(
             id,
             genesis_group,
             vec![],
             consensus_mode,
+            secure_rng,
         )))
     }
 
@@ -257,9 +259,10 @@ impl Peer {
         id: PeerId,
         genesis_group: &BTreeSet<PeerId>,
         consensus_mode: ConsensusMode,
+        secure_rng: Box<dyn Rng>,
     ) -> Self {
         Self::new(WrappedParsec::Malicious(MaliciousComponents {
-            test_parsec: TestParsec::from_genesis(id, genesis_group, consensus_mode),
+            test_parsec: TestParsec::from_genesis(id, genesis_group, consensus_mode, secure_rng),
             forked_event: None,
         }))
     }
@@ -269,12 +272,14 @@ impl Peer {
         genesis_group: &BTreeSet<PeerId>,
         current_group: &BTreeSet<PeerId>,
         consensus_mode: ConsensusMode,
+        secure_rng: Box<dyn Rng>,
     ) -> Self {
         Self::new(WrappedParsec::Good(Parsec::from_existing(
             id,
             genesis_group,
             current_group,
             consensus_mode,
+            secure_rng,
         )))
     }
 
@@ -283,6 +288,7 @@ impl Peer {
         genesis_group: &BTreeSet<PeerId>,
         current_group: &BTreeSet<PeerId>,
         consensus_mode: ConsensusMode,
+        secure_rng: Box<dyn Rng>,
     ) -> Self {
         Self::new(WrappedParsec::Malicious(MaliciousComponents {
             test_parsec: TestParsec::from_existing(
@@ -290,6 +296,7 @@ impl Peer {
                 genesis_group,
                 current_group,
                 consensus_mode,
+                secure_rng,
             ),
             forked_event: None,
         }))

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -322,10 +322,6 @@ impl Peer {
             .retain(|obs| !parsec.have_voted_for(obs) && parsec.vote_for(obs.clone()).is_err());
     }
 
-    pub fn vote_for_new_dkg(&mut self, peers: BTreeSet<PeerId>, rng: &mut Rng) {
-        let _ = self.parsec.vote_for_new_dkg(peers, rng);
-    }
-
     pub fn gossip_recipients(&self) -> impl Iterator<Item = &PeerId> {
         self.parsec.gossip_recipients()
     }

--- a/src/dev_utils/proptest/schedule.rs
+++ b/src/dev_utils/proptest/schedule.rs
@@ -8,8 +8,8 @@
 
 use super::{Bounded, BoundedBoxedStrategy};
 use crate::dev_utils::{
-    environment::{Environment, RngChoice},
     schedule::{DelayDistribution, Schedule, ScheduleOptions},
+    Environment, RngChoice,
 };
 use proptest_crate::{
     prelude::{Just, RngCore},

--- a/src/dev_utils/pseudo_random.rs
+++ b/src/dev_utils/pseudo_random.rs
@@ -1,0 +1,48 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use maidsafe_utilities::SeededRng;
+use rand::{Rng, SeedableRng, XorShiftRng};
+use std::fmt;
+
+pub trait RngDebug: Rng + fmt::Debug {}
+
+impl RngDebug for SeededRng {}
+impl RngDebug for XorShiftRng {}
+
+#[derive(Clone, Copy, Debug)]
+pub enum RngChoice {
+    SeededRandom,
+    #[allow(unused)]
+    Seeded([u32; 4]),
+    SeededXor([u32; 4]),
+}
+
+/// Create a new Rng: Use once per test.
+pub fn new_common_rng(seed: RngChoice) -> Box<dyn RngDebug> {
+    match seed {
+        RngChoice::SeededRandom => Box::new(SeededRng::new()),
+        RngChoice::Seeded(seed) => Box::new(SeededRng::from_seed(seed)),
+        RngChoice::SeededXor(seed) => {
+            let rng = Box::new(XorShiftRng::from_seed(seed));
+            println!("Using {:?}", rng);
+            rng
+        }
+    }
+}
+
+/// Create a new RNG using a seed generated from random data provided by `rng`.
+pub fn new_rng<R: Rng>(rng: &mut R) -> Box<dyn Rng> {
+    let new_seed = [
+        rng.next_u32().wrapping_add(rng.next_u32()),
+        rng.next_u32().wrapping_add(rng.next_u32()),
+        rng.next_u32().wrapping_add(rng.next_u32()),
+        rng.next_u32().wrapping_add(rng.next_u32()),
+    ];
+    Box::new(XorShiftRng::from_seed(new_seed))
+}

--- a/src/dev_utils/schedule.rs
+++ b/src/dev_utils/schedule.rs
@@ -120,7 +120,7 @@ pub enum ScheduleEvent {
     /// It is similar to Fail in that the peer will stop responding; however, this will also
     /// cause the other peers to vote for removal
     RemovePeer(PeerId),
-    /// Start Dkg process: place-holder for Dkg participant to avoid clippy::large_enum_variant
+    /// Start Dkg process with set of DKG participants
     StartDkg(BTreeSet<PeerId>),
 }
 
@@ -343,7 +343,8 @@ pub enum ObservationEvent {
     AddPeer(PeerId),
     RemovePeer(PeerId),
     Fail(PeerId),
-    StartDkg,
+    /// Start Dkg process with set of DKG participants
+    StartDkg(BTreeSet<PeerId>),
 }
 
 impl ObservationEvent {
@@ -692,8 +693,8 @@ impl Schedule {
                         peers.fail_peer(&peer);
                         schedule.push(ScheduleEvent::Fail(peer));
                     }
-                    ObservationEvent::StartDkg => {
-                        schedule.push(ScheduleEvent::StartDkg(Default::default()));
+                    ObservationEvent::StartDkg(peers) => {
+                        schedule.push(ScheduleEvent::StartDkg(peers));
                     }
                 }
             }

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -992,6 +992,7 @@ mod detail {
                     sanitise_peer_id(offender),
                     write_malice_to_string(malice, graph, peer_list, short_peer_ids),
                 ),
+                Observation::StartDkg(peers) => format!("StartDkg({:?})", peers),
                 Observation::DkgResult(result) => format!("DkgResult({:?})", result),
                 Observation::DkgMessage(msg) => format!("DkgMessage({:?})", msg),
                 Observation::OpaquePayload(payload) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,8 @@ pub enum Error {
     InvalidMessage,
     /// The request or response has already been handled by us.
     DuplicateMessage,
+    /// Faild DKG process
+    FailedDkg,
     /// Logic error.
     Logic,
 }
@@ -98,6 +100,7 @@ impl Display for Error {
             ),
             Error::InvalidMessage => write!(f, "This non-empty message is invalid."),
             Error::DuplicateMessage => write!(f, "This message has already been handled."),
+            Error::FailedDkg => write!(f, "The requested DKG could not proceed."),
             Error::Logic => write!(
                 f,
                 "This is a logic error and represents a flaw in the code."

--- a/src/key_gen/mod.rs
+++ b/src/key_gen/mod.rs
@@ -496,3 +496,8 @@ pub enum PartFault {
     #[fail(display = "Row does not match the commitment")]
     RowCommitment,
 }
+
+/// Threshold to use for running DKG
+pub fn dkg_threshold(participants_count: usize) -> usize {
+    participants_count.saturating_sub(1) / 3
+}

--- a/src/key_gen/tests.rs
+++ b/src/key_gen/tests.rs
@@ -23,7 +23,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use super::{KeyGen, PartOutcome};
+use super::{dkg_threshold, KeyGen, PartOutcome};
 use crate::dev_utils::{Environment, RngChoice};
 use crate::mock::PeerId;
 
@@ -111,8 +111,7 @@ fn test_key_gen_with(threshold: usize, node_num: usize) {
 }
 
 fn test_key_gen(node_num: usize) {
-    let threshold = (node_num - 1) / 3;
-    test_key_gen_with(threshold, node_num);
+    test_key_gen_with(dkg_threshold(node_num), node_num);
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ extern crate maidsafe_utilities;
 extern crate proptest as proptest_crate;
 #[macro_use]
 extern crate serde_derive;
-#[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
+//#[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
 #[macro_use]
 extern crate unwrap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ extern crate maidsafe_utilities;
 extern crate proptest as proptest_crate;
 #[macro_use]
 extern crate serde_derive;
-//#[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
+#[cfg(any(test, feature = "testing", feature = "dump-graphs"))]
 #[macro_use]
 extern crate unwrap;
 

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -60,6 +60,9 @@ pub enum Observation<T: NetworkEvent, P: PublicId> {
     },
     /// Vote for an event which is opaque to Parsec.
     OpaquePayload(T),
+    /// Internal only: No blocks with it.
+    /// Only use vote_for_new_dkg to vote for that event: Will start the DKG on consensus.
+    StartDkg(BTreeSet<P>),
     /// Output only: Do not vote for it.
     /// Will have empty proof set.
     /// public_key_set will be shared state.
@@ -90,6 +93,14 @@ impl<T: NetworkEvent, P: PublicId> Observation<T, P> {
         }
     }
 
+    /// Is this observation an internal and should not be published in a `Block`
+    pub fn is_internal(&self) -> bool {
+        match *self {
+            Observation::DkgMessage(_) | Observation::StartDkg(_) => true,
+            _ => false,
+        }
+    }
+
     /// Is this observation a result only `DkgResult`
     pub fn is_dkg_result(&self) -> bool {
         match *self {
@@ -108,6 +119,7 @@ impl<T: NetworkEvent, P: PublicId> Debug for Observation<T, P> {
             Observation::Accusation { offender, malice } => {
                 write!(formatter, "Accusation {{ {:?}, {:?} }}", offender, malice)
             }
+            Observation::StartDkg(result) => write!(formatter, "StartDkg({:?})", result),
             Observation::DkgResult(result) => write!(formatter, "{:?}", result),
             Observation::DkgMessage(msg) => write!(formatter, "{:?}", msg),
             Observation::OpaquePayload(payload) => {

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -61,7 +61,7 @@ pub enum Observation<T: NetworkEvent, P: PublicId> {
     /// Vote for an event which is opaque to Parsec.
     OpaquePayload(T),
     /// Internal only: No blocks with it.
-    /// Only use vote_for_new_dkg to vote for that event: Will start the DKG on consensus.
+    /// Can be voted as an input.
     StartDkg(BTreeSet<P>),
     /// Output only: Do not vote for it.
     /// Will have empty proof set.

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -93,8 +93,6 @@ pub(crate) type KeyGenId = usize;
 pub struct Parsec<T: NetworkEvent, S: SecretId> {
     // The PeerInfo of other nodes.
     peer_list: PeerList<S>,
-    // Set of KeyGen::new results pending use once their associated StartDkg reach consensus.
-    pending_key_gen: Vec<(KeyGen<S>, Option<Part>)>,
     // Set of active distributed key generation, with a KeyGenId used by `DkgMessage`.
     key_gen: BTreeMap<KeyGenId, KeyGen<S>>,
     // Next KeyGenId
@@ -119,6 +117,8 @@ pub struct Parsec<T: NetworkEvent, S: SecretId> {
     // parsec instances.
     #[cfg(any(test, feature = "testing"))]
     ignore_process_events: bool,
+    // Provided RNG: Needs to be cryptographically secure RNG as it is used for DKG key generation.
+    secure_rng: Box<dyn rand::Rng>,
 }
 
 impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
@@ -242,7 +242,6 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
 
         Self {
             peer_list,
-            pending_key_gen: Vec::new(),
             key_gen: BTreeMap::new(),
             key_gen_next_id: KeyGenId::default(),
             graph: Graph::new(),
@@ -257,6 +256,8 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
 
             #[cfg(any(test, feature = "testing"))]
             ignore_process_events: false,
+
+            secure_rng: Box::new(unwrap!(rand::OsRng::new())), // TODO: take Rng as parameter
         }
     }
 
@@ -954,23 +955,19 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
     }
 
     // This function must be called on consensus on a `StartDkg` observation.
-    // This allow the call-site to meet two preconditions:
-    // * All DKG participants will call it in the same order, and
-    // * Incidentally, it will guarantee that `pending_key_gen` contains an
-    //   entry for this set of peers.
-    //
-    // This is a problem, it require vote that may not have arrived yet before reaching
-    // that consensus or the Keygen would not be there.
-    //  => It seem we cannot avoid having the ability to call KeyGen::new from within
-    //     this function.
     fn handle_dkg_start_consensus(&mut self, peers: &BTreeSet<S::PublicId>) -> Option<()> {
-        let (key_gen, part) = {
-            let key_gen_idx = self
-                .pending_key_gen
-                .iter()
-                .position(|(gen, _)| gen.public_keys() == peers)?;
-            self.pending_key_gen.remove(key_gen_idx)
-        };
+        let threshold = dkg_threshold(peers.len());
+
+        let (key_gen, part) = KeyGen::new(
+            self.peer_list.our_id(),
+            peers.clone(),
+            threshold,
+            &mut self.secure_rng,
+        )
+        .map_err(|error| {
+            error!("Vote for new DKG Error: {}", error);
+        })
+        .ok()?;
 
         let key_gen_id = self.key_gen_next_id;
         self.key_gen_next_id += 1;
@@ -981,25 +978,6 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         }
         let _ = self.key_gen.insert(key_gen_id, key_gen);
         Some(())
-    }
-
-    /// Vote to start a DKG with the given peers participating.
-    pub fn vote_for_new_dkg(
-        &mut self,
-        peers: BTreeSet<S::PublicId>,
-        rng: &mut rand::Rng,
-    ) -> Result<()> {
-        let threshold = dkg_threshold(peers.len());
-        match KeyGen::new(self.peer_list.our_id(), peers.clone(), threshold, rng) {
-            Ok(result) => {
-                self.pending_key_gen.push(result);
-                self.vote_for(Observation::StartDkg(peers))
-            }
-            Err(error) => {
-                error!("Vote for new DKG Error: {}", error);
-                Err(Error::FailedDkg)
-            }
-        }
     }
 
     fn handle_add_peer(&mut self, peer_id: &S::PublicId) -> PeerListChange {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -70,7 +70,7 @@ use parsec::{
 };
 use proptest::{prelude::ProptestConfig, test_runner::FileFailurePersistence};
 use rand::Rng;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 // Alter the seed here to reproduce failures
 static SEED: RngChoice = RngChoice::SeededRandom;
@@ -260,10 +260,11 @@ fn run_dkg() {
 
     let mut names = NAMES.iter();
     let mut env = Environment::new(SEED);
+    let peer_ids: BTreeSet<_> = names.by_ref().take(4).cloned().map(PeerId::new).collect();
 
     let obs_schedule = ObservationSchedule {
-        genesis: Genesis::new(names.by_ref().take(4).cloned().map(PeerId::new).collect()),
-        schedule: vec![(50, ObservationEvent::StartDkg)],
+        genesis: Genesis::new(peer_ids.clone()),
+        schedule: vec![(50, ObservationEvent::StartDkg(peer_ids))],
     };
 
     let options = ScheduleOptions::default();


### PR DESCRIPTION
This change create a public way to start a DKG and get a result and update associated test.
This change does not address replaying dump-graph that include DKG.

Note:
-Initial commit started with an approach that avoided storing Rng in Parsec but was flawed.
 We have to trigger the DKG on event consensus whether we voted for it yet or not.
-The rang::Rng in the interface make consumer of Parsec depend on a specific version of rand.
 This can be addressed if we decide it would be a better approach when handling dump-graph and replay, possibly using std::io::Read as a stable interface.

Closes #323 