### PR TITLE
DKG with non voters participating in gossip

### DIFF
--- a/dot_gen/src/main.rs
+++ b/dot_gen/src/main.rs
@@ -350,10 +350,11 @@ fn add_dev_utils_record_smoke_tests(scenarios: &mut Scenarios) {
 
     let _ = scenarios
         .add("dev_utils::record::tests::smoke_dkg", |env| {
-            let peer_ids = peer_ids!("Alice", "Bob", "Carol", "Dave", "Eric");
+            let peer_ids = peer_ids!("Alice", "Bob", "Carol");
+            let dkg_peer_ids = peer_ids!("Alice", "Bob", "Carol", "Dave", "Eric");
             let obs = ObservationSchedule {
                 genesis: Genesis::new(peer_ids.clone()),
-                schedule: vec![(1, StartDkg(peer_ids))],
+                schedule: vec![(1, StartDkg(dkg_peer_ids))],
             };
             Schedule::from_observation_schedule(env, &ScheduleOptions::default(), obs)
         })

--- a/input_graphs/dev_utils_record_tests_smoke_dkg/alice.dot
+++ b/input_graphs/dev_utils_record_tests_smoke_dkg/alice.dot
@@ -1,13 +1,13 @@
 /// our_id: Alice
 /// peer_list: {
-///   Alice: PeerState(VOTE|SEND|RECV)
-///   Bob: PeerState(VOTE|SEND|RECV)
-///   Carol: PeerState(VOTE|SEND|RECV)
-///   Dave: PeerState(VOTE|SEND|RECV)
-///   Eric: PeerState(VOTE|SEND|RECV)
+///   Alice: PeerState(VOTE|SEND|RECV|DKG)
+///   Bob: PeerState(VOTE|SEND|RECV|DKG)
+///   Carol: PeerState(VOTE|SEND|RECV|DKG)
+///   Dave: PeerState(SEND|RECV|DKG)
+///   Eric: PeerState(SEND|RECV|DKG)
 /// }
 /// consensus_mode: Supermajority
-/// secure_rng: [50356992, 33579588, 63550234, 14409741, 12819317, 30460779, 1339029800, 2429264724, 2362415627, 197366634, 1005923715, 4142528682, 101071806, 290037975, 2202144328, 987208226, 222006541, 1361632101, 3263934278, 1141586879, 2508817878, 2188220401, 486795621, 13172665]
+/// secure_rng: [3603127959, 2501323383, 1378120399, 2258206147, 1247984737, 1711956936, 399103948, 1525925779, 86898968, 806145622, 1763837996, 2905183684, 3349568576, 2442019996, 3902037481, 166883978, 4232276904, 520780312, 1429935877, 3485948170, 675181937, 1688735956, 3920011387, 475839308]
 digraph GossipGraph {
   splines=false
   rankdir=BT
@@ -19,39 +19,39 @@ digraph GossipGraph {
     "Alice" -> "A_0" [style=invis]
     "A_0" -> "A_1" [minlen=1]
     "A_1" -> "A_2" [minlen=1]
-    "A_2" -> "A_3" [minlen=5]
+    "A_2" -> "A_3" [minlen=1]
     "A_3" -> "A_4" [minlen=1]
     "A_4" -> "A_5" [minlen=1]
     "A_5" -> "A_6" [minlen=1]
-    "A_6" -> "A_7" [minlen=5]
+    "A_6" -> "A_7" [minlen=2]
     "A_7" -> "A_8" [minlen=1]
     "A_8" -> "A_9" [minlen=1]
-    "A_9" -> "A_10" [minlen=1]
+    "A_9" -> "A_10" [minlen=2]
     "A_10" -> "A_11" [minlen=1]
-    "A_11" -> "A_12" [minlen=2]
+    "A_11" -> "A_12" [minlen=1]
     "A_12" -> "A_13" [minlen=1]
-    "A_13" -> "A_14" [minlen=2]
+    "A_13" -> "A_14" [minlen=1]
     "A_14" -> "A_15" [minlen=1]
-    "A_15" -> "A_16" [minlen=2]
-    "A_16" -> "A_17" [minlen=1]
+    "A_15" -> "A_16" [minlen=1]
+    "A_16" -> "A_17" [minlen=4]
     "A_17" -> "A_18" [minlen=1]
-    "A_18" -> "A_19" [minlen=1]
+    "A_18" -> "A_19" [minlen=3]
     "A_19" -> "A_20" [minlen=1]
     "A_20" -> "A_21" [minlen=1]
-    "A_21" -> "A_22" [minlen=4]
+    "A_21" -> "A_22" [minlen=3]
     "A_22" -> "A_23" [minlen=1]
     "A_23" -> "A_24" [minlen=1]
-    "A_24" -> "A_25" [minlen=1]
+    "A_24" -> "A_25" [minlen=2]
     "A_25" -> "A_26" [minlen=1]
-    "A_26" -> "A_27" [minlen=3]
+    "A_26" -> "A_27" [minlen=2]
     "A_27" -> "A_28" [minlen=1]
     "A_28" -> "A_29" [minlen=1]
-    "A_29" -> "A_30" [minlen=1]
+    "A_29" -> "A_30" [minlen=2]
     "A_30" -> "A_31" [minlen=1]
     "A_31" -> "A_32" [minlen=1]
-    "A_32" -> "A_33" [minlen=4]
-    "A_33" -> "A_34" [minlen=6]
-    "A_34" -> "A_35" [minlen=7]
+    "A_32" -> "A_33" [minlen=1]
+    "A_33" -> "A_34" [minlen=1]
+    "A_34" -> "A_35" [minlen=1]
     "A_35" -> "A_36" [minlen=1]
     "A_36" -> "A_37" [minlen=1]
     "A_37" -> "A_38" [minlen=1]
@@ -62,104 +62,70 @@ digraph GossipGraph {
     "A_42" -> "A_43" [minlen=1]
     "A_43" -> "A_44" [minlen=1]
     "A_44" -> "A_45" [minlen=1]
-    "A_45" -> "A_46" [minlen=2]
+    "A_45" -> "A_46" [minlen=1]
     "A_46" -> "A_47" [minlen=1]
     "A_47" -> "A_48" [minlen=1]
     "A_48" -> "A_49" [minlen=1]
     "A_49" -> "A_50" [minlen=1]
-    "A_50" -> "A_51" [minlen=1]
-    "A_51" -> "A_52" [minlen=1]
+    "A_50" -> "A_51" [minlen=2]
+    "A_51" -> "A_52" [minlen=6]
     "A_52" -> "A_53" [minlen=1]
-    "A_53" -> "A_54" [minlen=2]
-    "A_54" -> "A_55" [minlen=6]
+    "A_53" -> "A_54" [minlen=1]
+    "A_54" -> "A_55" [minlen=2]
     "A_55" -> "A_56" [minlen=1]
     "A_56" -> "A_57" [minlen=1]
-    "A_57" -> "A_58" [minlen=2]
+    "A_57" -> "A_58" [minlen=1]
     "A_58" -> "A_59" [minlen=1]
-    "A_59" -> "A_60" [minlen=1]
+    "A_59" -> "A_60" [minlen=4]
     "A_60" -> "A_61" [minlen=1]
-    "A_61" -> "A_62" [minlen=4]
-    "A_62" -> "A_63" [minlen=1]
-    "A_63" -> "A_64" [minlen=1]
-    "A_64" -> "A_65" [minlen=4]
-    "A_65" -> "A_66" [minlen=6]
+    "A_61" -> "A_62" [minlen=1]
+    "A_62" -> "A_63" [minlen=4]
+    "A_63" -> "A_64" [minlen=6]
+    "A_64" -> "A_65" [minlen=1]
+    "A_65" -> "A_66" [minlen=1]
     "A_66" -> "A_67" [minlen=1]
     "A_67" -> "A_68" [minlen=1]
-    "A_68" -> "A_69" [minlen=1]
-    "A_69" -> "A_70" [minlen=1]
-    "A_70" -> "A_71" [minlen=2]
-    "A_71" -> "A_72" [minlen=3]
-    "A_72" -> "A_73" [minlen=6]
-    "A_73" -> "A_74" [minlen=7]
-    "A_74" -> "A_75" [minlen=1]
-    "A_75" -> "A_76" [minlen=1]
-    "A_76" -> "A_77" [minlen=1]
-    "A_77" -> "A_78" [minlen=1]
-    "A_78" -> "A_79" [minlen=4]
-    "A_79" -> "A_80" [minlen=3]
-    "A_80" -> "A_81" [minlen=1]
-    "A_81" -> "A_82" [minlen=1]
-    "A_82" -> "A_83" [minlen=10]
-    "A_83" -> "A_84" [minlen=1]
-    "A_84" -> "A_85" [minlen=1]
-    "A_85" -> "A_86" [minlen=2]
   }
-  "B_5" -> "A_3" [constraint=false]
-  "B_6" -> "A_4" [constraint=false]
-  "E_3" -> "A_6" [constraint=false]
-  "D_6" -> "A_7" [constraint=false]
-  "B_11" -> "A_8" [constraint=false]
-  "E_5" -> "A_11" [constraint=false]
-  "C_11" -> "A_12" [constraint=false]
-  "D_9" -> "A_14" [constraint=false]
-  "D_10" -> "A_15" [constraint=false]
-  "D_12" -> "A_16" [constraint=false]
-  "C_13" -> "A_18" [constraint=false]
-  "C_14" -> "A_19" [constraint=false]
-  "E_8" -> "A_20" [constraint=false]
-  "C_20" -> "A_22" [constraint=false]
-  "B_20" -> "A_23" [constraint=false]
-  "B_23" -> "A_25" [constraint=false]
-  "D_18" -> "A_26" [constraint=false]
-  "B_26" -> "A_27" [constraint=false]
-  "D_19" -> "A_28" [constraint=false]
-  "E_13" -> "A_29" [constraint=false]
-  "C_26" -> "A_31" [constraint=false]
-  "D_22" -> "A_32" [constraint=false]
-  "B_32" -> "A_33" [constraint=false]
-  "B_36" -> "A_34" [constraint=false]
-  "B_41" -> "A_35" [constraint=false]
-  "C_39" -> "A_36" [constraint=false]
-  "E_25" -> "A_44" [constraint=false]
-  "E_33" -> "A_46" [constraint=false]
-  "E_35" -> "A_49" [constraint=false]
-  "B_52" -> "A_50" [constraint=false]
-  "E_36" -> "A_51" [constraint=false]
-  "C_50" -> "A_52" [constraint=false]
-  "C_53" -> "A_54" [constraint=false]
-  "B_58" -> "A_55" [constraint=false]
-  "C_57" -> "A_56" [constraint=false]
-  "C_61" -> "A_58" [constraint=false]
-  "C_62" -> "A_60" [constraint=false]
-  "C_63" -> "A_61" [constraint=false]
-  "C_67" -> "A_62" [constraint=false]
-  "D_45" -> "A_63" [constraint=false]
-  "D_48" -> "A_65" [constraint=false]
-  "D_52" -> "A_66" [constraint=false]
-  "D_53" -> "A_67" [constraint=false]
-  "E_60" -> "A_68" [constraint=false]
-  "E_64" -> "A_71" [constraint=false]
-  "C_73" -> "A_72" [constraint=false]
-  "D_67" -> "A_73" [constraint=false]
-  "D_71" -> "A_74" [constraint=false]
-  "C_84" -> "A_75" [constraint=false]
-  "B_80" -> "A_76" [constraint=false]
-  "B_81" -> "A_77" [constraint=false]
-  "C_87" -> "A_79" [constraint=false]
-  "D_75" -> "A_80" [constraint=false]
-  "B_98" -> "A_83" [constraint=false]
-  "D_80" -> "A_84" [constraint=false]
-  "B_101" -> "A_86" [constraint=false]
+  "B_2" -> "A_3" [constraint=false]
+  "C_2" -> "A_5" [constraint=false]
+  "B_4" -> "A_7" [constraint=false]
+  "B_5" -> "A_8" [constraint=false]
+  "C_5" -> "A_10" [constraint=false]
+  "B_10" -> "A_12" [constraint=false]
+  "B_11" -> "A_13" [constraint=false]
+  "C_9" -> "A_15" [constraint=false]
+  "C_10" -> "A_16" [constraint=false]
+  "C_14" -> "A_17" [constraint=false]
+  "C_18" -> "A_19" [constraint=false]
+  "B_18" -> "A_20" [constraint=false]
+  "B_19" -> "A_21" [constraint=false]
+  "B_21" -> "A_22" [constraint=false]
+  "C_20" -> "A_23" [constraint=false]
+  "C_22" -> "A_25" [constraint=false]
+  "C_25" -> "A_27" [constraint=false]
+  "D_2" -> "A_28" [constraint=false]
+  "B_24" -> "A_30" [constraint=false]
+  "B_25" -> "A_32" [constraint=false]
+  "C_28" -> "A_33" [constraint=false]
+  "C_29" -> "A_34" [constraint=false]
+  "E_4" -> "A_37" [constraint=false]
+  "E_6" -> "A_39" [constraint=false]
+  "E_8" -> "A_42" [constraint=false]
+  "B_31" -> "A_43" [constraint=false]
+  "E_9" -> "A_44" [constraint=false]
+  "C_36" -> "A_45" [constraint=false]
+  "C_43" -> "A_51" [constraint=false]
+  "B_41" -> "A_52" [constraint=false]
+  "C_47" -> "A_53" [constraint=false]
+  "C_51" -> "A_55" [constraint=false]
+  "C_52" -> "A_57" [constraint=false]
+  "C_53" -> "A_58" [constraint=false]
+  "C_58" -> "A_60" [constraint=false]
+  "D_14" -> "A_61" [constraint=false]
+  "D_18" -> "A_63" [constraint=false]
+  "D_22" -> "A_64" [constraint=false]
+  "D_23" -> "A_65" [constraint=false]
+  "E_38" -> "A_66" [constraint=false]
 
   style=invis
   subgraph cluster_Bob {
@@ -168,8 +134,8 @@ digraph GossipGraph {
     "Bob" -> "B_0" [style=invis]
     "B_0" -> "B_1" [minlen=1]
     "B_1" -> "B_2" [minlen=1]
-    "B_2" -> "B_3" [minlen=1]
-    "B_3" -> "B_4" [minlen=2]
+    "B_2" -> "B_3" [minlen=2]
+    "B_3" -> "B_4" [minlen=3]
     "B_4" -> "B_5" [minlen=1]
     "B_5" -> "B_6" [minlen=1]
     "B_6" -> "B_7" [minlen=1]
@@ -177,155 +143,79 @@ digraph GossipGraph {
     "B_8" -> "B_9" [minlen=1]
     "B_9" -> "B_10" [minlen=1]
     "B_10" -> "B_11" [minlen=1]
-    "B_11" -> "B_12" [minlen=5]
+    "B_11" -> "B_12" [minlen=1]
     "B_12" -> "B_13" [minlen=1]
     "B_13" -> "B_14" [minlen=1]
-    "B_14" -> "B_15" [minlen=1]
-    "B_15" -> "B_16" [minlen=9]
-    "B_16" -> "B_17" [minlen=1]
-    "B_17" -> "B_18" [minlen=2]
+    "B_14" -> "B_15" [minlen=4]
+    "B_15" -> "B_16" [minlen=1]
+    "B_16" -> "B_17" [minlen=3]
+    "B_17" -> "B_18" [minlen=1]
     "B_18" -> "B_19" [minlen=1]
-    "B_19" -> "B_20" [minlen=1]
+    "B_19" -> "B_20" [minlen=2]
     "B_20" -> "B_21" [minlen=1]
-    "B_21" -> "B_22" [minlen=1]
+    "B_21" -> "B_22" [minlen=2]
     "B_22" -> "B_23" [minlen=1]
-    "B_23" -> "B_24" [minlen=3]
+    "B_23" -> "B_24" [minlen=8]
     "B_24" -> "B_25" [minlen=1]
-    "B_25" -> "B_26" [minlen=1]
+    "B_25" -> "B_26" [minlen=3]
     "B_26" -> "B_27" [minlen=1]
     "B_27" -> "B_28" [minlen=1]
     "B_28" -> "B_29" [minlen=1]
-    "B_29" -> "B_30" [minlen=1]
-    "B_30" -> "B_31" [minlen=4]
+    "B_29" -> "B_30" [minlen=3]
+    "B_30" -> "B_31" [minlen=3]
     "B_31" -> "B_32" [minlen=1]
     "B_32" -> "B_33" [minlen=2]
-    "B_33" -> "B_34" [minlen=2]
+    "B_33" -> "B_34" [minlen=1]
     "B_34" -> "B_35" [minlen=1]
     "B_35" -> "B_36" [minlen=1]
     "B_36" -> "B_37" [minlen=1]
     "B_37" -> "B_38" [minlen=1]
-    "B_38" -> "B_39" [minlen=1]
+    "B_38" -> "B_39" [minlen=3]
     "B_39" -> "B_40" [minlen=3]
     "B_40" -> "B_41" [minlen=1]
     "B_41" -> "B_42" [minlen=2]
     "B_42" -> "B_43" [minlen=1]
-    "B_43" -> "B_44" [minlen=1]
+    "B_43" -> "B_44" [minlen=6]
     "B_44" -> "B_45" [minlen=1]
     "B_45" -> "B_46" [minlen=1]
     "B_46" -> "B_47" [minlen=1]
-    "B_47" -> "B_48" [minlen=1]
+    "B_47" -> "B_48" [minlen=2]
     "B_48" -> "B_49" [minlen=1]
-    "B_49" -> "B_50" [minlen=1]
+    "B_49" -> "B_50" [minlen=2]
     "B_50" -> "B_51" [minlen=1]
-    "B_51" -> "B_52" [minlen=5]
-    "B_52" -> "B_53" [minlen=1]
-    "B_53" -> "B_54" [minlen=2]
-    "B_54" -> "B_55" [minlen=1]
-    "B_55" -> "B_56" [minlen=3]
-    "B_56" -> "B_57" [minlen=3]
-    "B_57" -> "B_58" [minlen=1]
-    "B_58" -> "B_59" [minlen=2]
-    "B_59" -> "B_60" [minlen=1]
-    "B_60" -> "B_61" [minlen=6]
-    "B_61" -> "B_62" [minlen=1]
-    "B_62" -> "B_63" [minlen=1]
-    "B_63" -> "B_64" [minlen=2]
-    "B_64" -> "B_65" [minlen=1]
-    "B_65" -> "B_66" [minlen=2]
-    "B_66" -> "B_67" [minlen=1]
-    "B_67" -> "B_68" [minlen=2]
-    "B_68" -> "B_69" [minlen=2]
-    "B_69" -> "B_70" [minlen=1]
-    "B_70" -> "B_71" [minlen=11]
-    "B_71" -> "B_72" [minlen=3]
-    "B_72" -> "B_73" [minlen=1]
-    "B_73" -> "B_74" [minlen=1]
-    "B_74" -> "B_75" [minlen=1]
-    "B_75" -> "B_76" [minlen=1]
-    "B_76" -> "B_77" [minlen=2]
-    "B_77" -> "B_78" [minlen=1]
-    "B_78" -> "B_79" [minlen=1]
-    "B_79" -> "B_80" [minlen=1]
-    "B_80" -> "B_81" [minlen=1]
-    "B_81" -> "B_82" [minlen=1]
-    "B_82" -> "B_83" [minlen=2]
-    "B_83" -> "B_84" [minlen=1]
-    "B_84" -> "B_85" [minlen=1]
-    "B_85" -> "B_86" [minlen=2]
-    "B_86" -> "B_87" [minlen=1]
-    "B_87" -> "B_88" [minlen=1]
-    "B_88" -> "B_89" [minlen=1]
-    "B_89" -> "B_90" [minlen=1]
-    "B_90" -> "B_91" [minlen=1]
-    "B_91" -> "B_92" [minlen=2]
-    "B_92" -> "B_93" [minlen=1]
-    "B_93" -> "B_94" [minlen=1]
-    "B_94" -> "B_95" [minlen=1]
-    "B_95" -> "B_96" [minlen=3]
-    "B_96" -> "B_97" [minlen=1]
-    "B_97" -> "B_98" [minlen=1]
-    "B_98" -> "B_99" [minlen=1]
-    "B_99" -> "B_100" [minlen=1]
-    "B_100" -> "B_101" [minlen=2]
+    "B_51" -> "B_52" [minlen=2]
+    "B_52" -> "B_53" [minlen=2]
   }
-  "C_3" -> "B_4" [constraint=false]
-  "A_3" -> "B_7" [constraint=false]
+  "A_3" -> "B_3" [constraint=false]
+  "A_6" -> "B_4" [constraint=false]
+  "A_4" -> "B_5" [constraint=false]
+  "C_3" -> "B_7" [constraint=false]
   "C_4" -> "B_8" [constraint=false]
-  "A_4" -> "B_9" [constraint=false]
-  "D_3" -> "B_10" [constraint=false]
-  "A_8" -> "B_12" [constraint=false]
-  "C_9" -> "B_14" [constraint=false]
-  "C_10" -> "B_15" [constraint=false]
-  "D_14" -> "B_16" [constraint=false]
-  "C_16" -> "B_18" [constraint=false]
+  "A_12" -> "B_12" [constraint=false]
+  "C_8" -> "B_13" [constraint=false]
+  "A_13" -> "B_14" [constraint=false]
+  "C_13" -> "B_15" [constraint=false]
+  "C_17" -> "B_17" [constraint=false]
+  "A_18" -> "B_18" [constraint=false]
   "A_21" -> "B_20" [constraint=false]
-  "C_19" -> "B_21" [constraint=false]
-  "E_10" -> "B_22" [constraint=false]
-  "C_24" -> "B_24" [constraint=false]
-  "A_25" -> "B_25" [constraint=false]
-  "A_27" -> "B_28" [constraint=false]
-  "D_20" -> "B_29" [constraint=false]
-  "C_29" -> "B_31" [constraint=false]
-  "A_33" -> "B_33" [constraint=false]
-  "C_32" -> "B_34" [constraint=false]
-  "E_20" -> "B_37" [constraint=false]
-  "A_34" -> "B_38" [constraint=false]
-  "E_21" -> "B_39" [constraint=false]
-  "C_36" -> "B_40" [constraint=false]
-  "A_35" -> "B_42" [constraint=false]
-  "D_33" -> "B_45" [constraint=false]
-  "C_43" -> "B_46" [constraint=false]
-  "A_48" -> "B_52" [constraint=false]
-  "D_39" -> "B_54" [constraint=false]
-  "E_39" -> "B_55" [constraint=false]
-  "C_54" -> "B_56" [constraint=false]
-  "C_56" -> "B_57" [constraint=false]
-  "A_55" -> "B_59" [constraint=false]
-  "E_43" -> "B_60" [constraint=false]
-  "C_64" -> "B_61" [constraint=false]
-  "E_49" -> "B_62" [constraint=false]
-  "E_52" -> "B_64" [constraint=false]
-  "E_53" -> "B_66" [constraint=false]
-  "E_55" -> "B_68" [constraint=false]
-  "E_57" -> "B_69" [constraint=false]
-  "D_61" -> "B_71" [constraint=false]
-  "C_75" -> "B_72" [constraint=false]
-  "C_77" -> "B_75" [constraint=false]
-  "C_78" -> "B_76" [constraint=false]
-  "C_80" -> "B_77" [constraint=false]
-  "E_71" -> "B_79" [constraint=false]
-  "E_72" -> "B_82" [constraint=false]
-  "A_76" -> "B_83" [constraint=false]
-  "A_77" -> "B_84" [constraint=false]
-  "C_86" -> "B_86" [constraint=false]
-  "E_74" -> "B_89" [constraint=false]
-  "E_75" -> "B_90" [constraint=false]
-  "E_77" -> "B_92" [constraint=false]
-  "D_79" -> "B_96" [constraint=false]
-  "D_76" -> "B_97" [constraint=false]
-  "A_81" -> "B_98" [constraint=false]
-  "D_78" -> "B_99" [constraint=false]
-  "A_85" -> "B_101" [constraint=false]
+  "A_22" -> "B_22" [constraint=false]
+  "A_29" -> "B_24" [constraint=false]
+  "A_32" -> "B_26" [constraint=false]
+  "D_3" -> "B_29" [constraint=false]
+  "C_34" -> "B_30" [constraint=false]
+  "A_41" -> "B_31" [constraint=false]
+  "D_4" -> "B_33" [constraint=false]
+  "E_12" -> "B_34" [constraint=false]
+  "C_44" -> "B_39" [constraint=false]
+  "C_46" -> "B_40" [constraint=false]
+  "A_52" -> "B_42" [constraint=false]
+  "E_16" -> "B_43" [constraint=false]
+  "C_54" -> "B_44" [constraint=false]
+  "E_26" -> "B_46" [constraint=false]
+  "E_30" -> "B_48" [constraint=false]
+  "E_31" -> "B_50" [constraint=false]
+  "E_33" -> "B_52" [constraint=false]
+  "E_35" -> "B_53" [constraint=false]
 
   style=invis
   subgraph cluster_Carol {
@@ -333,147 +223,99 @@ digraph GossipGraph {
     "Carol" [style=invis]
     "Carol" -> "C_0" [style=invis]
     "C_0" -> "C_1" [minlen=1]
-    "C_1" -> "C_2" [minlen=1]
-    "C_2" -> "C_3" [minlen=2]
-    "C_3" -> "C_4" [minlen=1]
-    "C_4" -> "C_5" [minlen=5]
+    "C_1" -> "C_2" [minlen=2]
+    "C_2" -> "C_3" [minlen=1]
+    "C_3" -> "C_4" [minlen=6]
+    "C_4" -> "C_5" [minlen=1]
     "C_5" -> "C_6" [minlen=1]
-    "C_6" -> "C_7" [minlen=3]
-    "C_7" -> "C_8" [minlen=2]
+    "C_6" -> "C_7" [minlen=1]
+    "C_7" -> "C_8" [minlen=1]
     "C_8" -> "C_9" [minlen=1]
     "C_9" -> "C_10" [minlen=2]
     "C_10" -> "C_11" [minlen=1]
     "C_11" -> "C_12" [minlen=1]
     "C_12" -> "C_13" [minlen=1]
-    "C_13" -> "C_14" [minlen=7]
+    "C_13" -> "C_14" [minlen=1]
     "C_14" -> "C_15" [minlen=1]
     "C_15" -> "C_16" [minlen=1]
     "C_16" -> "C_17" [minlen=1]
     "C_17" -> "C_18" [minlen=1]
-    "C_18" -> "C_19" [minlen=1]
+    "C_18" -> "C_19" [minlen=2]
     "C_19" -> "C_20" [minlen=1]
-    "C_20" -> "C_21" [minlen=1]
+    "C_20" -> "C_21" [minlen=5]
     "C_21" -> "C_22" [minlen=1]
     "C_22" -> "C_23" [minlen=1]
     "C_23" -> "C_24" [minlen=1]
-    "C_24" -> "C_25" [minlen=2]
-    "C_25" -> "C_26" [minlen=1]
+    "C_24" -> "C_25" [minlen=1]
+    "C_25" -> "C_26" [minlen=2]
     "C_26" -> "C_27" [minlen=1]
-    "C_27" -> "C_28" [minlen=5]
+    "C_27" -> "C_28" [minlen=4]
     "C_28" -> "C_29" [minlen=1]
-    "C_29" -> "C_30" [minlen=2]
-    "C_30" -> "C_31" [minlen=2]
+    "C_29" -> "C_30" [minlen=1]
+    "C_30" -> "C_31" [minlen=1]
     "C_31" -> "C_32" [minlen=1]
-    "C_32" -> "C_33" [minlen=2]
-    "C_33" -> "C_34" [minlen=2]
-    "C_34" -> "C_35" [minlen=3]
+    "C_32" -> "C_33" [minlen=1]
+    "C_33" -> "C_34" [minlen=1]
+    "C_34" -> "C_35" [minlen=2]
     "C_35" -> "C_36" [minlen=1]
-    "C_36" -> "C_37" [minlen=1]
-    "C_37" -> "C_38" [minlen=1]
+    "C_36" -> "C_37" [minlen=2]
+    "C_37" -> "C_38" [minlen=3]
     "C_38" -> "C_39" [minlen=1]
     "C_39" -> "C_40" [minlen=1]
     "C_40" -> "C_41" [minlen=1]
     "C_41" -> "C_42" [minlen=1]
     "C_42" -> "C_43" [minlen=1]
     "C_43" -> "C_44" [minlen=1]
-    "C_44" -> "C_45" [minlen=1]
+    "C_44" -> "C_45" [minlen=2]
     "C_45" -> "C_46" [minlen=1]
     "C_46" -> "C_47" [minlen=1]
     "C_47" -> "C_48" [minlen=1]
-    "C_48" -> "C_49" [minlen=4]
-    "C_49" -> "C_50" [minlen=1]
-    "C_50" -> "C_51" [minlen=2]
-    "C_51" -> "C_52" [minlen=3]
-    "C_52" -> "C_53" [minlen=1]
+    "C_48" -> "C_49" [minlen=1]
+    "C_49" -> "C_50" [minlen=2]
+    "C_50" -> "C_51" [minlen=1]
+    "C_51" -> "C_52" [minlen=1]
+    "C_52" -> "C_53" [minlen=2]
     "C_53" -> "C_54" [minlen=1]
-    "C_54" -> "C_55" [minlen=2]
+    "C_54" -> "C_55" [minlen=1]
     "C_55" -> "C_56" [minlen=1]
     "C_56" -> "C_57" [minlen=1]
     "C_57" -> "C_58" [minlen=1]
-    "C_58" -> "C_59" [minlen=1]
-    "C_59" -> "C_60" [minlen=2]
-    "C_60" -> "C_61" [minlen=1]
-    "C_61" -> "C_62" [minlen=1]
-    "C_62" -> "C_63" [minlen=2]
-    "C_63" -> "C_64" [minlen=1]
-    "C_64" -> "C_65" [minlen=1]
-    "C_65" -> "C_66" [minlen=1]
-    "C_66" -> "C_67" [minlen=1]
-    "C_67" -> "C_68" [minlen=2]
-    "C_68" -> "C_69" [minlen=1]
-    "C_69" -> "C_70" [minlen=1]
-    "C_70" -> "C_71" [minlen=15]
-    "C_71" -> "C_72" [minlen=1]
-    "C_72" -> "C_73" [minlen=1]
-    "C_73" -> "C_74" [minlen=2]
-    "C_74" -> "C_75" [minlen=1]
-    "C_75" -> "C_76" [minlen=2]
-    "C_76" -> "C_77" [minlen=1]
-    "C_77" -> "C_78" [minlen=1]
-    "C_78" -> "C_79" [minlen=1]
-    "C_79" -> "C_80" [minlen=1]
-    "C_80" -> "C_81" [minlen=1]
-    "C_81" -> "C_82" [minlen=1]
-    "C_82" -> "C_83" [minlen=2]
-    "C_83" -> "C_84" [minlen=1]
-    "C_84" -> "C_85" [minlen=2]
-    "C_85" -> "C_86" [minlen=4]
-    "C_86" -> "C_87" [minlen=1]
-    "C_87" -> "C_88" [minlen=1]
+    "C_58" -> "C_59" [minlen=2]
+    "C_59" -> "C_60" [minlen=1]
   }
-  "B_3" -> "C_3" [constraint=false]
-  "B_8" -> "C_5" [constraint=false]
-  "D_5" -> "C_7" [constraint=false]
-  "D_7" -> "C_8" [constraint=false]
-  "B_13" -> "C_10" [constraint=false]
-  "A_10" -> "C_11" [constraint=false]
-  "B_14" -> "C_12" [constraint=false]
-  "A_17" -> "C_14" [constraint=false]
-  "B_17" -> "C_16" [constraint=false]
-  "A_18" -> "C_17" [constraint=false]
-  "D_17" -> "C_18" [constraint=false]
-  "B_21" -> "C_21" [constraint=false]
-  "A_22" -> "C_22" [constraint=false]
-  "E_11" -> "C_23" [constraint=false]
-  "B_24" -> "C_25" [constraint=false]
+  "A_2" -> "C_2" [constraint=false]
+  "B_6" -> "C_4" [constraint=false]
+  "A_9" -> "C_5" [constraint=false]
+  "B_7" -> "C_6" [constraint=false]
+  "A_14" -> "C_10" [constraint=false]
+  "B_13" -> "C_11" [constraint=false]
+  "A_15" -> "C_12" [constraint=false]
+  "B_15" -> "C_15" [constraint=false]
+  "A_17" -> "C_16" [constraint=false]
+  "B_16" -> "C_17" [constraint=false]
+  "A_19" -> "C_19" [constraint=false]
+  "A_23" -> "C_21" [constraint=false]
+  "A_25" -> "C_24" [constraint=false]
+  "A_27" -> "C_26" [constraint=false]
   "A_31" -> "C_28" [constraint=false]
-  "B_31" -> "C_30" [constraint=false]
-  "E_17" -> "C_31" [constraint=false]
-  "B_34" -> "C_33" [constraint=false]
-  "D_29" -> "C_34" [constraint=false]
-  "D_31" -> "C_35" [constraint=false]
-  "E_23" -> "C_37" [constraint=false]
-  "B_40" -> "C_38" [constraint=false]
-  "E_24" -> "C_40" [constraint=false]
-  "A_36" -> "C_42" [constraint=false]
-  "B_44" -> "C_43" [constraint=false]
-  "E_34" -> "C_49" [constraint=false]
-  "E_37" -> "C_51" [constraint=false]
-  "A_52" -> "C_52" [constraint=false]
-  "A_53" -> "C_53" [constraint=false]
-  "B_56" -> "C_55" [constraint=false]
-  "B_57" -> "C_58" [constraint=false]
-  "E_42" -> "C_59" [constraint=false]
-  "A_56" -> "C_60" [constraint=false]
-  "A_57" -> "C_61" [constraint=false]
-  "A_59" -> "C_63" [constraint=false]
-  "A_60" -> "C_65" [constraint=false]
-  "B_61" -> "C_66" [constraint=false]
-  "A_62" -> "C_68" [constraint=false]
-  "D_44" -> "C_69" [constraint=false]
-  "D_58" -> "C_71" [constraint=false]
-  "A_69" -> "C_73" [constraint=false]
-  "D_62" -> "C_74" [constraint=false]
-  "B_72" -> "C_76" [constraint=false]
-  "B_73" -> "C_77" [constraint=false]
-  "E_67" -> "C_79" [constraint=false]
-  "B_74" -> "C_80" [constraint=false]
-  "B_76" -> "C_81" [constraint=false]
-  "D_70" -> "C_83" [constraint=false]
-  "A_75" -> "C_85" [constraint=false]
-  "B_85" -> "C_86" [constraint=false]
-  "A_78" -> "C_87" [constraint=false]
-  "D_73" -> "C_88" [constraint=false]
+  "E_3" -> "C_30" [constraint=false]
+  "E_2" -> "C_31" [constraint=false]
+  "A_34" -> "C_33" [constraint=false]
+  "B_28" -> "C_34" [constraint=false]
+  "E_7" -> "C_35" [constraint=false]
+  "E_10" -> "C_37" [constraint=false]
+  "A_45" -> "C_38" [constraint=false]
+  "A_46" -> "C_43" [constraint=false]
+  "B_39" -> "C_45" [constraint=false]
+  "B_40" -> "C_48" [constraint=false]
+  "E_15" -> "C_49" [constraint=false]
+  "A_53" -> "C_50" [constraint=false]
+  "A_54" -> "C_51" [constraint=false]
+  "A_56" -> "C_53" [constraint=false]
+  "A_57" -> "C_55" [constraint=false]
+  "B_44" -> "C_57" [constraint=false]
+  "A_60" -> "C_59" [constraint=false]
+  "D_13" -> "C_60" [constraint=false]
 
   style=invis
   subgraph cluster_Dave {
@@ -481,133 +323,40 @@ digraph GossipGraph {
     "Dave" [style=invis]
     "Dave" -> "D_0" [style=invis]
     "D_0" -> "D_1" [minlen=1]
-    "D_1" -> "D_2" [minlen=1]
-    "D_2" -> "D_3" [minlen=1]
+    "D_1" -> "D_2" [minlen=36]
+    "D_2" -> "D_3" [minlen=10]
     "D_3" -> "D_4" [minlen=9]
     "D_4" -> "D_5" [minlen=1]
-    "D_5" -> "D_6" [minlen=1]
+    "D_5" -> "D_6" [minlen=4]
     "D_6" -> "D_7" [minlen=1]
-    "D_7" -> "D_8" [minlen=2]
-    "D_8" -> "D_9" [minlen=6]
+    "D_7" -> "D_8" [minlen=1]
+    "D_8" -> "D_9" [minlen=1]
     "D_9" -> "D_10" [minlen=1]
-    "D_10" -> "D_11" [minlen=1]
-    "D_11" -> "D_12" [minlen=1]
+    "D_10" -> "D_11" [minlen=10]
+    "D_11" -> "D_12" [minlen=3]
     "D_12" -> "D_13" [minlen=1]
     "D_13" -> "D_14" [minlen=1]
     "D_14" -> "D_15" [minlen=1]
-    "D_15" -> "D_16" [minlen=1]
+    "D_15" -> "D_16" [minlen=4]
     "D_16" -> "D_17" [minlen=1]
-    "D_17" -> "D_18" [minlen=8]
+    "D_17" -> "D_18" [minlen=1]
     "D_18" -> "D_19" [minlen=1]
-    "D_19" -> "D_20" [minlen=4]
-    "D_20" -> "D_21" [minlen=1]
+    "D_19" -> "D_20" [minlen=1]
+    "D_20" -> "D_21" [minlen=3]
     "D_21" -> "D_22" [minlen=1]
     "D_22" -> "D_23" [minlen=1]
-    "D_23" -> "D_24" [minlen=2]
-    "D_24" -> "D_25" [minlen=1]
-    "D_25" -> "D_26" [minlen=2]
-    "D_26" -> "D_27" [minlen=1]
-    "D_27" -> "D_28" [minlen=3]
-    "D_28" -> "D_29" [minlen=1]
-    "D_29" -> "D_30" [minlen=2]
-    "D_30" -> "D_31" [minlen=1]
-    "D_31" -> "D_32" [minlen=2]
-    "D_32" -> "D_33" [minlen=6]
-    "D_33" -> "D_34" [minlen=1]
-    "D_34" -> "D_35" [minlen=1]
-    "D_35" -> "D_36" [minlen=1]
-    "D_36" -> "D_37" [minlen=1]
-    "D_37" -> "D_38" [minlen=1]
-    "D_38" -> "D_39" [minlen=9]
-    "D_39" -> "D_40" [minlen=1]
-    "D_40" -> "D_41" [minlen=4]
-    "D_41" -> "D_42" [minlen=10]
-    "D_42" -> "D_43" [minlen=3]
-    "D_43" -> "D_44" [minlen=1]
-    "D_44" -> "D_45" [minlen=1]
-    "D_45" -> "D_46" [minlen=4]
-    "D_46" -> "D_47" [minlen=1]
-    "D_47" -> "D_48" [minlen=1]
-    "D_48" -> "D_49" [minlen=1]
-    "D_49" -> "D_50" [minlen=1]
-    "D_50" -> "D_51" [minlen=3]
-    "D_51" -> "D_52" [minlen=1]
-    "D_52" -> "D_53" [minlen=1]
-    "D_53" -> "D_54" [minlen=1]
-    "D_54" -> "D_55" [minlen=1]
-    "D_55" -> "D_56" [minlen=1]
-    "D_56" -> "D_57" [minlen=1]
-    "D_57" -> "D_58" [minlen=1]
-    "D_58" -> "D_59" [minlen=1]
-    "D_59" -> "D_60" [minlen=1]
-    "D_60" -> "D_61" [minlen=1]
-    "D_61" -> "D_62" [minlen=1]
-    "D_62" -> "D_63" [minlen=1]
-    "D_63" -> "D_64" [minlen=1]
-    "D_64" -> "D_65" [minlen=1]
-    "D_65" -> "D_66" [minlen=1]
-    "D_66" -> "D_67" [minlen=1]
-    "D_67" -> "D_68" [minlen=1]
-    "D_68" -> "D_69" [minlen=1]
-    "D_69" -> "D_70" [minlen=4]
-    "D_70" -> "D_71" [minlen=1]
-    "D_71" -> "D_72" [minlen=2]
-    "D_72" -> "D_73" [minlen=1]
-    "D_73" -> "D_74" [minlen=7]
-    "D_74" -> "D_75" [minlen=1]
-    "D_75" -> "D_76" [minlen=6]
-    "D_76" -> "D_77" [minlen=1]
-    "D_77" -> "D_78" [minlen=1]
-    "D_78" -> "D_79" [minlen=1]
-    "D_79" -> "D_80" [minlen=1]
   }
-  "B_10" -> "D_4" [constraint=false]
-  "C_6" -> "D_5" [constraint=false]
-  "A_5" -> "D_6" [constraint=false]
-  "C_8" -> "D_8" [constraint=false]
-  "A_13" -> "D_9" [constraint=false]
-  "E_6" -> "D_11" [constraint=false]
-  "A_15" -> "D_13" [constraint=false]
-  "A_16" -> "D_15" [constraint=false]
-  "B_16" -> "D_16" [constraint=false]
-  "C_15" -> "D_17" [constraint=false]
-  "A_24" -> "D_18" [constraint=false]
-  "B_27" -> "D_20" [constraint=false]
-  "A_28" -> "D_21" [constraint=false]
-  "A_32" -> "D_24" [constraint=false]
-  "E_16" -> "D_26" [constraint=false]
-  "E_19" -> "D_28" [constraint=false]
-  "C_34" -> "D_30" [constraint=false]
-  "C_35" -> "D_32" [constraint=false]
-  "B_43" -> "D_33" [constraint=false]
-  "B_53" -> "D_39" [constraint=false]
-  "E_41" -> "D_41" [constraint=false]
-  "E_46" -> "D_42" [constraint=false]
-  "E_48" -> "D_43" [constraint=false]
-  "C_69" -> "D_46" [constraint=false]
-  "A_63" -> "D_47" [constraint=false]
-  "A_64" -> "D_48" [constraint=false]
-  "E_54" -> "D_49" [constraint=false]
-  "E_58" -> "D_51" [constraint=false]
-  "A_67" -> "D_56" [constraint=false]
-  "A_66" -> "D_57" [constraint=false]
-  "C_70" -> "D_58" [constraint=false]
-  "E_61" -> "D_59" [constraint=false]
-  "E_63" -> "D_60" [constraint=false]
-  "B_70" -> "D_61" [constraint=false]
-  "C_72" -> "D_62" [constraint=false]
-  "E_65" -> "D_65" [constraint=false]
-  "E_66" -> "D_66" [constraint=false]
-  "E_68" -> "D_68" [constraint=false]
-  "A_73" -> "D_69" [constraint=false]
-  "C_82" -> "D_70" [constraint=false]
-  "A_74" -> "D_72" [constraint=false]
-  "C_88" -> "D_74" [constraint=false]
-  "B_93" -> "D_76" [constraint=false]
-  "A_80" -> "D_77" [constraint=false]
-  "B_94" -> "D_78" [constraint=false]
-  "B_95" -> "D_79" [constraint=false]
-  "A_82" -> "D_80" [constraint=false]
+  "A_26" -> "D_2" [constraint=false]
+  "B_27" -> "D_3" [constraint=false]
+  "B_32" -> "D_4" [constraint=false]
+  "E_14" -> "D_6" [constraint=false]
+  "E_23" -> "D_11" [constraint=false]
+  "E_25" -> "D_12" [constraint=false]
+  "C_60" -> "D_16" [constraint=false]
+  "A_61" -> "D_17" [constraint=false]
+  "A_62" -> "D_18" [constraint=false]
+  "E_32" -> "D_19" [constraint=false]
+  "E_36" -> "D_21" [constraint=false]
 
   style=invis
   subgraph cluster_Eric {
@@ -615,129 +364,65 @@ digraph GossipGraph {
     "Eric" [style=invis]
     "Eric" -> "E_0" [style=invis]
     "E_0" -> "E_1" [minlen=1]
-    "E_1" -> "E_2" [minlen=1]
+    "E_1" -> "E_2" [minlen=40]
     "E_2" -> "E_3" [minlen=1]
-    "E_3" -> "E_4" [minlen=8]
-    "E_4" -> "E_5" [minlen=7]
+    "E_3" -> "E_4" [minlen=6]
+    "E_4" -> "E_5" [minlen=1]
     "E_5" -> "E_6" [minlen=1]
-    "E_6" -> "E_7" [minlen=7]
+    "E_6" -> "E_7" [minlen=1]
     "E_7" -> "E_8" [minlen=1]
-    "E_8" -> "E_9" [minlen=5]
-    "E_9" -> "E_10" [minlen=2]
-    "E_10" -> "E_11" [minlen=1]
-    "E_11" -> "E_12" [minlen=4]
-    "E_12" -> "E_13" [minlen=1]
+    "E_8" -> "E_9" [minlen=1]
+    "E_9" -> "E_10" [minlen=1]
+    "E_10" -> "E_11" [minlen=2]
+    "E_11" -> "E_12" [minlen=1]
+    "E_12" -> "E_13" [minlen=2]
     "E_13" -> "E_14" [minlen=1]
-    "E_14" -> "E_15" [minlen=5]
-    "E_15" -> "E_16" [minlen=5]
+    "E_14" -> "E_15" [minlen=1]
+    "E_15" -> "E_16" [minlen=1]
     "E_16" -> "E_17" [minlen=1]
-    "E_17" -> "E_18" [minlen=2]
+    "E_17" -> "E_18" [minlen=1]
     "E_18" -> "E_19" [minlen=1]
-    "E_19" -> "E_20" [minlen=2]
-    "E_20" -> "E_21" [minlen=1]
-    "E_21" -> "E_22" [minlen=3]
+    "E_19" -> "E_20" [minlen=1]
+    "E_20" -> "E_21" [minlen=5]
+    "E_21" -> "E_22" [minlen=2]
     "E_22" -> "E_23" [minlen=1]
-    "E_23" -> "E_24" [minlen=1]
-    "E_24" -> "E_25" [minlen=5]
+    "E_23" -> "E_24" [minlen=2]
+    "E_24" -> "E_25" [minlen=1]
     "E_25" -> "E_26" [minlen=1]
     "E_26" -> "E_27" [minlen=1]
     "E_27" -> "E_28" [minlen=1]
     "E_28" -> "E_29" [minlen=1]
     "E_29" -> "E_30" [minlen=1]
-    "E_30" -> "E_31" [minlen=1]
+    "E_30" -> "E_31" [minlen=3]
     "E_31" -> "E_32" [minlen=1]
-    "E_32" -> "E_33" [minlen=1]
+    "E_32" -> "E_33" [minlen=2]
     "E_33" -> "E_34" [minlen=1]
     "E_34" -> "E_35" [minlen=1]
     "E_35" -> "E_36" [minlen=1]
     "E_36" -> "E_37" [minlen=1]
-    "E_37" -> "E_38" [minlen=2]
-    "E_38" -> "E_39" [minlen=1]
-    "E_39" -> "E_40" [minlen=2]
-    "E_40" -> "E_41" [minlen=1]
-    "E_41" -> "E_42" [minlen=1]
-    "E_42" -> "E_43" [minlen=1]
-    "E_43" -> "E_44" [minlen=5]
-    "E_44" -> "E_45" [minlen=2]
-    "E_45" -> "E_46" [minlen=1]
-    "E_46" -> "E_47" [minlen=2]
-    "E_47" -> "E_48" [minlen=1]
-    "E_48" -> "E_49" [minlen=1]
-    "E_49" -> "E_50" [minlen=1]
-    "E_50" -> "E_51" [minlen=1]
-    "E_51" -> "E_52" [minlen=1]
-    "E_52" -> "E_53" [minlen=3]
-    "E_53" -> "E_54" [minlen=1]
-    "E_54" -> "E_55" [minlen=2]
-    "E_55" -> "E_56" [minlen=1]
-    "E_56" -> "E_57" [minlen=1]
-    "E_57" -> "E_58" [minlen=1]
-    "E_58" -> "E_59" [minlen=1]
-    "E_59" -> "E_60" [minlen=1]
-    "E_60" -> "E_61" [minlen=3]
-    "E_61" -> "E_62" [minlen=1]
-    "E_62" -> "E_63" [minlen=1]
-    "E_63" -> "E_64" [minlen=1]
-    "E_64" -> "E_65" [minlen=6]
-    "E_65" -> "E_66" [minlen=1]
-    "E_66" -> "E_67" [minlen=1]
-    "E_67" -> "E_68" [minlen=1]
-    "E_68" -> "E_69" [minlen=2]
-    "E_69" -> "E_70" [minlen=1]
-    "E_70" -> "E_71" [minlen=1]
-    "E_71" -> "E_72" [minlen=2]
-    "E_72" -> "E_73" [minlen=1]
-    "E_73" -> "E_74" [minlen=10]
-    "E_74" -> "E_75" [minlen=1]
-    "E_75" -> "E_76" [minlen=1]
-    "E_76" -> "E_77" [minlen=2]
+    "E_37" -> "E_38" [minlen=1]
   }
-  "A_6" -> "E_4" [constraint=false]
-  "A_9" -> "E_5" [constraint=false]
-  "D_11" -> "E_7" [constraint=false]
-  "A_20" -> "E_9" [constraint=false]
-  "B_19" -> "E_10" [constraint=false]
-  "C_23" -> "E_12" [constraint=false]
-  "A_29" -> "E_15" [constraint=false]
-  "D_25" -> "E_16" [constraint=false]
-  "C_31" -> "E_18" [constraint=false]
-  "D_27" -> "E_19" [constraint=false]
-  "B_35" -> "E_20" [constraint=false]
-  "B_39" -> "E_22" [constraint=false]
-  "A_37" -> "E_25" [constraint=false]
-  "C_40" -> "E_31" [constraint=false]
-  "C_37" -> "E_32" [constraint=false]
-  "A_38" -> "E_33" [constraint=false]
-  "C_41" -> "E_34" [constraint=false]
-  "A_45" -> "E_35" [constraint=false]
-  "A_47" -> "E_36" [constraint=false]
-  "C_51" -> "E_38" [constraint=false]
-  "B_55" -> "E_40" [constraint=false]
-  "D_40" -> "E_41" [constraint=false]
-  "C_59" -> "E_44" [constraint=false]
-  "B_60" -> "E_45" [constraint=false]
-  "D_42" -> "E_47" [constraint=false]
-  "D_43" -> "E_50" [constraint=false]
-  "B_62" -> "E_51" [constraint=false]
-  "B_63" -> "E_52" [constraint=false]
-  "B_65" -> "E_53" [constraint=false]
-  "B_67" -> "E_55" [constraint=false]
-  "D_49" -> "E_56" [constraint=false]
-  "D_50" -> "E_58" [constraint=false]
-  "B_69" -> "E_59" [constraint=false]
-  "D_54" -> "E_61" [constraint=false]
-  "A_68" -> "E_62" [constraint=false]
-  "D_55" -> "E_63" [constraint=false]
-  "A_70" -> "E_64" [constraint=false]
-  "D_63" -> "E_65" [constraint=false]
-  "D_64" -> "E_66" [constraint=false]
-  "D_68" -> "E_69" [constraint=false]
-  "C_79" -> "E_70" [constraint=false]
-  "B_78" -> "E_72" [constraint=false]
-  "B_79" -> "E_73" [constraint=false]
-  "B_87" -> "E_74" [constraint=false]
-  "B_88" -> "E_75" [constraint=false]
-  "B_91" -> "E_77" [constraint=false]
+  "C_27" -> "E_2" [constraint=false]
+  "A_35" -> "E_4" [constraint=false]
+  "C_30" -> "E_5" [constraint=false]
+  "A_36" -> "E_6" [constraint=false]
+  "C_32" -> "E_7" [constraint=false]
+  "A_38" -> "E_8" [constraint=false]
+  "A_40" -> "E_9" [constraint=false]
+  "C_37" -> "E_11" [constraint=false]
+  "B_34" -> "E_13" [constraint=false]
+  "D_5" -> "E_14" [constraint=false]
+  "C_49" -> "E_21" [constraint=false]
+  "B_43" -> "E_22" [constraint=false]
+  "D_11" -> "E_24" [constraint=false]
+  "D_12" -> "E_27" [constraint=false]
+  "B_46" -> "E_29" [constraint=false]
+  "B_47" -> "E_30" [constraint=false]
+  "B_49" -> "E_31" [constraint=false]
+  "B_51" -> "E_33" [constraint=false]
+  "D_19" -> "E_34" [constraint=false]
+  "D_20" -> "E_36" [constraint=false]
+  "B_53" -> "E_37" [constraint=false]
 
   {
     rank=same
@@ -758,527 +443,434 @@ digraph GossipGraph {
 
   "A_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_1</td></tr>
-<tr><td colspan="6">Genesis({Alice, Bob, Carol, Dave, Eric})</td></tr>
+<tr><td colspan="6">Genesis({Alice, Bob, Carol})</td></tr>
 </table>>]
-/// cause: Observation(Genesis({Alice, Bob, Carol, Dave, Eric}))
+/// cause: Observation(Genesis({Alice, Bob, Carol}))
 /// last_ancestors: {Alice: 1}
 
-  "A_2" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_2</td></tr>
-<tr><td colspan="6">StartDkg({Alice, Bob, Carol, Dave, Eric})</td></tr>
 </table>>]
-/// cause: Observation(StartDkg({Alice, Bob, Carol, Dave, Eric}))
+/// cause: Requesting(Carol)
 /// last_ancestors: {Alice: 2}
 
   "A_3" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_3</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 3, Bob: 5, Carol: 3}
+/// last_ancestors: {Alice: 3, Bob: 2}
 
   "A_4" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_4</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 4, Bob: 6, Carol: 3}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 4, Bob: 2}
 
   "A_5" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_5</td></tr>
 </table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 5, Bob: 6, Carol: 3}
+/// cause: Response
+/// last_ancestors: {Alice: 5, Bob: 2, Carol: 2}
 
   "A_6" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_6</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 6, Bob: 6, Carol: 3, Eric: 3}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 6, Bob: 2, Carol: 2}
 
   "A_7" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_7</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 7, Bob: 10, Carol: 6, Dave: 6, Eric: 3}
+/// last_ancestors: {Alice: 7, Bob: 4, Carol: 2}
 
   "A_8" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_8</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 8, Bob: 11, Carol: 6, Dave: 6, Eric: 3}
+/// cause: Response
+/// last_ancestors: {Alice: 8, Bob: 5, Carol: 2}
 
   "A_9" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_9</td></tr>
 </table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 9, Bob: 11, Carol: 6, Dave: 6, Eric: 3}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 9, Bob: 5, Carol: 2}
 
   "A_10" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_10</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 10, Bob: 11, Carol: 6, Dave: 6, Eric: 3}
-
-  "A_11" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_11</td></tr>
-</table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 11, Bob: 11, Carol: 6, Dave: 6, Eric: 5}
+/// last_ancestors: {Alice: 10, Bob: 6, Carol: 5}
+
+  "A_11" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">A_11</td></tr>
+<tr><td colspan="6">StartDkg({Alice, Bob, Carol, Dave, Eric})</td></tr>
+</table>>]
+/// cause: Observation(StartDkg({Alice, Bob, Carol, Dave, Eric}))
+/// last_ancestors: {Alice: 11, Bob: 6, Carol: 5}
 
   "A_12" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_12</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 12, Bob: 13, Carol: 11, Dave: 7, Eric: 5}
+/// cause: Request
+/// last_ancestors: {Alice: 12, Bob: 10, Carol: 5}
 
   "A_13" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_13</td></tr>
 </table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 13, Bob: 13, Carol: 11, Dave: 7, Eric: 5}
+/// cause: Request
+/// last_ancestors: {Alice: 13, Bob: 11, Carol: 5}
 
   "A_14" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_14</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 14, Bob: 13, Carol: 11, Dave: 9, Eric: 5}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 14, Bob: 11, Carol: 5}
 
   "A_15" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_15</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 15, Bob: 13, Carol: 11, Dave: 10, Eric: 5}
+/// last_ancestors: {Alice: 15, Bob: 11, Carol: 9}
 
   "A_16" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_16</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 16, Bob: 13, Carol: 11, Dave: 12, Eric: 6}
+/// cause: Response
+/// last_ancestors: {Alice: 16, Bob: 11, Carol: 10}
 
   "A_17" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_17</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 17, Bob: 13, Carol: 11, Dave: 12, Eric: 6}
+/// cause: Request
+/// last_ancestors: {Alice: 17, Bob: 13, Carol: 14}
 
   "A_18" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_18</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 18, Bob: 14, Carol: 13, Dave: 12, Eric: 6}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 18, Bob: 13, Carol: 14}
 
   "A_19" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_19</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 19, Bob: 14, Carol: 14, Dave: 12, Eric: 6}
+/// cause: Request
+/// last_ancestors: {Alice: 19, Bob: 16, Carol: 18}
 
   "A_20" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_20</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 20, Bob: 14, Carol: 14, Dave: 12, Eric: 8}
+/// cause: Response
+/// last_ancestors: {Alice: 20, Bob: 18, Carol: 18}
 
   "A_21" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_21</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 21, Bob: 14, Carol: 14, Dave: 12, Eric: 8}
+/// cause: Request
+/// last_ancestors: {Alice: 21, Bob: 19, Carol: 18}
 
   "A_22" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_22</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 22, Bob: 17, Carol: 20, Dave: 17, Eric: 8}
+/// last_ancestors: {Alice: 22, Bob: 21, Carol: 18}
 
   "A_23" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_23</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 23, Bob: 20, Carol: 20, Dave: 17, Eric: 8}
+/// cause: Request
+/// last_ancestors: {Alice: 23, Bob: 21, Carol: 20}
 
-  "A_24" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_24" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_24</td></tr>
+<tr><td colspan="6">DkgMessage(DkgPart(0))</td></tr>
 </table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 24, Bob: 20, Carol: 20, Dave: 17, Eric: 8}
+/// cause: Observation(DkgMessage(DkgPart(0)), SerialisedDkgMessage([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 170, 56, 47, 207, 186, 245, 24, 247, 217, 150, 140, 50, 227, 30, 135, 223, 79, 243, 187, 189, 185, 203, 218, 43, 136, 156, 197, 104, 75, 192, 26, 187, 246, 165, 224, 37, 252, 2, 244, 3, 240, 29, 185, 58, 131, 63, 181, 83, 174, 16, 78, 149, 67, 26, 234, 121, 171, 195, 67, 159, 78, 234, 207, 135, 121, 209, 110, 16, 62, 59, 192, 40, 40, 145, 14, 90, 67, 222, 127, 17, 148, 37, 122, 141, 117, 10, 220, 223, 147, 84, 23, 124, 45, 34, 24, 149, 130, 166, 155, 34, 75, 94, 84, 89, 50, 181, 27, 228, 175, 215, 177, 194, 59, 87, 231, 155, 241, 44, 111, 54, 211, 185, 222, 248, 242, 14, 128, 162, 9, 6, 30, 226, 69, 178, 7, 177, 219, 109, 101, 218, 222, 248, 40, 4, 5, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 143, 16, 169, 60, 176, 143, 10, 221, 31, 235, 166, 195, 234, 254, 14, 187, 86, 0, 179, 59, 15, 14, 185, 97, 140, 156, 242, 85, 31, 98, 102, 59, 252, 192, 22, 33, 70, 85, 100, 157, 140, 75, 54, 89, 23, 176, 229, 79, 46, 194, 179, 211, 29, 173, 19, 237, 104, 118, 74, 167, 184, 240, 230, 86, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 84, 255, 112, 174, 64, 70, 82, 172, 244, 46, 105, 39, 36, 175, 68, 78, 106, 159, 4, 129, 107, 190, 71, 77, 238, 78, 112, 233, 236, 180, 232, 96, 50, 147, 101, 208, 252, 243, 128, 107, 69, 247, 171, 78, 242, 11, 216, 184, 67, 13, 116, 88, 215, 209, 94, 187, 39, 189, 121, 145, 80, 231, 93, 20, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 24, 238, 56, 32, 210, 252, 153, 123, 202, 22, 45, 139, 90, 187, 188, 141, 120, 102, 180, 188, 191, 150, 156, 5, 8, 132, 80, 83, 103, 96, 125, 18, 105, 101, 180, 127, 178, 146, 157, 57, 253, 254, 31, 68, 208, 11, 136, 117, 94, 48, 214, 230, 152, 206, 227, 188, 46, 129, 70, 165, 59, 133, 194, 69, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 221, 220, 0, 146, 98, 179, 225, 74, 159, 90, 239, 238, 147, 107, 242, 32, 140, 5, 6, 2, 28, 71, 43, 241, 105, 54, 206, 230, 52, 179, 255, 55, 159, 55, 3, 47, 105, 49, 186, 7, 182, 170, 149, 57, 171, 103, 122, 222, 115, 123, 150, 107, 82, 243, 46, 139, 237, 199, 117, 143, 211, 123, 57, 3, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 162, 203, 200, 3, 243, 105, 41, 26, 116, 158, 177, 82, 205, 27, 40, 180, 159, 164, 87, 71, 120, 247, 185, 220, 203, 232, 75, 122, 2, 6, 130, 93, 214, 9, 82, 222, 30, 208, 214, 213, 109, 178, 9, 47, 137, 103, 42, 155, 142, 158, 248, 249, 19, 240, 179, 140, 244, 139, 66, 163, 190, 25, 158, 52, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32]))
+/// last_ancestors: {Alice: 24, Bob: 21, Carol: 20}
 
   "A_25" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_25</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 25, Bob: 23, Carol: 20, Dave: 17, Eric: 10}
+/// last_ancestors: {Alice: 25, Bob: 21, Carol: 22}
 
   "A_26" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_26</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 26, Bob: 23, Carol: 20, Dave: 18, Eric: 10}
+/// cause: Requesting(Dave)
+/// last_ancestors: {Alice: 26, Bob: 21, Carol: 22}
 
   "A_27" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_27</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 27, Bob: 26, Carol: 24, Dave: 18, Eric: 11}
+/// last_ancestors: {Alice: 27, Bob: 21, Carol: 25}
 
   "A_28" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_28</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 28, Bob: 26, Carol: 24, Dave: 19, Eric: 11}
+/// cause: Response
+/// last_ancestors: {Alice: 28, Bob: 21, Carol: 25, Dave: 2}
 
   "A_29" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_29</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 29, Bob: 26, Carol: 24, Dave: 19, Eric: 13}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 29, Bob: 21, Carol: 25, Dave: 2}
 
-  "A_30" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_30" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_30</td></tr>
-<tr><td colspan="6">DkgMessage(DkgPart(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgPart(0)), SerialisedDkgMessage([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 152, 214, 162, 242, 91, 155, 191, 217, 36, 142, 44, 157, 129, 14, 160, 111, 138, 146, 236, 179, 65, 12, 58, 178, 92, 48, 130, 97, 119, 165, 208, 173, 17, 131, 25, 30, 40, 190, 229, 182, 209, 43, 52, 226, 141, 185, 109, 62, 142, 210, 67, 37, 118, 68, 153, 249, 218, 1, 39, 190, 6, 55, 250, 201, 19, 179, 16, 12, 182, 116, 20, 54, 71, 192, 250, 39, 208, 94, 212, 22, 149, 77, 158, 224, 176, 225, 147, 104, 143, 162, 187, 79, 106, 84, 60, 203, 160, 238, 218, 198, 105, 160, 116, 38, 65, 121, 47, 214, 104, 112, 138, 119, 184, 84, 146, 151, 178, 148, 195, 41, 154, 147, 145, 55, 17, 163, 119, 94, 87, 225, 4, 111, 111, 44, 210, 175, 65, 116, 4, 85, 76, 222, 117, 58, 5, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 59, 234, 6, 78, 2, 1, 148, 68, 95, 138, 45, 212, 79, 5, 160, 54, 21, 237, 86, 1, 86, 175, 136, 255, 92, 169, 130, 76, 199, 3, 179, 91, 148, 1, 28, 206, 83, 17, 158, 32, 94, 7, 165, 234, 14, 5, 204, 85, 184, 243, 231, 154, 64, 159, 37, 194, 3, 53, 103, 109, 94, 215, 87, 93, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 77, 45, 121, 54, 128, 220, 155, 16, 212, 31, 180, 230, 60, 69, 127, 189, 36, 147, 12, 188, 3, 251, 92, 127, 237, 202, 47, 116, 184, 55, 46, 109, 21, 192, 197, 179, 42, 71, 52, 117, 72, 29, 197, 194, 45, 38, 251, 208, 91, 105, 120, 113, 203, 26, 61, 209, 46, 203, 131, 137, 120, 211, 70, 53, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 94, 112, 235, 30, 255, 183, 163, 220, 73, 89, 60, 249, 38, 225, 160, 240, 46, 97, 32, 109, 169, 110, 247, 203, 53, 111, 63, 114, 86, 196, 187, 10, 150, 126, 111, 153, 1, 125, 202, 201, 50, 51, 229, 154, 76, 71, 42, 76, 255, 222, 8, 72, 86, 150, 84, 224, 89, 97, 160, 165, 146, 207, 53, 13, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 112, 179, 93, 7, 125, 147, 171, 168, 190, 238, 194, 11, 20, 33, 128, 119, 62, 7, 214, 39, 87, 186, 203, 75, 198, 144, 236, 153, 71, 248, 54, 28, 24, 61, 25, 127, 215, 178, 96, 30, 28, 165, 3, 115, 110, 12, 23, 27, 168, 44, 59, 40, 233, 233, 165, 34, 205, 116, 90, 235, 255, 114, 18, 89, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 130, 246, 207, 239, 250, 110, 179, 116, 51, 132, 73, 30, 1, 97, 95, 254, 77, 173, 139, 226, 4, 6, 160, 203, 86, 178, 153, 193, 56, 44, 178, 45, 153, 251, 194, 100, 174, 232, 246, 114, 6, 187, 35, 75, 141, 45, 70, 150, 75, 162, 203, 254, 115, 101, 189, 49, 248, 10, 119, 7, 26, 111, 1, 49, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32]))
-/// last_ancestors: {Alice: 30, Bob: 26, Carol: 24, Dave: 19, Eric: 13}
+/// cause: Response
+/// last_ancestors: {Alice: 30, Bob: 24, Carol: 25, Dave: 2}
 
   "A_31" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_31</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 31, Bob: 26, Carol: 26, Dave: 19, Eric: 13}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 31, Bob: 24, Carol: 25, Dave: 2}
 
   "A_32" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_32</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 32, Bob: 27, Carol: 26, Dave: 22, Eric: 13}
+/// last_ancestors: {Alice: 32, Bob: 25, Carol: 25, Dave: 2}
 
   "A_33" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_33</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 33, Bob: 32, Carol: 29, Dave: 22, Eric: 13}
+/// cause: Response
+/// last_ancestors: {Alice: 33, Bob: 25, Carol: 28, Dave: 2}
 
   "A_34" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_34</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 34, Bob: 36, Carol: 32, Dave: 25, Eric: 17}
+/// last_ancestors: {Alice: 34, Bob: 25, Carol: 29, Dave: 2}
 
   "A_35" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_35</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 35, Bob: 41, Carol: 36, Dave: 31, Eric: 21}
+/// cause: Requesting(Eric)
+/// last_ancestors: {Alice: 35, Bob: 25, Carol: 29, Dave: 2}
 
   "A_36" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_36</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 36, Bob: 41, Carol: 39, Dave: 31, Eric: 23}
+/// cause: Requesting(Eric)
+/// last_ancestors: {Alice: 36, Bob: 25, Carol: 29, Dave: 2}
 
   "A_37" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_37</td></tr>
 </table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 37, Bob: 41, Carol: 39, Dave: 31, Eric: 23}
+/// cause: Response
+/// last_ancestors: {Alice: 37, Bob: 25, Carol: 29, Dave: 2, Eric: 4}
 
   "A_38" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_38</td></tr>
 </table>>]
 /// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 38, Bob: 41, Carol: 39, Dave: 31, Eric: 23}
+/// last_ancestors: {Alice: 38, Bob: 25, Carol: 29, Dave: 2, Eric: 4}
 
-  "A_39" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_39" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_39</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 216, 35, 226, 28, 80, 143, 22, 169, 93, 234, 240, 228, 76, 167, 137, 95, 108, 82, 193, 175, 232, 163, 86, 11, 218, 218, 82, 221, 210, 206, 166, 108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 68, 129, 178, 19, 163, 33, 127, 93, 97, 163, 9, 136, 67, 163, 179, 107, 109, 87, 252, 27, 117, 225, 129, 232, 222, 174, 191, 220, 198, 122, 0, 43, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 177, 222, 130, 10, 245, 179, 231, 17, 100, 184, 32, 43, 61, 67, 155, 203, 115, 52, 217, 145, 9, 247, 230, 248, 43, 0, 202, 5, 14, 206, 71, 93, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 29, 60, 83, 1, 72, 70, 80, 198, 103, 113, 57, 206, 51, 63, 197, 215, 116, 57, 20, 254, 149, 52, 18, 214, 48, 212, 54, 5, 2, 122, 161, 27, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 138, 153, 35, 248, 153, 216, 184, 122, 106, 134, 80, 113, 45, 223, 172, 55, 123, 22, 241, 115, 42, 74, 119, 230, 125, 37, 65, 46, 73, 205, 232, 77, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32]))
-/// last_ancestors: {Alice: 39, Bob: 41, Carol: 39, Dave: 31, Eric: 23}
+/// cause: Response
+/// last_ancestors: {Alice: 39, Bob: 25, Carol: 30, Dave: 2, Eric: 6}
 
-  "A_40" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_40" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_40</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 92, 180, 42, 179, 144, 122, 79, 57, 244, 133, 183, 213, 120, 215, 237, 249, 79, 7, 39, 159, 220, 158, 191, 241, 175, 157, 76, 55, 249, 239, 58, 107, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 3, 116, 13, 232, 218, 125, 192, 55, 120, 229, 107, 4, 255, 112, 39, 70, 136, 241, 109, 143, 221, 199, 110, 220, 216, 232, 147, 243, 96, 231, 39, 12, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 171, 51, 240, 28, 36, 129, 49, 54, 251, 160, 30, 51, 136, 174, 30, 230, 197, 179, 86, 137, 230, 200, 87, 250, 73, 177, 120, 217, 27, 134, 2, 33, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 83, 243, 210, 81, 109, 132, 162, 52, 126, 92, 209, 97, 17, 236, 21, 134, 3, 118, 63, 131, 239, 201, 64, 24, 187, 121, 93, 191, 214, 36, 221, 53, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 251, 178, 181, 134, 182, 135, 19, 51, 1, 24, 132, 144, 154, 41, 13, 38, 65, 56, 40, 125, 248, 202, 41, 54, 44, 66, 66, 165, 145, 195, 183, 74, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32]))
-/// last_ancestors: {Alice: 40, Bob: 41, Carol: 39, Dave: 31, Eric: 23}
+/// cause: Requesting(Eric)
+/// last_ancestors: {Alice: 40, Bob: 25, Carol: 30, Dave: 2, Eric: 6}
 
-  "A_41" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_41" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_41</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 121, 203, 29, 85, 57, 202, 159, 160, 182, 213, 13, 123, 32, 207, 107, 60, 118, 149, 125, 114, 62, 207, 67, 63, 98, 246, 45, 71, 229, 95, 161, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 129, 54, 86, 39, 17, 94, 98, 25, 103, 85, 231, 57, 59, 104, 229, 214, 247, 42, 57, 87, 164, 129, 193, 1, 164, 93, 100, 136, 64, 162, 95, 106, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 136, 161, 142, 249, 233, 241, 36, 146, 24, 121, 194, 248, 82, 93, 161, 29, 116, 232, 82, 50, 2, 92, 5, 145, 157, 71, 253, 159, 72, 61, 48, 88, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 143, 12, 199, 203, 194, 133, 231, 10, 202, 156, 157, 183, 106, 82, 93, 100, 240, 165, 108, 13, 96, 54, 73, 32, 151, 49, 150, 183, 80, 216, 0, 70, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 150, 119, 255, 157, 155, 25, 170, 131, 123, 192, 120, 118, 130, 71, 25, 171, 108, 99, 134, 232, 189, 16, 141, 175, 144, 27, 47, 207, 88, 115, 209, 51, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32]))
-/// last_ancestors: {Alice: 41, Bob: 41, Carol: 39, Dave: 31, Eric: 23}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 41, Bob: 25, Carol: 30, Dave: 2, Eric: 6}
 
-  "A_42" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_42" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_42</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 44, 143, 84, 69, 182, 206, 207, 216, 217, 126, 66, 225, 25, 184, 174, 94, 114, 230, 55, 228, 72, 11, 98, 81, 220, 170, 87, 140, 89, 5, 123, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 14, 163, 152, 15, 59, 89, 56, 220, 247, 233, 12, 160, 251, 40, 13, 106, 229, 62, 77, 161, 196, 85, 2, 200, 74, 206, 89, 217, 211, 128, 105, 115, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 239, 182, 220, 217, 192, 227, 160, 223, 22, 249, 216, 94, 218, 245, 173, 33, 83, 191, 192, 84, 56, 200, 104, 11, 113, 116, 190, 252, 250, 84, 106, 71, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 208, 202, 32, 164, 70, 110, 9, 227, 53, 8, 165, 29, 185, 194, 78, 217, 192, 63, 52, 8, 172, 58, 207, 78, 151, 26, 35, 32, 34, 41, 107, 27, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 178, 222, 100, 110, 203, 248, 113, 230, 83, 115, 111, 220, 154, 51, 173, 228, 51, 152, 73, 197, 39, 133, 111, 197, 5, 62, 37, 109, 156, 164, 89, 99, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32]))
-/// last_ancestors: {Alice: 42, Bob: 41, Carol: 39, Dave: 31, Eric: 23}
+/// cause: Response
+/// last_ancestors: {Alice: 42, Bob: 25, Carol: 32, Dave: 2, Eric: 8}
 
-  "A_43" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_43" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_43</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 206, 235, 34, 28, 87, 18, 50, 101, 190, 53, 212, 190, 91, 102, 174, 56, 200, 8, 157, 146, 142, 118, 116, 142, 24, 97, 76, 144, 210, 51, 29, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 97, 237, 62, 234, 171, 35, 208, 133, 29, 225, 122, 169, 103, 199, 188, 58, 123, 36, 227, 35, 199, 61, 96, 29, 212, 24, 22, 212, 221, 99, 135, 46, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 244, 238, 90, 184, 0, 53, 110, 166, 124, 140, 33, 148, 115, 40, 203, 60, 46, 64, 41, 181, 255, 4, 76, 172, 143, 208, 223, 23, 233, 147, 241, 23, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 135, 240, 118, 134, 85, 70, 12, 199, 219, 55, 200, 126, 127, 137, 217, 62, 225, 91, 111, 70, 56, 204, 55, 59, 75, 136, 169, 91, 244, 195, 91, 1, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 27, 242, 146, 84, 169, 87, 170, 231, 57, 63, 109, 105, 142, 142, 165, 148, 153, 79, 87, 225, 120, 107, 93, 253, 78, 189, 16, 201, 82, 155, 179, 94, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32]))
-/// last_ancestors: {Alice: 43, Bob: 41, Carol: 39, Dave: 31, Eric: 23}
+/// cause: Response
+/// last_ancestors: {Alice: 43, Bob: 31, Carol: 34, Dave: 3, Eric: 8}
 
   "A_44" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_44</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 44, Bob: 41, Carol: 39, Dave: 31, Eric: 25}
+/// last_ancestors: {Alice: 44, Bob: 31, Carol: 34, Dave: 3, Eric: 9}
 
   "A_45" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_45</td></tr>
 </table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 45, Bob: 41, Carol: 39, Dave: 31, Eric: 25}
+/// cause: Request
+/// last_ancestors: {Alice: 45, Bob: 31, Carol: 36, Dave: 3, Eric: 9}
 
   "A_46" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_46</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 46, Bob: 41, Carol: 40, Dave: 31, Eric: 33}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 46, Bob: 31, Carol: 36, Dave: 3, Eric: 9}
 
-  "A_47" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_47" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_47</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 47, Bob: 41, Carol: 40, Dave: 31, Eric: 33}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 136, 92, 188, 212, 43, 57, 46, 74, 205, 188, 214, 175, 187, 122, 176, 82, 171, 36, 24, 45, 131, 181, 153, 28, 82, 239, 162, 2, 4, 162, 89, 60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 103, 2, 61, 187, 50, 65, 235, 155, 233, 175, 226, 184, 139, 3, 99, 113, 141, 8, 38, 248, 67, 213, 136, 29, 138, 173, 168, 60, 102, 52, 147, 13, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 71, 168, 189, 161, 56, 73, 168, 237, 4, 255, 236, 193, 94, 48, 211, 227, 116, 196, 213, 204, 12, 205, 177, 81, 10, 233, 75, 160, 27, 110, 186, 82, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 38, 78, 62, 136, 63, 81, 101, 63, 33, 242, 248, 202, 46, 185, 133, 2, 87, 168, 227, 151, 205, 236, 160, 82, 66, 167, 81, 218, 125, 0, 244, 35, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 6, 244, 190, 110, 69, 89, 34, 145, 60, 65, 3, 212, 1, 230, 245, 116, 62, 100, 147, 108, 150, 228, 201, 134, 194, 226, 244, 61, 51, 58, 27, 105, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32]))
+/// last_ancestors: {Alice: 47, Bob: 31, Carol: 36, Dave: 3, Eric: 9}
 
-  "A_48" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_48" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_48</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 48, Bob: 41, Carol: 40, Dave: 31, Eric: 33}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 138, 209, 191, 93, 247, 228, 110, 122, 173, 218, 222, 28, 255, 10, 55, 183, 127, 234, 196, 5, 37, 227, 146, 27, 173, 149, 159, 211, 132, 171, 95, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 133, 146, 214, 126, 62, 58, 211, 23, 59, 202, 22, 118, 19, 23, 95, 179, 168, 212, 214, 207, 58, 184, 108, 213, 205, 142, 76, 81, 234, 244, 88, 1, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 129, 83, 237, 159, 132, 143, 55, 181, 199, 21, 77, 207, 42, 199, 68, 3, 215, 150, 138, 163, 88, 101, 128, 194, 54, 5, 151, 248, 162, 229, 63, 88, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 124, 20, 4, 193, 203, 228, 155, 82, 85, 5, 133, 40, 63, 211, 108, 255, 255, 128, 156, 109, 110, 58, 90, 124, 87, 254, 67, 118, 8, 47, 57, 59, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 119, 213, 26, 226, 18, 58, 0, 240, 226, 244, 188, 129, 83, 223, 148, 251, 40, 107, 174, 55, 132, 15, 52, 54, 120, 247, 240, 243, 109, 120, 50, 30, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32]))
+/// last_ancestors: {Alice: 48, Bob: 31, Carol: 36, Dave: 3, Eric: 9}
 
-  "A_49" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_49" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_49</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 49, Bob: 41, Carol: 41, Dave: 31, Eric: 35}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 166, 15, 74, 142, 232, 34, 229, 209, 240, 100, 130, 138, 161, 104, 44, 124, 206, 3, 162, 127, 126, 101, 255, 66, 161, 51, 152, 195, 1, 231, 109, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 227, 4, 106, 115, 207, 23, 85, 215, 31, 127, 61, 172, 73, 124, 137, 237, 55, 40, 115, 42, 61, 21, 176, 102, 137, 241, 202, 186, 91, 136, 25, 81, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 31, 250, 137, 88, 183, 12, 197, 220, 79, 61, 250, 205, 238, 235, 40, 11, 156, 116, 162, 203, 243, 236, 38, 87, 41, 50, 96, 136, 98, 130, 215, 41, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 91, 239, 169, 61, 159, 1, 53, 226, 127, 251, 182, 239, 147, 91, 200, 40, 0, 193, 209, 108, 170, 196, 157, 71, 201, 114, 245, 85, 105, 124, 149, 2, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 152, 228, 201, 34, 134, 246, 164, 231, 174, 21, 114, 17, 60, 111, 37, 154, 105, 229, 162, 23, 105, 116, 78, 107, 177, 48, 40, 77, 195, 29, 65, 79, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32]))
+/// last_ancestors: {Alice: 49, Bob: 31, Carol: 36, Dave: 3, Eric: 9}
 
-  "A_50" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_50" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_50</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 50, Bob: 52, Carol: 43, Dave: 33, Eric: 35}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 6, 33, 58, 252, 200, 112, 193, 234, 219, 96, 230, 44, 255, 83, 233, 1, 59, 110, 37, 239, 8, 47, 124, 241, 59, 254, 65, 88, 239, 131, 130, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 151, 53, 21, 223, 142, 71, 247, 166, 241, 187, 131, 50, 184, 118, 235, 49, 159, 125, 60, 62, 184, 33, 205, 217, 188, 165, 238, 225, 184, 135, 83, 66, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 39, 74, 240, 193, 85, 30, 45, 99, 8, 187, 34, 56, 110, 245, 47, 14, 254, 180, 177, 131, 95, 60, 228, 142, 245, 207, 253, 65, 47, 228, 54, 9, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 184, 94, 203, 164, 27, 245, 98, 31, 30, 22, 192, 61, 39, 24, 50, 62, 98, 196, 200, 210, 14, 47, 53, 119, 118, 119, 170, 203, 248, 231, 7, 68, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 72, 115, 166, 135, 226, 203, 152, 219, 52, 21, 95, 67, 221, 150, 118, 26, 193, 251, 61, 24, 182, 73, 76, 44, 175, 161, 185, 43, 111, 68, 235, 10, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32]))
+/// last_ancestors: {Alice: 50, Bob: 31, Carol: 36, Dave: 3, Eric: 9}
 
   "A_51" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_51</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 51, Bob: 52, Carol: 43, Dave: 33, Eric: 36}
+/// last_ancestors: {Alice: 51, Bob: 31, Carol: 43, Dave: 3, Eric: 10}
 
   "A_52" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_52</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 52, Bob: 52, Carol: 50, Dave: 33, Eric: 36}
+/// last_ancestors: {Alice: 52, Bob: 41, Carol: 46, Dave: 4, Eric: 12}
 
   "A_53" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_53</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 53, Bob: 52, Carol: 50, Dave: 33, Eric: 36}
+/// cause: Request
+/// last_ancestors: {Alice: 53, Bob: 41, Carol: 47, Dave: 4, Eric: 12}
 
   "A_54" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_54</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 54, Bob: 52, Carol: 53, Dave: 33, Eric: 37}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 54, Bob: 41, Carol: 47, Dave: 4, Eric: 12}
 
   "A_55" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_55</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 55, Bob: 58, Carol: 56, Dave: 39, Eric: 39}
+/// cause: Response
+/// last_ancestors: {Alice: 55, Bob: 41, Carol: 51, Dave: 5, Eric: 15}
 
   "A_56" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_56</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 56, Bob: 58, Carol: 57, Dave: 39, Eric: 39}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 56, Bob: 41, Carol: 51, Dave: 5, Eric: 15}
 
   "A_57" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_57</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 57, Bob: 58, Carol: 57, Dave: 39, Eric: 39}
+/// cause: Request
+/// last_ancestors: {Alice: 57, Bob: 41, Carol: 52, Dave: 5, Eric: 15}
 
   "A_58" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_58</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 58, Bob: 58, Carol: 61, Dave: 40, Eric: 42}
+/// last_ancestors: {Alice: 58, Bob: 41, Carol: 53, Dave: 5, Eric: 15}
 
-  "A_59" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_59" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_59</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 59, Bob: 58, Carol: 61, Dave: 40, Eric: 42}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 245, 2, 14, 163, 49, 133, 31, 188, 153, 187, 166, 31, 182, 69, 13, 125, 76, 163, 100, 51, 161, 74, 14, 201, 125, 119, 119, 227, 176, 242, 65, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 135, 159, 192, 68, 148, 118, 149, 130, 192, 66, 38, 146, 69, 170, 215, 132, 94, 44, 70, 181, 180, 36, 48, 171, 28, 237, 81, 34, 11, 108, 132, 67, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 24, 60, 115, 230, 247, 103, 11, 73, 232, 109, 167, 4, 210, 106, 228, 56, 107, 221, 133, 45, 192, 38, 24, 90, 115, 229, 142, 55, 18, 62, 217, 4, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 170, 216, 37, 136, 90, 89, 129, 15, 15, 245, 38, 119, 97, 207, 174, 64, 125, 102, 103, 175, 211, 0, 58, 60, 18, 91, 105, 118, 108, 183, 27, 58, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 60, 117, 216, 41, 189, 74, 247, 213, 53, 124, 166, 233, 240, 51, 121, 72, 143, 239, 72, 49, 231, 218, 91, 30, 177, 208, 67, 181, 198, 48, 94, 111, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32]))
+/// last_ancestors: {Alice: 59, Bob: 41, Carol: 53, Dave: 5, Eric: 15}
 
-  "A_60" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_60" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_60</td></tr>
-</table>>]
+<tr><td colspan="6">[DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0))]</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 60, Bob: 58, Carol: 62, Dave: 40, Eric: 42}
+/// last_ancestors: {Alice: 60, Bob: 44, Carol: 58, Dave: 5, Eric: 16}
 
-  "A_61" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_61" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_61</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 61, Bob: 58, Carol: 63, Dave: 40, Eric: 42}
+<tr><td colspan="6">[DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0))]</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 61, Bob: 44, Carol: 58, Dave: 14, Eric: 25}
 
-  "A_62" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_62" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_62</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 62, Bob: 61, Carol: 67, Dave: 40, Eric: 43}
+/// cause: Requesting(Dave)
+/// last_ancestors: {Alice: 62, Bob: 44, Carol: 58, Dave: 14, Eric: 25}
 
-  "A_63" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_63" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_63</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 63, Bob: 61, Carol: 67, Dave: 45, Eric: 48}
+<tr><td colspan="6">[DkgMessage(DkgAck(0))]</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 63, Bob: 44, Carol: 60, Dave: 18, Eric: 25}
 
-  "A_64" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_64" [style=filled, fillcolor=orange, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_64</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 64, Bob: 61, Carol: 67, Dave: 45, Eric: 48}
+<tr><td colspan="6">[DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0))]</td></tr><tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 64, Bob: 51, Carol: 60, Dave: 22, Eric: 36}
 
-  "A_65" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_65" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_65</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 65, Bob: 61, Carol: 69, Dave: 48, Eric: 48}
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 65, Bob: 51, Carol: 60, Dave: 23, Eric: 36}
 
-  "A_66" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_66" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_66</td></tr>
-</table>>]
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 66, Bob: 67, Carol: 69, Dave: 52, Eric: 58}
+/// last_ancestors: {Alice: 66, Bob: 53, Carol: 60, Dave: 23, Eric: 38}
 
-  "A_67" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_67" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_67</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 67, Bob: 67, Carol: 69, Dave: 53, Eric: 58}
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 67, Bob: 53, Carol: 60, Dave: 23, Eric: 38}
 
-  "A_68" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "A_68" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">A_68</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 68, Bob: 69, Carol: 69, Dave: 53, Eric: 60}
-
-  "A_69" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_69</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 69, Bob: 69, Carol: 69, Dave: 53, Eric: 60}
-
-  "A_70" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_70</td></tr>
-</table>>]
+<tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
 /// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 70, Bob: 69, Carol: 69, Dave: 53, Eric: 60}
-
-  "A_71" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_71</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 71, Bob: 69, Carol: 69, Dave: 55, Eric: 64}
-
-  "A_72" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_72</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 72, Bob: 69, Carol: 73, Dave: 58, Eric: 64}
-
-  "A_73" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_73</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 73, Bob: 70, Carol: 73, Dave: 67, Eric: 66}
-
-  "A_74" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_74</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 74, Bob: 76, Carol: 82, Dave: 71, Eric: 68}
-
-  "A_75" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_75</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 75, Bob: 76, Carol: 84, Dave: 71, Eric: 68}
-
-  "A_76" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_76</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 76, Bob: 80, Carol: 84, Dave: 71, Eric: 71}
-
-  "A_77" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_77</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 77, Bob: 81, Carol: 84, Dave: 71, Eric: 71}
-
-  "A_78" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_78</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 78, Bob: 81, Carol: 84, Dave: 71, Eric: 71}
-
-  "A_79" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_79</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 79, Bob: 85, Carol: 87, Dave: 71, Eric: 72}
-
-  "A_80" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_80</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 80, Bob: 85, Carol: 88, Dave: 75, Eric: 72}
-
-  "A_81" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_81</td></tr>
-</table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 81, Bob: 85, Carol: 88, Dave: 75, Eric: 72}
-
-  "A_82" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_82</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 82, Bob: 85, Carol: 88, Dave: 75, Eric: 72}
-
-  "A_83" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_83</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 83, Bob: 98, Carol: 88, Dave: 79, Eric: 77}
-
-  "A_84" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_84</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 84, Bob: 98, Carol: 88, Dave: 80, Eric: 77}
-
-  "A_85" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_85</td></tr>
-</table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 85, Bob: 98, Carol: 88, Dave: 80, Eric: 77}
-
-  "A_86" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">A_86</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 86, Bob: 101, Carol: 88, Dave: 80, Eric: 77}
+/// last_ancestors: {Alice: 68, Bob: 53, Carol: 60, Dave: 23, Eric: 38}
 
   "B_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_0</td></tr>
@@ -1288,617 +880,332 @@ digraph GossipGraph {
 
   "B_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_1</td></tr>
-<tr><td colspan="6">Genesis({Alice, Bob, Carol, Dave, Eric})</td></tr>
+<tr><td colspan="6">Genesis({Alice, Bob, Carol})</td></tr>
 </table>>]
-/// cause: Observation(Genesis({Alice, Bob, Carol, Dave, Eric}))
+/// cause: Observation(Genesis({Alice, Bob, Carol}))
 /// last_ancestors: {Bob: 1}
 
-  "B_2" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_2</td></tr>
-<tr><td colspan="6">StartDkg({Alice, Bob, Carol, Dave, Eric})</td></tr>
 </table>>]
-/// cause: Observation(StartDkg({Alice, Bob, Carol, Dave, Eric}))
+/// cause: Requesting(Alice)
 /// last_ancestors: {Bob: 2}
 
   "B_3" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_3</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Bob: 3}
+/// cause: Response
+/// last_ancestors: {Alice: 3, Bob: 3}
 
   "B_4" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_4</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Bob: 4, Carol: 3}
+/// cause: Request
+/// last_ancestors: {Alice: 6, Bob: 4, Carol: 2}
 
   "B_5" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_5</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Bob: 5, Carol: 3}
+/// cause: Request
+/// last_ancestors: {Alice: 6, Bob: 5, Carol: 2}
 
   "B_6" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_6</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Bob: 6, Carol: 3}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 6, Bob: 6, Carol: 2}
 
   "B_7" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_7</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 3, Bob: 7, Carol: 3}
+/// cause: Request
+/// last_ancestors: {Alice: 6, Bob: 7, Carol: 3}
 
   "B_8" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_8</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 3, Bob: 8, Carol: 4}
-
-  "B_9" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_9</td></tr>
-</table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 4, Bob: 9, Carol: 4}
+/// last_ancestors: {Alice: 6, Bob: 8, Carol: 4}
+
+  "B_9" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_9</td></tr>
+<tr><td colspan="6">StartDkg({Alice, Bob, Carol, Dave, Eric})</td></tr>
+</table>>]
+/// cause: Observation(StartDkg({Alice, Bob, Carol, Dave, Eric}))
+/// last_ancestors: {Alice: 6, Bob: 9, Carol: 4}
 
   "B_10" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_10</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 4, Bob: 10, Carol: 4, Dave: 3}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 6, Bob: 10, Carol: 4}
 
   "B_11" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_11</td></tr>
 </table>>]
 /// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 4, Bob: 11, Carol: 4, Dave: 3}
+/// last_ancestors: {Alice: 6, Bob: 11, Carol: 4}
 
   "B_12" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_12</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 8, Bob: 12, Carol: 6, Dave: 6, Eric: 3}
+/// last_ancestors: {Alice: 12, Bob: 12, Carol: 5}
 
   "B_13" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_13</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 8, Bob: 13, Carol: 6, Dave: 6, Eric: 3}
+/// cause: Request
+/// last_ancestors: {Alice: 12, Bob: 13, Carol: 8}
 
   "B_14" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_14</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 8, Bob: 14, Carol: 9, Dave: 7, Eric: 3}
+/// cause: Response
+/// last_ancestors: {Alice: 13, Bob: 14, Carol: 8}
 
   "B_15" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_15</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 8, Bob: 15, Carol: 10, Dave: 7, Eric: 3}
+/// cause: Request
+/// last_ancestors: {Alice: 15, Bob: 15, Carol: 13}
 
   "B_16" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_16</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 15, Bob: 16, Carol: 11, Dave: 14, Eric: 6}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 15, Bob: 16, Carol: 13}
 
   "B_17" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_17</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 15, Bob: 17, Carol: 11, Dave: 14, Eric: 6}
+/// cause: Response
+/// last_ancestors: {Alice: 17, Bob: 17, Carol: 17}
 
   "B_18" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_18</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 17, Bob: 18, Carol: 16, Dave: 14, Eric: 6}
+/// cause: Request
+/// last_ancestors: {Alice: 18, Bob: 18, Carol: 17}
 
   "B_19" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_19</td></tr>
 </table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 17, Bob: 19, Carol: 16, Dave: 14, Eric: 6}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 18, Bob: 19, Carol: 17}
 
   "B_20" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_20</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 21, Bob: 20, Carol: 16, Dave: 14, Eric: 8}
+/// cause: Response
+/// last_ancestors: {Alice: 21, Bob: 20, Carol: 18}
 
   "B_21" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_21</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 21, Bob: 21, Carol: 19, Dave: 17, Eric: 8}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 21, Bob: 21, Carol: 18}
 
   "B_22" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_22</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 21, Bob: 22, Carol: 19, Dave: 17, Eric: 10}
+/// last_ancestors: {Alice: 22, Bob: 22, Carol: 18}
 
-  "B_23" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_23" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_23</td></tr>
+<tr><td colspan="6">DkgMessage(DkgPart(0))</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 21, Bob: 23, Carol: 19, Dave: 17, Eric: 10}
+/// cause: Observation(DkgMessage(DkgPart(0)), SerialisedDkgMessage([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 143, 109, 107, 205, 223, 15, 34, 217, 94, 2, 224, 245, 182, 211, 85, 189, 116, 97, 48, 47, 112, 41, 122, 50, 133, 226, 99, 97, 108, 151, 197, 65, 145, 217, 250, 167, 17, 112, 128, 255, 185, 47, 219, 50, 238, 18, 106, 83, 142, 43, 1, 127, 78, 192, 134, 73, 208, 40, 124, 88, 228, 78, 110, 233, 211, 177, 34, 223, 167, 120, 34, 213, 16, 124, 35, 18, 172, 83, 33, 35, 113, 173, 218, 141, 18, 132, 23, 232, 117, 174, 207, 18, 141, 222, 44, 82, 139, 149, 214, 93, 0, 146, 252, 84, 162, 145, 85, 33, 108, 152, 115, 70, 151, 160, 231, 183, 147, 234, 62, 21, 66, 176, 91, 228, 86, 233, 162, 64, 34, 188, 172, 206, 39, 34, 192, 151, 173, 104, 1, 180, 238, 39, 245, 68, 5, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 169, 182, 59, 238, 36, 49, 113, 248, 176, 201, 202, 166, 235, 241, 253, 51, 201, 64, 10, 98, 194, 149, 170, 27, 26, 49, 157, 200, 161, 15, 32, 107, 224, 165, 128, 230, 5, 8, 189, 81, 27, 79, 10, 9, 211, 44, 112, 114, 231, 187, 175, 212, 200, 247, 40, 52, 128, 59, 163, 99, 181, 57, 39, 69, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 220, 42, 232, 116, 198, 66, 199, 138, 20, 136, 135, 200, 105, 66, 107, 184, 166, 92, 251, 0, 120, 217, 73, 214, 254, 3, 164, 249, 113, 69, 5, 103, 140, 215, 84, 70, 107, 254, 35, 17, 212, 131, 89, 240, 36, 101, 181, 12, 236, 131, 204, 0, 212, 211, 120, 122, 211, 38, 162, 108, 71, 150, 123, 26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 15, 159, 148, 251, 103, 84, 29, 29, 120, 70, 68, 234, 231, 146, 216, 60, 132, 120, 236, 159, 45, 29, 233, 144, 227, 214, 170, 42, 66, 123, 234, 98, 57, 9, 41, 166, 207, 244, 138, 208, 139, 20, 167, 215, 121, 65, 184, 250, 245, 35, 139, 54, 231, 135, 2, 244, 110, 143, 62, 159, 44, 154, 189, 99, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 66, 19, 65, 130, 9, 102, 115, 175, 219, 4, 1, 12, 102, 227, 69, 193, 97, 148, 221, 62, 227, 96, 136, 75, 200, 169, 177, 91, 18, 177, 207, 94, 229, 58, 253, 5, 53, 235, 241, 143, 68, 73, 246, 190, 203, 121, 253, 148, 250, 235, 167, 98, 242, 99, 82, 58, 194, 122, 61, 168, 190, 246, 17, 57, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 117, 135, 237, 8, 171, 119, 201, 65, 63, 195, 189, 45, 228, 51, 179, 69, 63, 176, 206, 221, 152, 164, 39, 6, 173, 124, 184, 140, 226, 230, 180, 90, 145, 108, 209, 101, 154, 225, 88, 79, 253, 125, 69, 166, 29, 178, 66, 47, 255, 179, 196, 142, 253, 63, 162, 128, 21, 102, 60, 177, 80, 83, 102, 14, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53]))
+/// last_ancestors: {Alice: 22, Bob: 23, Carol: 18}
 
   "B_24" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_24</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 22, Bob: 24, Carol: 24, Dave: 17, Eric: 11}
+/// last_ancestors: {Alice: 29, Bob: 24, Carol: 25, Dave: 2}
 
   "B_25" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_25</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 25, Bob: 25, Carol: 24, Dave: 17, Eric: 11}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 29, Bob: 25, Carol: 25, Dave: 2}
 
   "B_26" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_26</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 25, Bob: 26, Carol: 24, Dave: 17, Eric: 11}
+/// cause: Response
+/// last_ancestors: {Alice: 32, Bob: 26, Carol: 25, Dave: 2}
 
   "B_27" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_27</td></tr>
 </table>>]
 /// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 25, Bob: 27, Carol: 24, Dave: 17, Eric: 11}
+/// last_ancestors: {Alice: 32, Bob: 27, Carol: 25, Dave: 2}
 
   "B_28" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_28</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 27, Bob: 28, Carol: 24, Dave: 18, Eric: 11}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 32, Bob: 28, Carol: 25, Dave: 2}
 
   "B_29" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_29</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 27, Bob: 29, Carol: 24, Dave: 20, Eric: 11}
+/// last_ancestors: {Alice: 32, Bob: 29, Carol: 25, Dave: 3}
 
-  "B_30" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_30" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_30</td></tr>
-<tr><td colspan="6">DkgMessage(DkgPart(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgPart(0)), SerialisedDkgMessage([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 149, 143, 248, 59, 10, 156, 133, 41, 35, 148, 248, 4, 180, 208, 116, 114, 227, 118, 155, 169, 5, 108, 154, 118, 22, 76, 137, 191, 191, 50, 76, 39, 136, 167, 112, 233, 113, 50, 129, 18, 104, 235, 236, 213, 242, 115, 181, 232, 163, 92, 155, 208, 49, 30, 50, 20, 199, 132, 212, 147, 82, 151, 119, 72, 27, 15, 151, 250, 213, 106, 227, 217, 38, 21, 201, 202, 215, 125, 60, 195, 246, 12, 120, 33, 6, 103, 254, 9, 151, 161, 112, 228, 55, 171, 161, 185, 148, 237, 77, 117, 232, 14, 129, 221, 219, 64, 166, 216, 73, 88, 143, 20, 31, 111, 49, 122, 149, 18, 177, 52, 48, 23, 193, 149, 251, 144, 102, 177, 136, 206, 23, 172, 85, 135, 73, 175, 227, 149, 65, 226, 239, 5, 177, 147, 5, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 75, 123, 16, 123, 48, 68, 103, 213, 186, 111, 118, 34, 59, 235, 13, 167, 4, 102, 196, 48, 213, 152, 251, 13, 182, 4, 243, 104, 50, 49, 122, 87, 226, 19, 68, 202, 132, 138, 104, 3, 30, 107, 202, 190, 225, 112, 94, 11, 115, 88, 21, 189, 123, 74, 160, 118, 110, 35, 2, 77, 122, 123, 238, 71, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 64, 31, 26, 21, 150, 64, 24, 105, 208, 208, 27, 194, 33, 23, 95, 181, 101, 13, 120, 78, 14, 190, 199, 165, 70, 130, 198, 208, 189, 116, 158, 107, 206, 131, 126, 250, 164, 24, 32, 115, 39, 25, 241, 221, 217, 17, 174, 180, 127, 49, 213, 82, 182, 151, 58, 34, 4, 76, 147, 8, 22, 12, 203, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 52, 195, 35, 175, 252, 60, 201, 252, 230, 213, 194, 97, 5, 159, 242, 111, 193, 220, 137, 98, 63, 11, 90, 10, 143, 130, 252, 14, 246, 16, 213, 11, 187, 243, 184, 42, 196, 166, 215, 226, 47, 35, 22, 253, 212, 86, 187, 177, 145, 226, 54, 242, 248, 188, 14, 1, 226, 241, 193, 237, 4, 68, 149, 59, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 41, 103, 45, 73, 98, 57, 122, 144, 252, 54, 104, 1, 236, 202, 67, 126, 34, 132, 61, 128, 120, 48, 38, 162, 31, 0, 208, 118, 129, 84, 249, 31, 168, 99, 243, 90, 227, 52, 143, 82, 56, 45, 59, 28, 208, 155, 200, 174, 163, 147, 152, 145, 59, 226, 226, 223, 191, 151, 240, 210, 243, 123, 95, 111, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 30, 11, 55, 227, 199, 53, 43, 36, 18, 152, 13, 161, 210, 246, 148, 140, 131, 43, 241, 157, 177, 85, 242, 57, 176, 125, 163, 222, 12, 152, 29, 52, 148, 211, 45, 139, 3, 195, 70, 194, 65, 219, 97, 59, 200, 60, 24, 88, 176, 108, 88, 39, 118, 47, 125, 139, 85, 192, 129, 142, 143, 12, 60, 47, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53]))
-/// last_ancestors: {Alice: 27, Bob: 30, Carol: 24, Dave: 20, Eric: 11}
+/// cause: Response
+/// last_ancestors: {Alice: 34, Bob: 30, Carol: 34, Dave: 3, Eric: 3}
 
   "B_31" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_31</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 31, Bob: 31, Carol: 29, Dave: 20, Eric: 13}
+/// last_ancestors: {Alice: 41, Bob: 31, Carol: 34, Dave: 3, Eric: 6}
 
   "B_32" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_32</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 31, Bob: 32, Carol: 29, Dave: 20, Eric: 13}
+/// cause: Requesting(Dave)
+/// last_ancestors: {Alice: 41, Bob: 32, Carol: 34, Dave: 3, Eric: 6}
 
   "B_33" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_33</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 33, Bob: 33, Carol: 29, Dave: 22, Eric: 13}
+/// last_ancestors: {Alice: 41, Bob: 33, Carol: 34, Dave: 4, Eric: 6}
 
   "B_34" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_34</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 33, Bob: 34, Carol: 32, Dave: 25, Eric: 17}
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 4, Eric: 12}
 
-  "B_35" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_35" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_35</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 33, Bob: 35, Carol: 32, Dave: 25, Eric: 17}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 103, 2, 61, 187, 50, 65, 235, 155, 233, 175, 226, 184, 139, 3, 99, 113, 141, 8, 38, 248, 67, 213, 136, 29, 138, 173, 168, 60, 102, 52, 147, 13, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 243, 217, 145, 1, 158, 63, 15, 173, 189, 51, 60, 169, 176, 104, 24, 126, 121, 140, 242, 248, 23, 169, 1, 152, 93, 212, 74, 169, 173, 202, 14, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 127, 177, 230, 71, 9, 62, 51, 190, 145, 183, 149, 153, 213, 205, 205, 138, 101, 16, 191, 249, 235, 124, 122, 18, 49, 251, 236, 21, 245, 96, 138, 66, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 11, 137, 59, 142, 116, 60, 87, 207, 101, 59, 239, 137, 250, 50, 131, 151, 81, 148, 139, 250, 191, 80, 243, 140, 4, 34, 143, 130, 60, 247, 5, 93, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 150, 96, 144, 212, 224, 58, 123, 224, 58, 99, 74, 122, 28, 244, 122, 80, 56, 64, 182, 241, 139, 76, 50, 212, 143, 203, 147, 197, 48, 230, 147, 3, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53]))
+/// last_ancestors: {Alice: 41, Bob: 35, Carol: 37, Dave: 4, Eric: 12}
 
-  "B_36" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_36" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_36</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 33, Bob: 36, Carol: 32, Dave: 25, Eric: 17}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 133, 146, 214, 126, 62, 58, 211, 23, 59, 202, 22, 118, 19, 23, 95, 179, 168, 212, 214, 207, 58, 184, 108, 213, 205, 142, 76, 81, 234, 244, 88, 1, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 183, 37, 60, 79, 59, 46, 84, 131, 128, 193, 194, 196, 5, 35, 55, 108, 236, 225, 74, 40, 18, 138, 203, 144, 245, 75, 198, 226, 58, 220, 182, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 233, 184, 161, 31, 56, 34, 213, 238, 197, 184, 110, 19, 248, 46, 15, 37, 48, 239, 190, 128, 233, 91, 42, 76, 29, 9, 64, 116, 139, 195, 20, 42, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 27, 76, 7, 240, 52, 22, 86, 90, 11, 176, 26, 98, 234, 58, 231, 221, 115, 252, 50, 217, 192, 45, 137, 7, 69, 198, 185, 5, 220, 170, 114, 62, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 77, 223, 108, 192, 49, 10, 215, 197, 80, 167, 198, 176, 220, 70, 191, 150, 183, 9, 167, 49, 152, 255, 231, 194, 108, 131, 51, 151, 44, 146, 208, 82, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53]))
+/// last_ancestors: {Alice: 41, Bob: 36, Carol: 37, Dave: 4, Eric: 12}
 
-  "B_37" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_37" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_37</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 33, Bob: 37, Carol: 32, Dave: 27, Eric: 20}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 227, 4, 106, 115, 207, 23, 85, 215, 31, 127, 61, 172, 73, 124, 137, 237, 55, 40, 115, 42, 61, 21, 176, 102, 137, 241, 202, 186, 91, 136, 25, 81, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 193, 196, 100, 26, 185, 200, 92, 174, 77, 181, 164, 55, 142, 137, 251, 214, 231, 71, 87, 172, 69, 123, 136, 106, 183, 68, 18, 19, 227, 105, 84, 39, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 160, 132, 95, 193, 161, 121, 100, 133, 122, 71, 10, 195, 213, 58, 43, 20, 157, 63, 221, 55, 86, 185, 154, 161, 45, 21, 247, 148, 189, 242, 124, 113, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 126, 68, 90, 104, 139, 42, 108, 92, 168, 125, 113, 78, 26, 72, 157, 253, 76, 95, 193, 185, 94, 31, 115, 165, 91, 104, 62, 237, 68, 212, 183, 71, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 92, 4, 85, 15, 117, 219, 115, 51, 214, 179, 216, 217, 94, 85, 15, 231, 252, 126, 165, 59, 103, 133, 75, 169, 137, 187, 133, 69, 204, 181, 242, 29, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53]))
+/// last_ancestors: {Alice: 41, Bob: 37, Carol: 37, Dave: 4, Eric: 12}
 
-  "B_38" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_38" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_38</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 34, Bob: 38, Carol: 32, Dave: 27, Eric: 20}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 151, 53, 21, 223, 142, 71, 247, 166, 241, 187, 131, 50, 184, 118, 235, 49, 159, 125, 60, 62, 184, 33, 205, 217, 188, 165, 238, 225, 184, 135, 83, 66, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 121, 71, 162, 76, 188, 242, 105, 229, 66, 37, 101, 255, 129, 46, 183, 33, 47, 247, 173, 124, 188, 41, 37, 188, 43, 10, 167, 159, 159, 252, 150, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 90, 89, 47, 186, 234, 157, 220, 35, 149, 50, 72, 204, 72, 66, 197, 189, 185, 152, 125, 177, 184, 89, 67, 107, 82, 241, 193, 51, 51, 202, 236, 44, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 60, 107, 188, 39, 24, 73, 79, 98, 230, 155, 41, 153, 18, 250, 144, 173, 73, 18, 239, 239, 188, 97, 155, 77, 193, 85, 122, 241, 25, 63, 48, 92, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 29, 125, 73, 149, 70, 244, 193, 160, 56, 169, 12, 102, 217, 13, 159, 73, 212, 179, 190, 36, 185, 145, 185, 252, 231, 60, 149, 133, 173, 12, 134, 23, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53]))
+/// last_ancestors: {Alice: 41, Bob: 38, Carol: 37, Dave: 4, Eric: 12}
 
   "B_39" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_39</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 34, Bob: 39, Carol: 32, Dave: 27, Eric: 21}
+/// last_ancestors: {Alice: 46, Bob: 39, Carol: 44, Dave: 4, Eric: 12}
 
   "B_40" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_40</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 34, Bob: 40, Carol: 36, Dave: 31, Eric: 21}
+/// last_ancestors: {Alice: 46, Bob: 40, Carol: 46, Dave: 4, Eric: 12}
 
   "B_41" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_41</td></tr>
 </table>>]
 /// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 34, Bob: 41, Carol: 36, Dave: 31, Eric: 21}
+/// last_ancestors: {Alice: 46, Bob: 41, Carol: 46, Dave: 4, Eric: 12}
 
   "B_42" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_42</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 35, Bob: 42, Carol: 36, Dave: 31, Eric: 21}
+/// last_ancestors: {Alice: 52, Bob: 42, Carol: 46, Dave: 4, Eric: 12}
 
   "B_43" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_43</td></tr>
 </table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 35, Bob: 43, Carol: 36, Dave: 31, Eric: 21}
+/// cause: Request
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 46, Dave: 5, Eric: 16}
 
   "B_44" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_44</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 35, Bob: 44, Carol: 36, Dave: 31, Eric: 21}
+/// cause: Request
+/// last_ancestors: {Alice: 56, Bob: 44, Carol: 54, Dave: 5, Eric: 16}
 
-  "B_45" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_45" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_45</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 35, Bob: 45, Carol: 36, Dave: 33, Eric: 21}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 135, 159, 192, 68, 148, 118, 149, 130, 192, 66, 38, 146, 69, 170, 215, 132, 94, 44, 70, 181, 180, 36, 48, 171, 28, 237, 81, 34, 11, 108, 132, 67, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 245, 245, 45, 42, 227, 193, 174, 224, 64, 94, 221, 219, 211, 238, 66, 153, 16, 230, 210, 83, 210, 74, 101, 227, 126, 221, 96, 138, 76, 22, 240, 89, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 99, 76, 155, 15, 50, 13, 200, 62, 193, 121, 148, 37, 98, 51, 174, 173, 194, 159, 95, 242, 239, 112, 154, 27, 225, 205, 111, 242, 141, 192, 91, 112, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 208, 162, 8, 245, 129, 88, 225, 156, 66, 57, 77, 111, 237, 211, 91, 110, 111, 129, 74, 135, 5, 191, 149, 32, 251, 64, 225, 48, 124, 195, 217, 18, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 62, 249, 117, 218, 208, 163, 250, 250, 194, 84, 4, 185, 123, 24, 199, 130, 33, 59, 215, 37, 35, 229, 202, 88, 93, 49, 240, 152, 189, 109, 69, 41, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53]))
+/// last_ancestors: {Alice: 56, Bob: 45, Carol: 54, Dave: 5, Eric: 16}
 
-  "B_46" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_46" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_46</td></tr>
+<tr><td colspan="6">[DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0))]</td></tr></table>>]
+/// cause: Request
+/// last_ancestors: {Alice: 56, Bob: 46, Carol: 54, Dave: 11, Eric: 26}
+
+  "B_47" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_47</td></tr>
+</table>>]
+/// cause: Requesting(Eric)
+/// last_ancestors: {Alice: 56, Bob: 47, Carol: 54, Dave: 11, Eric: 26}
+
+  "B_48" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_48</td></tr>
+<tr><td colspan="6">[DkgMessage(DkgAck(0))]</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 56, Bob: 48, Carol: 54, Dave: 12, Eric: 30}
+
+  "B_49" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_49</td></tr>
+</table>>]
+/// cause: Requesting(Eric)
+/// last_ancestors: {Alice: 56, Bob: 49, Carol: 54, Dave: 12, Eric: 30}
+
+  "B_50" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">B_50</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 36, Bob: 46, Carol: 43, Dave: 33, Eric: 24}
+/// last_ancestors: {Alice: 56, Bob: 50, Carol: 54, Dave: 12, Eric: 31}
 
-  "B_47" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_47</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
-</table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 68, 129, 178, 19, 163, 33, 127, 93, 97, 163, 9, 136, 67, 163, 179, 107, 109, 87, 252, 27, 117, 225, 129, 232, 222, 174, 191, 220, 198, 122, 0, 43, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 171, 83, 235, 10, 122, 71, 73, 84, 230, 111, 145, 52, 112, 118, 87, 85, 159, 88, 39, 57, 242, 188, 219, 103, 110, 113, 29, 183, 190, 24, 246, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 18, 38, 36, 2, 81, 109, 19, 75, 107, 60, 25, 225, 156, 73, 251, 62, 209, 89, 82, 86, 111, 152, 53, 231, 253, 51, 123, 145, 182, 182, 235, 96, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 120, 248, 92, 249, 40, 147, 221, 65, 241, 172, 162, 141, 198, 120, 225, 212, 253, 130, 219, 105, 228, 155, 85, 51, 69, 121, 59, 66, 91, 173, 243, 7, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 223, 202, 149, 240, 255, 184, 167, 56, 118, 121, 42, 58, 243, 75, 133, 190, 47, 132, 6, 135, 97, 119, 175, 178, 212, 59, 153, 28, 83, 75, 233, 34, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53]))
-/// last_ancestors: {Alice: 36, Bob: 47, Carol: 43, Dave: 33, Eric: 24}
-
-  "B_48" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_48</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
-</table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 3, 116, 13, 232, 218, 125, 192, 55, 120, 229, 107, 4, 255, 112, 39, 70, 136, 241, 109, 143, 221, 199, 110, 220, 216, 232, 147, 243, 96, 231, 39, 12, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 206, 250, 104, 41, 252, 52, 31, 63, 38, 145, 129, 245, 147, 107, 205, 161, 92, 63, 64, 128, 177, 183, 148, 210, 45, 32, 15, 120, 237, 156, 152, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 153, 129, 196, 106, 29, 236, 125, 70, 212, 60, 151, 230, 40, 102, 115, 253, 48, 141, 18, 113, 133, 167, 186, 200, 130, 87, 138, 252, 121, 82, 9, 89, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 99, 8, 32, 172, 63, 163, 220, 77, 131, 140, 174, 215, 186, 188, 91, 5, 0, 3, 67, 88, 81, 191, 166, 139, 143, 17, 104, 87, 179, 96, 140, 11, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 46, 143, 123, 237, 96, 90, 59, 85, 49, 56, 196, 200, 79, 183, 1, 97, 212, 80, 21, 73, 37, 175, 204, 129, 228, 72, 227, 219, 63, 22, 253, 49, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53]))
-/// last_ancestors: {Alice: 36, Bob: 48, Carol: 43, Dave: 33, Eric: 24}
-
-  "B_49" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_49</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
-</table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 129, 54, 86, 39, 17, 94, 98, 25, 103, 85, 231, 57, 59, 104, 229, 214, 247, 42, 57, 87, 164, 129, 193, 1, 164, 93, 100, 136, 64, 162, 95, 106, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 64, 157, 7, 31, 103, 44, 191, 167, 4, 168, 199, 137, 53, 164, 247, 115, 15, 160, 213, 200, 199, 35, 232, 216, 173, 21, 212, 2, 197, 206, 225, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 255, 3, 185, 22, 189, 250, 27, 54, 162, 250, 167, 217, 47, 224, 9, 17, 39, 21, 114, 58, 235, 197, 14, 176, 183, 205, 67, 125, 73, 251, 99, 71, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 190, 106, 106, 14, 19, 201, 120, 196, 63, 77, 136, 41, 42, 28, 28, 174, 62, 138, 14, 172, 14, 104, 53, 135, 193, 133, 179, 247, 205, 39, 230, 53, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 125, 209, 27, 6, 105, 151, 213, 82, 221, 159, 104, 121, 36, 88, 46, 75, 86, 255, 170, 29, 50, 10, 92, 94, 203, 61, 35, 114, 82, 84, 104, 36, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53]))
-/// last_ancestors: {Alice: 36, Bob: 49, Carol: 43, Dave: 33, Eric: 24}
-
-  "B_50" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_50</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
-</table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 14, 163, 152, 15, 59, 89, 56, 220, 247, 233, 12, 160, 251, 40, 13, 106, 229, 62, 77, 161, 196, 85, 2, 200, 74, 206, 89, 217, 211, 128, 105, 115, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 219, 38, 23, 10, 225, 113, 88, 79, 32, 167, 255, 125, 210, 150, 253, 202, 95, 152, 128, 234, 114, 21, 3, 183, 6, 157, 79, 184, 150, 229, 70, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 169, 170, 149, 4, 134, 138, 120, 194, 71, 192, 240, 91, 172, 168, 171, 127, 223, 201, 85, 61, 41, 173, 61, 217, 10, 233, 226, 192, 172, 241, 17, 15, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 119, 46, 20, 255, 42, 163, 152, 53, 111, 217, 225, 57, 134, 186, 89, 52, 95, 251, 42, 144, 223, 68, 120, 251, 14, 53, 118, 201, 194, 253, 220, 22, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 69, 178, 146, 249, 207, 187, 184, 168, 150, 242, 210, 23, 96, 204, 7, 233, 222, 44, 0, 227, 149, 220, 178, 29, 19, 129, 9, 210, 216, 9, 168, 30, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53]))
-/// last_ancestors: {Alice: 36, Bob: 50, Carol: 43, Dave: 33, Eric: 24}
-
-  "B_51" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_51" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_51</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 97, 237, 62, 234, 171, 35, 208, 133, 29, 225, 122, 169, 103, 199, 188, 58, 123, 36, 227, 35, 199, 61, 96, 29, 212, 24, 22, 212, 221, 99, 135, 46, 249, 113, 5, 251, 33, 55, 31, 7, 124, 72, 72, 234, 5, 181, 231, 108, 49, 117, 71, 80, 190, 172, 67, 29, 43, 4, 68, 197, 146, 144, 94, 21, 64, 0, 0, 0, 0, 0, 0, 0, 118, 173, 4, 158, 214, 106, 4, 251, 101, 254, 63, 108, 149, 237, 183, 11, 215, 141, 91, 149, 146, 88, 157, 238, 2, 228, 153, 93, 86, 55, 206, 99, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 138, 109, 202, 81, 2, 178, 56, 112, 175, 191, 6, 47, 192, 111, 245, 136, 45, 31, 50, 253, 85, 155, 160, 140, 233, 49, 128, 189, 123, 99, 39, 37, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 159, 45, 144, 5, 45, 249, 108, 229, 247, 220, 203, 241, 237, 149, 240, 89, 137, 136, 170, 110, 33, 182, 221, 93, 24, 253, 3, 71, 244, 54, 110, 90, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 179, 237, 85, 185, 88, 64, 161, 90, 65, 158, 146, 180, 24, 24, 46, 215, 223, 25, 129, 214, 228, 248, 224, 251, 254, 74, 234, 166, 25, 99, 199, 27, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53]))
-/// last_ancestors: {Alice: 36, Bob: 51, Carol: 43, Dave: 33, Eric: 24}
+/// cause: Requesting(Eric)
+/// last_ancestors: {Alice: 56, Bob: 51, Carol: 54, Dave: 12, Eric: 31}
 
-  "B_52" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_52" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_52</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 48, Bob: 52, Carol: 43, Dave: 33, Eric: 33}
+/// cause: Response
+/// last_ancestors: {Alice: 56, Bob: 52, Carol: 54, Dave: 12, Eric: 33}
 
-  "B_53" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "B_53" [style=filled, fillcolor=orange, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">B_53</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 48, Bob: 53, Carol: 43, Dave: 33, Eric: 33}
-
-  "B_54" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_54</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 48, Bob: 54, Carol: 43, Dave: 39, Eric: 33}
-
-  "B_55" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_55</td></tr>
-</table>>]
+<tr><td colspan="6">[DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0))]</td></tr><tr><td></td><td width="50">stage</td><td width="30">est</td><td width="30">bin</td><td width="30">aux</td><td width="30">dec</td></tr>
+<tr><td>A: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>B: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr>
+<tr><td>C: </td><td>0/0</td><td>t</td><td>-</td><td>-</td><td>-</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 48, Bob: 55, Carol: 51, Dave: 39, Eric: 39}
-
-  "B_56" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_56</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 53, Bob: 56, Carol: 54, Dave: 39, Eric: 39}
-
-  "B_57" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_57</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 53, Bob: 57, Carol: 56, Dave: 39, Eric: 39}
-
-  "B_58" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_58</td></tr>
-</table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 53, Bob: 58, Carol: 56, Dave: 39, Eric: 39}
-
-  "B_59" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_59</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 55, Bob: 59, Carol: 56, Dave: 39, Eric: 39}
-
-  "B_60" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_60</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 55, Bob: 60, Carol: 56, Dave: 40, Eric: 43}
-
-  "B_61" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_61</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 59, Bob: 61, Carol: 64, Dave: 40, Eric: 43}
-
-  "B_62" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_62</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 59, Bob: 62, Carol: 64, Dave: 42, Eric: 49}
-
-  "B_63" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_63</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 59, Bob: 63, Carol: 64, Dave: 42, Eric: 49}
-
-  "B_64" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_64</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 59, Bob: 64, Carol: 64, Dave: 43, Eric: 52}
-
-  "B_65" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_65</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 59, Bob: 65, Carol: 64, Dave: 43, Eric: 52}
-
-  "B_66" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_66</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 59, Bob: 66, Carol: 64, Dave: 43, Eric: 53}
-
-  "B_67" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_67</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 59, Bob: 67, Carol: 64, Dave: 43, Eric: 53}
-
-  "B_68" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_68</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 59, Bob: 68, Carol: 64, Dave: 43, Eric: 55}
-
-  "B_69" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_69</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 64, Bob: 69, Carol: 69, Dave: 49, Eric: 57}
-
-  "B_70" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_70</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 64, Bob: 70, Carol: 69, Dave: 49, Eric: 57}
-
-  "B_71" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_71</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 68, Bob: 71, Carol: 70, Dave: 61, Eric: 63}
-
-  "B_72" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_72</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 69, Bob: 72, Carol: 75, Dave: 62, Eric: 63}
-
-  "B_73" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_73</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 69, Bob: 73, Carol: 75, Dave: 62, Eric: 63}
-
-  "B_74" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_74</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 69, Bob: 74, Carol: 75, Dave: 62, Eric: 63}
-
-  "B_75" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_75</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 69, Bob: 75, Carol: 77, Dave: 62, Eric: 63}
-
-  "B_76" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_76</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 69, Bob: 76, Carol: 78, Dave: 62, Eric: 63}
-
-  "B_77" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_77</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 70, Bob: 77, Carol: 80, Dave: 64, Eric: 67}
-
-  "B_78" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_78</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 70, Bob: 78, Carol: 80, Dave: 64, Eric: 67}
-
-  "B_79" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_79</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 70, Bob: 79, Carol: 80, Dave: 68, Eric: 71}
-
-  "B_80" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_80</td></tr>
-</table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 70, Bob: 80, Carol: 80, Dave: 68, Eric: 71}
-
-  "B_81" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_81</td></tr>
-</table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 70, Bob: 81, Carol: 80, Dave: 68, Eric: 71}
-
-  "B_82" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_82</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 70, Bob: 82, Carol: 80, Dave: 68, Eric: 72}
-
-  "B_83" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_83</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 76, Bob: 83, Carol: 84, Dave: 71, Eric: 72}
-
-  "B_84" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_84</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 77, Bob: 84, Carol: 84, Dave: 71, Eric: 72}
-
-  "B_85" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_85</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 77, Bob: 85, Carol: 84, Dave: 71, Eric: 72}
-
-  "B_86" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_86</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 77, Bob: 86, Carol: 86, Dave: 71, Eric: 72}
-
-  "B_87" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_87</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 77, Bob: 87, Carol: 86, Dave: 71, Eric: 72}
-
-  "B_88" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_88</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 77, Bob: 88, Carol: 86, Dave: 71, Eric: 72}
-
-  "B_89" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_89</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 77, Bob: 89, Carol: 86, Dave: 71, Eric: 74}
-
-  "B_90" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_90</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 77, Bob: 90, Carol: 86, Dave: 71, Eric: 75}
-
-  "B_91" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_91</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 77, Bob: 91, Carol: 86, Dave: 71, Eric: 75}
-
-  "B_92" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_92</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 77, Bob: 92, Carol: 86, Dave: 71, Eric: 77}
-
-  "B_93" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_93</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 77, Bob: 93, Carol: 86, Dave: 71, Eric: 77}
-
-  "B_94" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_94</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 77, Bob: 94, Carol: 86, Dave: 71, Eric: 77}
-
-  "B_95" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_95</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 77, Bob: 95, Carol: 86, Dave: 71, Eric: 77}
-
-  "B_96" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_96</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 80, Bob: 96, Carol: 88, Dave: 79, Eric: 77}
-
-  "B_97" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_97</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 80, Bob: 97, Carol: 88, Dave: 79, Eric: 77}
-
-  "B_98" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_98</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 81, Bob: 98, Carol: 88, Dave: 79, Eric: 77}
-
-  "B_99" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_99</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 81, Bob: 99, Carol: 88, Dave: 79, Eric: 77}
-
-  "B_100" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_100</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 81, Bob: 100, Carol: 88, Dave: 79, Eric: 77}
-
-  "B_101" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">B_101</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 85, Bob: 101, Carol: 88, Dave: 80, Eric: 77}
+/// last_ancestors: {Alice: 62, Bob: 53, Carol: 60, Dave: 19, Eric: 35}
 
   "C_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_0</td></tr>
@@ -1908,539 +1215,371 @@ digraph GossipGraph {
 
   "C_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_1</td></tr>
-<tr><td colspan="6">Genesis({Alice, Bob, Carol, Dave, Eric})</td></tr>
+<tr><td colspan="6">Genesis({Alice, Bob, Carol})</td></tr>
 </table>>]
-/// cause: Observation(Genesis({Alice, Bob, Carol, Dave, Eric}))
+/// cause: Observation(Genesis({Alice, Bob, Carol}))
 /// last_ancestors: {Carol: 1}
 
-  "C_2" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_2</td></tr>
-<tr><td colspan="6">StartDkg({Alice, Bob, Carol, Dave, Eric})</td></tr>
 </table>>]
-/// cause: Observation(StartDkg({Alice, Bob, Carol, Dave, Eric}))
-/// last_ancestors: {Carol: 2}
+/// cause: Request
+/// last_ancestors: {Alice: 2, Carol: 2}
 
   "C_3" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_3</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Bob: 3, Carol: 3}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 2, Carol: 3}
 
   "C_4" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_4</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Bob: 3, Carol: 4}
+/// cause: Request
+/// last_ancestors: {Alice: 6, Bob: 6, Carol: 4}
 
   "C_5" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_5</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 3, Bob: 8, Carol: 5}
+/// cause: Request
+/// last_ancestors: {Alice: 9, Bob: 6, Carol: 5}
 
   "C_6" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_6</td></tr>
 </table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 3, Bob: 8, Carol: 6}
-
-  "C_7" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_7</td></tr>
-</table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 4, Bob: 10, Carol: 7, Dave: 5}
+/// last_ancestors: {Alice: 9, Bob: 7, Carol: 6}
+
+  "C_7" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">C_7</td></tr>
+<tr><td colspan="6">StartDkg({Alice, Bob, Carol, Dave, Eric})</td></tr>
+</table>>]
+/// cause: Observation(StartDkg({Alice, Bob, Carol, Dave, Eric}))
+/// last_ancestors: {Alice: 9, Bob: 7, Carol: 7}
 
   "C_8" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_8</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 5, Bob: 10, Carol: 8, Dave: 7}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 9, Bob: 7, Carol: 8}
 
   "C_9" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_9</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 5, Bob: 10, Carol: 9, Dave: 7}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 9, Bob: 7, Carol: 9}
 
   "C_10" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_10</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 8, Bob: 13, Carol: 10, Dave: 7, Eric: 3}
+/// last_ancestors: {Alice: 14, Bob: 11, Carol: 10}
 
   "C_11" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_11</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 10, Bob: 13, Carol: 11, Dave: 7, Eric: 3}
+/// cause: Response
+/// last_ancestors: {Alice: 14, Bob: 13, Carol: 11}
 
   "C_12" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_12</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 10, Bob: 14, Carol: 12, Dave: 7, Eric: 3}
+/// last_ancestors: {Alice: 15, Bob: 13, Carol: 12}
 
   "C_13" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_13</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 10, Bob: 14, Carol: 13, Dave: 7, Eric: 3}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 15, Bob: 13, Carol: 13}
 
   "C_14" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_14</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 17, Bob: 14, Carol: 14, Dave: 12, Eric: 6}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 15, Bob: 13, Carol: 14}
 
   "C_15" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_15</td></tr>
 </table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 17, Bob: 14, Carol: 15, Dave: 12, Eric: 6}
+/// cause: Response
+/// last_ancestors: {Alice: 15, Bob: 15, Carol: 15}
 
   "C_16" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_16</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 17, Bob: 17, Carol: 16, Dave: 14, Eric: 6}
+/// cause: Response
+/// last_ancestors: {Alice: 17, Bob: 15, Carol: 16}
 
   "C_17" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_17</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 18, Bob: 17, Carol: 17, Dave: 14, Eric: 6}
+/// cause: Request
+/// last_ancestors: {Alice: 17, Bob: 16, Carol: 17}
 
   "C_18" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_18</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 18, Bob: 17, Carol: 18, Dave: 17, Eric: 6}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 17, Bob: 16, Carol: 18}
 
   "C_19" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_19</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 18, Bob: 17, Carol: 19, Dave: 17, Eric: 6}
+/// cause: Response
+/// last_ancestors: {Alice: 19, Bob: 16, Carol: 19}
 
   "C_20" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_20</td></tr>
 </table>>]
 /// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 18, Bob: 17, Carol: 20, Dave: 17, Eric: 6}
+/// last_ancestors: {Alice: 19, Bob: 16, Carol: 20}
 
   "C_21" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_21</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 21, Bob: 21, Carol: 21, Dave: 17, Eric: 8}
+/// last_ancestors: {Alice: 23, Bob: 21, Carol: 21}
 
   "C_22" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_22</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 22, Bob: 21, Carol: 22, Dave: 17, Eric: 8}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 23, Bob: 21, Carol: 22}
 
-  "C_23" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_23" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_23</td></tr>
+<tr><td colspan="6">DkgMessage(DkgPart(0))</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 22, Bob: 21, Carol: 23, Dave: 17, Eric: 11}
+/// cause: Observation(DkgMessage(DkgPart(0)), SerialisedDkgMessage([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 129, 103, 165, 232, 126, 23, 137, 111, 236, 201, 114, 88, 32, 167, 31, 140, 47, 171, 161, 212, 183, 141, 252, 97, 168, 155, 130, 96, 94, 26, 255, 242, 80, 122, 11, 215, 216, 96, 61, 55, 146, 253, 76, 207, 175, 200, 95, 58, 135, 7, 16, 226, 228, 227, 131, 105, 121, 42, 184, 16, 80, 90, 19, 228, 45, 34, 249, 142, 143, 74, 77, 65, 52, 125, 135, 3, 66, 205, 88, 182, 214, 250, 54, 51, 61, 135, 228, 94, 245, 119, 57, 17, 6, 189, 59, 240, 142, 218, 50, 138, 247, 162, 108, 90, 61, 87, 195, 223, 153, 206, 94, 190, 5, 5, 253, 64, 110, 255, 22, 207, 1, 251, 147, 12, 128, 165, 86, 167, 172, 100, 134, 95, 170, 116, 179, 250, 147, 245, 17, 46, 35, 120, 155, 66, 5, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 106, 26, 42, 169, 0, 46, 117, 204, 192, 166, 197, 104, 252, 248, 140, 94, 106, 183, 114, 222, 199, 141, 136, 82, 1, 243, 2, 246, 250, 236, 175, 43, 61, 245, 31, 229, 230, 244, 111, 5, 47, 26, 187, 33, 168, 19, 93, 113, 105, 36, 209, 170, 190, 175, 176, 35, 232, 189, 50, 247, 89, 161, 171, 76, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 4, 69, 111, 204, 230, 102, 77, 0, 243, 236, 215, 32, 2, 203, 89, 176, 130, 48, 237, 158, 44, 215, 157, 47, 19, 33, 230, 56, 129, 255, 240, 6, 223, 191, 250, 166, 232, 176, 7, 215, 44, 146, 101, 139, 71, 177, 47, 61, 181, 247, 133, 139, 16, 62, 18, 55, 118, 208, 228, 129, 218, 136, 40, 74, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 159, 111, 180, 239, 203, 159, 37, 52, 36, 143, 232, 216, 10, 65, 228, 85, 160, 129, 9, 105, 153, 248, 236, 63, 109, 204, 102, 165, 90, 185, 31, 86, 129, 138, 213, 104, 234, 108, 159, 168, 42, 10, 16, 245, 230, 78, 2, 9, 1, 203, 58, 108, 98, 204, 115, 74, 4, 227, 150, 12, 91, 112, 165, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 57, 154, 249, 18, 178, 216, 253, 103, 86, 213, 250, 144, 16, 19, 177, 167, 184, 250, 131, 41, 254, 65, 2, 29, 127, 250, 73, 232, 224, 203, 96, 49, 35, 85, 176, 42, 236, 40, 55, 122, 40, 130, 186, 94, 134, 236, 212, 212, 76, 158, 239, 76, 180, 90, 213, 93, 146, 245, 72, 151, 219, 87, 34, 69, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 211, 196, 62, 54, 152, 17, 214, 155, 136, 27, 13, 73, 22, 229, 125, 249, 208, 115, 254, 233, 98, 139, 23, 250, 144, 40, 45, 43, 103, 222, 161, 12, 197, 31, 139, 236, 237, 228, 206, 75, 38, 250, 100, 200, 37, 138, 167, 160, 152, 113, 164, 45, 6, 233, 54, 113, 32, 8, 251, 33, 92, 63, 159, 66, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106]))
+/// last_ancestors: {Alice: 23, Bob: 21, Carol: 23}
 
   "C_24" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_24</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 22, Bob: 21, Carol: 24, Dave: 17, Eric: 11}
+/// cause: Response
+/// last_ancestors: {Alice: 25, Bob: 21, Carol: 24}
 
   "C_25" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_25</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 22, Bob: 24, Carol: 25, Dave: 17, Eric: 11}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 25, Bob: 21, Carol: 25}
 
   "C_26" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_26</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 22, Bob: 24, Carol: 26, Dave: 17, Eric: 11}
+/// cause: Response
+/// last_ancestors: {Alice: 27, Bob: 21, Carol: 26}
 
-  "C_27" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_27" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_27</td></tr>
-<tr><td colspan="6">DkgMessage(DkgPart(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgPart(0)), SerialisedDkgMessage([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 146, 65, 94, 29, 131, 12, 161, 31, 227, 114, 53, 217, 3, 132, 207, 113, 123, 6, 64, 102, 123, 156, 167, 168, 181, 177, 35, 124, 214, 129, 220, 18, 205, 139, 25, 135, 238, 62, 48, 11, 181, 204, 238, 12, 89, 235, 246, 64, 138, 72, 21, 120, 64, 84, 112, 150, 59, 69, 231, 40, 48, 68, 40, 34, 79, 246, 188, 18, 49, 187, 196, 60, 28, 254, 222, 78, 212, 194, 214, 122, 23, 0, 24, 152, 178, 110, 237, 39, 203, 194, 15, 44, 223, 171, 139, 16, 165, 208, 145, 34, 249, 213, 158, 240, 7, 63, 110, 207, 106, 215, 87, 33, 6, 68, 245, 198, 122, 153, 132, 164, 224, 132, 118, 182, 50, 56, 134, 31, 120, 162, 30, 127, 11, 76, 224, 158, 78, 101, 36, 19, 124, 122, 21, 206, 5, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 107, 198, 17, 38, 254, 252, 173, 244, 90, 213, 217, 65, 83, 7, 162, 255, 101, 117, 228, 57, 84, 142, 241, 250, 140, 137, 72, 180, 139, 123, 95, 58, 109, 93, 208, 246, 81, 146, 104, 180, 2, 21, 23, 163, 249, 159, 231, 95, 6, 221, 220, 117, 148, 21, 101, 16, 77, 81, 10, 41, 71, 83, 71, 50, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 221, 174, 121, 28, 204, 251, 180, 102, 220, 214, 129, 219, 22, 208, 15, 130, 59, 86, 209, 254, 247, 5, 40, 105, 79, 236, 97, 2, 207, 220, 10, 16, 103, 210, 56, 247, 214, 37, 202, 246, 132, 204, 135, 172, 44, 211, 163, 233, 49, 1, 43, 29, 125, 219, 89, 127, 143, 194, 93, 218, 247, 157, 245, 26, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 80, 151, 225, 18, 153, 250, 187, 216, 92, 52, 40, 117, 221, 60, 59, 88, 22, 15, 96, 205, 163, 85, 152, 10, 90, 204, 24, 122, 101, 229, 163, 89, 97, 71, 161, 247, 91, 185, 43, 57, 7, 132, 248, 181, 95, 6, 96, 115, 93, 37, 121, 196, 101, 161, 78, 238, 209, 51, 177, 139, 168, 232, 163, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 194, 127, 73, 9, 103, 249, 194, 74, 222, 53, 208, 14, 161, 5, 169, 218, 235, 239, 76, 146, 71, 205, 206, 120, 28, 47, 50, 200, 168, 70, 79, 47, 92, 188, 9, 248, 223, 76, 141, 123, 136, 151, 103, 191, 149, 221, 217, 80, 142, 33, 105, 117, 86, 63, 125, 144, 92, 34, 162, 102, 172, 218, 63, 96, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 52, 104, 177, 255, 52, 248, 201, 188, 95, 55, 120, 168, 100, 206, 22, 93, 193, 208, 57, 87, 235, 68, 5, 231, 222, 145, 75, 22, 236, 167, 250, 4, 86, 49, 114, 248, 100, 224, 238, 189, 10, 79, 216, 200, 200, 16, 150, 218, 185, 69, 183, 28, 63, 5, 114, 255, 158, 147, 245, 23, 93, 37, 238, 72, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106]))
-/// last_ancestors: {Alice: 22, Bob: 24, Carol: 27, Dave: 17, Eric: 11}
+/// cause: Requesting(Eric)
+/// last_ancestors: {Alice: 27, Bob: 21, Carol: 27}
 
   "C_28" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_28</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 31, Bob: 26, Carol: 28, Dave: 19, Eric: 13}
+/// cause: Request
+/// last_ancestors: {Alice: 31, Bob: 24, Carol: 28, Dave: 2}
 
   "C_29" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_29</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 31, Bob: 26, Carol: 29, Dave: 19, Eric: 13}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 31, Bob: 24, Carol: 29, Dave: 2}
 
   "C_30" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_30</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 31, Bob: 31, Carol: 30, Dave: 20, Eric: 13}
+/// cause: Request
+/// last_ancestors: {Alice: 31, Bob: 24, Carol: 30, Dave: 2, Eric: 3}
 
   "C_31" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_31</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 32, Bob: 31, Carol: 31, Dave: 25, Eric: 17}
+/// cause: Response
+/// last_ancestors: {Alice: 31, Bob: 24, Carol: 31, Dave: 2, Eric: 3}
 
   "C_32" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_32</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 32, Bob: 31, Carol: 32, Dave: 25, Eric: 17}
+/// cause: Requesting(Eric)
+/// last_ancestors: {Alice: 31, Bob: 24, Carol: 32, Dave: 2, Eric: 3}
 
   "C_33" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_33</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 33, Bob: 34, Carol: 33, Dave: 25, Eric: 17}
+/// last_ancestors: {Alice: 34, Bob: 25, Carol: 33, Dave: 2, Eric: 3}
 
   "C_34" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_34</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 33, Bob: 34, Carol: 34, Dave: 29, Eric: 19}
+/// last_ancestors: {Alice: 34, Bob: 28, Carol: 34, Dave: 2, Eric: 3}
 
   "C_35" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_35</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 33, Bob: 34, Carol: 35, Dave: 31, Eric: 19}
+/// cause: Response
+/// last_ancestors: {Alice: 36, Bob: 28, Carol: 35, Dave: 2, Eric: 7}
 
   "C_36" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_36</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 33, Bob: 34, Carol: 36, Dave: 31, Eric: 19}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 36, Bob: 28, Carol: 36, Dave: 2, Eric: 7}
 
   "C_37" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_37</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 34, Bob: 39, Carol: 37, Dave: 31, Eric: 23}
+/// last_ancestors: {Alice: 40, Bob: 28, Carol: 37, Dave: 2, Eric: 10}
 
   "C_38" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_38</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 34, Bob: 40, Carol: 38, Dave: 31, Eric: 23}
+/// last_ancestors: {Alice: 45, Bob: 31, Carol: 38, Dave: 3, Eric: 10}
 
-  "C_39" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_39" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_39</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 34, Bob: 40, Carol: 39, Dave: 31, Eric: 23}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 71, 168, 189, 161, 56, 73, 168, 237, 4, 255, 236, 193, 94, 48, 211, 227, 116, 196, 213, 204, 12, 205, 177, 81, 10, 233, 75, 160, 27, 110, 186, 82, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 127, 177, 230, 71, 9, 62, 51, 190, 145, 183, 149, 153, 213, 205, 205, 138, 101, 16, 191, 249, 235, 124, 122, 18, 49, 251, 236, 21, 245, 96, 138, 66, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 183, 186, 15, 238, 217, 50, 190, 142, 30, 112, 62, 113, 76, 107, 200, 49, 86, 92, 168, 38, 203, 44, 67, 211, 87, 13, 142, 139, 206, 83, 90, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 239, 195, 56, 148, 170, 39, 73, 95, 171, 40, 231, 72, 195, 8, 195, 216, 70, 168, 145, 83, 170, 220, 11, 148, 126, 31, 47, 1, 168, 70, 42, 34, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 39, 205, 97, 58, 123, 28, 212, 47, 56, 225, 143, 32, 58, 166, 189, 127, 55, 244, 122, 128, 137, 140, 212, 84, 165, 49, 208, 118, 129, 57, 250, 17, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106]))
+/// last_ancestors: {Alice: 45, Bob: 31, Carol: 39, Dave: 3, Eric: 10}
 
-  "C_40" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_40" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_40</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 34, Bob: 40, Carol: 40, Dave: 31, Eric: 24}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 129, 83, 237, 159, 132, 143, 55, 181, 199, 21, 77, 207, 42, 199, 68, 3, 215, 150, 138, 163, 88, 101, 128, 194, 54, 5, 151, 248, 162, 229, 63, 88, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 233, 184, 161, 31, 56, 34, 213, 238, 197, 184, 110, 19, 248, 46, 15, 37, 48, 239, 190, 128, 233, 91, 42, 76, 29, 9, 64, 116, 139, 195, 20, 42, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 82, 30, 86, 159, 234, 180, 114, 40, 195, 183, 142, 87, 200, 58, 151, 154, 142, 31, 149, 103, 130, 42, 14, 9, 76, 138, 134, 25, 199, 72, 215, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 186, 131, 10, 31, 158, 71, 16, 98, 193, 90, 176, 155, 149, 162, 97, 188, 231, 119, 201, 68, 19, 33, 184, 146, 50, 142, 47, 149, 175, 38, 172, 65, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 34, 233, 190, 158, 81, 218, 173, 155, 191, 253, 209, 223, 98, 10, 44, 222, 64, 208, 253, 33, 164, 23, 98, 28, 25, 146, 216, 16, 152, 4, 129, 19, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106]))
+/// last_ancestors: {Alice: 45, Bob: 31, Carol: 40, Dave: 3, Eric: 10}
 
-  "C_41" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_41" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_41</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 34, Bob: 40, Carol: 41, Dave: 31, Eric: 24}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 31, 250, 137, 88, 183, 12, 197, 220, 79, 61, 250, 205, 238, 235, 40, 11, 156, 116, 162, 203, 243, 236, 38, 87, 41, 50, 96, 136, 98, 130, 215, 41, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 160, 132, 95, 193, 161, 121, 100, 133, 122, 71, 10, 195, 213, 58, 43, 20, 157, 63, 221, 55, 86, 185, 154, 161, 45, 21, 247, 148, 189, 242, 124, 113, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 32, 15, 53, 42, 141, 230, 3, 46, 166, 245, 27, 184, 185, 229, 111, 201, 152, 50, 118, 154, 176, 173, 212, 184, 233, 122, 240, 119, 197, 187, 52, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 160, 153, 10, 147, 120, 83, 163, 214, 209, 163, 45, 173, 157, 144, 180, 126, 148, 37, 15, 253, 10, 162, 14, 208, 165, 224, 233, 90, 205, 132, 236, 24, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 33, 36, 224, 251, 98, 192, 66, 127, 252, 173, 61, 162, 132, 223, 182, 135, 149, 240, 73, 105, 109, 110, 130, 26, 170, 195, 128, 103, 40, 245, 145, 96, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106]))
+/// last_ancestors: {Alice: 45, Bob: 31, Carol: 41, Dave: 3, Eric: 10}
 
-  "C_42" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_42" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_42</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 36, Bob: 41, Carol: 42, Dave: 31, Eric: 24}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 39, 74, 240, 193, 85, 30, 45, 99, 8, 187, 34, 56, 110, 245, 47, 14, 254, 180, 177, 131, 95, 60, 228, 142, 245, 207, 253, 65, 47, 228, 54, 9, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 90, 89, 47, 186, 234, 157, 220, 35, 149, 50, 72, 204, 72, 66, 197, 189, 185, 152, 125, 177, 184, 89, 67, 107, 82, 241, 193, 51, 51, 202, 236, 44, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 141, 104, 110, 178, 127, 29, 140, 228, 33, 170, 109, 96, 35, 143, 90, 109, 117, 124, 73, 223, 17, 119, 162, 71, 175, 18, 134, 37, 55, 176, 162, 80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 191, 119, 173, 170, 21, 157, 59, 165, 175, 197, 148, 244, 250, 55, 50, 201, 43, 136, 115, 3, 99, 188, 199, 240, 195, 182, 172, 237, 231, 238, 106, 0, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 242, 134, 236, 162, 170, 28, 235, 101, 60, 61, 186, 136, 213, 132, 199, 120, 231, 107, 63, 49, 188, 217, 38, 205, 32, 216, 112, 223, 235, 212, 32, 36, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106]))
+/// last_ancestors: {Alice: 45, Bob: 31, Carol: 42, Dave: 3, Eric: 10}
 
   "C_43" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_43</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 36, Bob: 44, Carol: 43, Dave: 31, Eric: 24}
+/// last_ancestors: {Alice: 46, Bob: 31, Carol: 43, Dave: 3, Eric: 10}
 
-  "C_44" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_44" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_44</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 177, 222, 130, 10, 245, 179, 231, 17, 100, 184, 32, 43, 61, 67, 155, 203, 115, 52, 217, 145, 9, 247, 230, 248, 43, 0, 202, 5, 14, 206, 71, 93, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 18, 38, 36, 2, 81, 109, 19, 75, 107, 60, 25, 225, 156, 73, 251, 62, 209, 89, 82, 86, 111, 152, 53, 231, 253, 51, 123, 145, 182, 182, 235, 96, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 115, 109, 197, 249, 172, 38, 63, 132, 114, 192, 17, 151, 252, 79, 91, 178, 46, 127, 203, 26, 213, 57, 132, 213, 207, 103, 44, 29, 95, 159, 143, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 212, 180, 102, 241, 8, 224, 106, 189, 121, 68, 10, 77, 92, 86, 187, 37, 140, 164, 68, 223, 58, 219, 210, 195, 161, 155, 221, 168, 7, 136, 51, 104, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 53, 252, 7, 233, 100, 153, 150, 246, 128, 200, 2, 3, 188, 92, 27, 153, 233, 201, 189, 163, 160, 124, 33, 178, 115, 207, 142, 52, 176, 112, 215, 107, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106]))
-/// last_ancestors: {Alice: 36, Bob: 44, Carol: 44, Dave: 31, Eric: 24}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 46, Bob: 31, Carol: 44, Dave: 3, Eric: 10}
 
-  "C_45" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_45" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_45</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 171, 51, 240, 28, 36, 129, 49, 54, 251, 160, 30, 51, 136, 174, 30, 230, 197, 179, 86, 137, 230, 200, 87, 250, 73, 177, 120, 217, 27, 134, 2, 33, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 153, 129, 196, 106, 29, 236, 125, 70, 212, 60, 151, 230, 40, 102, 115, 253, 48, 141, 18, 113, 133, 167, 186, 200, 130, 87, 138, 252, 121, 82, 9, 89, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 134, 207, 152, 184, 23, 87, 202, 86, 174, 124, 17, 154, 198, 121, 10, 193, 150, 142, 44, 79, 28, 174, 227, 99, 115, 128, 254, 245, 132, 119, 34, 29, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 116, 29, 109, 6, 17, 194, 22, 103, 135, 24, 138, 77, 103, 49, 95, 216, 1, 104, 232, 54, 187, 140, 70, 50, 172, 38, 16, 25, 227, 67, 41, 85, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 97, 107, 65, 84, 11, 45, 99, 119, 97, 88, 4, 1, 5, 69, 246, 155, 103, 105, 2, 21, 82, 147, 111, 205, 156, 79, 132, 18, 238, 104, 66, 25, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106]))
-/// last_ancestors: {Alice: 36, Bob: 44, Carol: 45, Dave: 31, Eric: 24}
+/// cause: Response
+/// last_ancestors: {Alice: 46, Bob: 39, Carol: 45, Dave: 4, Eric: 12}
 
-  "C_46" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_46" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_46</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 136, 161, 142, 249, 233, 241, 36, 146, 24, 121, 194, 248, 82, 93, 161, 29, 116, 232, 82, 50, 2, 92, 5, 145, 157, 71, 253, 159, 72, 61, 48, 88, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 255, 3, 185, 22, 189, 250, 27, 54, 162, 250, 167, 217, 47, 224, 9, 17, 39, 21, 114, 58, 235, 197, 14, 176, 183, 205, 67, 125, 73, 251, 99, 71, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 118, 102, 227, 51, 144, 3, 19, 218, 43, 124, 141, 186, 12, 99, 114, 4, 218, 65, 145, 66, 212, 47, 24, 207, 209, 83, 138, 90, 74, 185, 151, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 237, 200, 13, 81, 99, 12, 10, 126, 181, 253, 114, 155, 233, 229, 218, 247, 140, 110, 176, 74, 189, 153, 33, 238, 235, 217, 208, 55, 75, 119, 203, 37, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 100, 43, 56, 110, 54, 21, 1, 34, 63, 127, 88, 124, 198, 104, 67, 235, 63, 155, 207, 82, 166, 3, 43, 13, 6, 96, 23, 21, 76, 53, 255, 20, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106]))
-/// last_ancestors: {Alice: 36, Bob: 44, Carol: 46, Dave: 31, Eric: 24}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 46, Bob: 39, Carol: 46, Dave: 4, Eric: 12}
 
-  "C_47" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_47" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_47</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 239, 182, 220, 217, 192, 227, 160, 223, 22, 249, 216, 94, 218, 245, 173, 33, 83, 191, 192, 84, 56, 200, 104, 11, 113, 116, 190, 252, 250, 84, 106, 71, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 169, 170, 149, 4, 134, 138, 120, 194, 71, 192, 240, 91, 172, 168, 171, 127, 223, 201, 85, 61, 41, 173, 61, 217, 10, 233, 226, 192, 172, 241, 17, 15, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 100, 158, 78, 47, 74, 49, 80, 165, 119, 227, 6, 89, 129, 255, 102, 49, 113, 172, 140, 47, 34, 106, 76, 218, 236, 218, 164, 174, 177, 53, 167, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 30, 146, 7, 90, 15, 216, 39, 136, 168, 170, 30, 86, 83, 178, 100, 143, 253, 182, 33, 24, 19, 79, 33, 168, 134, 79, 201, 114, 99, 210, 78, 18, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 217, 133, 192, 132, 211, 126, 255, 106, 216, 205, 52, 83, 40, 9, 32, 65, 143, 153, 88, 10, 12, 12, 48, 169, 104, 65, 139, 96, 104, 22, 228, 77, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106]))
-/// last_ancestors: {Alice: 36, Bob: 44, Carol: 47, Dave: 31, Eric: 24}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 46, Bob: 39, Carol: 47, Dave: 4, Eric: 12}
 
-  "C_48" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_48" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_48</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 244, 238, 90, 184, 0, 53, 110, 166, 124, 140, 33, 148, 115, 40, 203, 60, 46, 64, 41, 181, 255, 4, 76, 172, 143, 208, 223, 23, 233, 147, 241, 23, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 138, 109, 202, 81, 2, 178, 56, 112, 175, 191, 6, 47, 192, 111, 245, 136, 45, 31, 50, 253, 85, 155, 160, 140, 233, 49, 128, 189, 123, 99, 39, 37, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 32, 236, 57, 235, 3, 47, 3, 58, 226, 242, 235, 201, 12, 183, 31, 213, 44, 254, 58, 69, 172, 49, 245, 108, 67, 147, 32, 99, 14, 51, 93, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 182, 106, 169, 132, 5, 172, 205, 3, 21, 38, 209, 100, 89, 254, 73, 33, 44, 221, 67, 141, 2, 200, 73, 77, 157, 244, 192, 8, 161, 2, 147, 63, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 76, 233, 24, 30, 7, 41, 152, 205, 71, 89, 182, 255, 165, 69, 116, 109, 43, 188, 76, 213, 88, 94, 158, 45, 247, 85, 97, 174, 51, 210, 200, 76, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106]))
-/// last_ancestors: {Alice: 36, Bob: 44, Carol: 48, Dave: 31, Eric: 24}
+/// cause: Response
+/// last_ancestors: {Alice: 46, Bob: 40, Carol: 48, Dave: 4, Eric: 12}
 
   "C_49" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_49</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 38, Bob: 44, Carol: 49, Dave: 31, Eric: 34}
+/// cause: Request
+/// last_ancestors: {Alice: 46, Bob: 40, Carol: 49, Dave: 5, Eric: 15}
 
   "C_50" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_50</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 38, Bob: 44, Carol: 50, Dave: 31, Eric: 34}
+/// cause: Response
+/// last_ancestors: {Alice: 53, Bob: 41, Carol: 50, Dave: 5, Eric: 15}
 
   "C_51" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_51</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 47, Bob: 44, Carol: 51, Dave: 31, Eric: 37}
+/// last_ancestors: {Alice: 54, Bob: 41, Carol: 51, Dave: 5, Eric: 15}
 
   "C_52" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_52</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 52, Bob: 52, Carol: 52, Dave: 33, Eric: 37}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 54, Bob: 41, Carol: 52, Dave: 5, Eric: 15}
 
   "C_53" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_53</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 53, Bob: 52, Carol: 53, Dave: 33, Eric: 37}
+/// last_ancestors: {Alice: 56, Bob: 41, Carol: 53, Dave: 5, Eric: 15}
 
   "C_54" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_54</td></tr>
 </table>>]
 /// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 53, Bob: 52, Carol: 54, Dave: 33, Eric: 37}
+/// last_ancestors: {Alice: 56, Bob: 41, Carol: 54, Dave: 5, Eric: 15}
 
   "C_55" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_55</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 53, Bob: 56, Carol: 55, Dave: 39, Eric: 39}
+/// last_ancestors: {Alice: 57, Bob: 41, Carol: 55, Dave: 5, Eric: 15}
 
-  "C_56" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_56" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_56</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 53, Bob: 56, Carol: 56, Dave: 39, Eric: 39}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 24, 60, 115, 230, 247, 103, 11, 73, 232, 109, 167, 4, 210, 106, 228, 56, 107, 221, 133, 45, 192, 38, 24, 90, 115, 229, 142, 55, 18, 62, 217, 4, 13, 97, 221, 111, 254, 86, 159, 183, 65, 16, 32, 2, 110, 161, 149, 195, 35, 24, 127, 75, 210, 168, 13, 190, 119, 14, 70, 100, 183, 60, 150, 74, 64, 0, 0, 0, 0, 0, 0, 0, 99, 76, 155, 15, 50, 13, 200, 62, 193, 121, 148, 37, 98, 51, 174, 173, 194, 159, 95, 242, 239, 112, 154, 27, 225, 205, 111, 242, 141, 192, 91, 112, 244, 16, 216, 148, 223, 97, 128, 176, 61, 88, 104, 232, 107, 20, 114, 175, 18, 109, 56, 27, 108, 4, 78, 163, 92, 10, 2, 161, 37, 172, 200, 95, 64, 0, 0, 0, 0, 0, 0, 0, 173, 92, 195, 56, 109, 178, 132, 52, 155, 41, 131, 70, 239, 87, 186, 206, 20, 138, 151, 173, 23, 227, 226, 169, 6, 57, 179, 131, 182, 155, 240, 103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 247, 108, 235, 97, 168, 87, 65, 42, 117, 217, 113, 103, 124, 124, 198, 239, 102, 116, 207, 104, 63, 85, 43, 56, 44, 164, 246, 20, 223, 118, 133, 95, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 65, 125, 19, 139, 227, 252, 253, 31, 79, 137, 96, 136, 9, 161, 210, 16, 185, 94, 7, 36, 103, 199, 115, 198, 81, 15, 58, 166, 7, 82, 26, 87, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106]))
+/// last_ancestors: {Alice: 57, Bob: 41, Carol: 56, Dave: 5, Eric: 15}
 
-  "C_57" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_57" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_57</td></tr>
-</table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 53, Bob: 56, Carol: 57, Dave: 39, Eric: 39}
+<tr><td colspan="6">[DkgMessage(DkgAck(0))]</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 57, Bob: 44, Carol: 57, Dave: 5, Eric: 16}
 
-  "C_58" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_58" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_58</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 53, Bob: 57, Carol: 58, Dave: 39, Eric: 39}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 57, Bob: 44, Carol: 58, Dave: 5, Eric: 16}
 
-  "C_59" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_59" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_59</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 53, Bob: 57, Carol: 59, Dave: 40, Eric: 42}
+<tr><td colspan="6">[DkgMessage(DkgAck(0))]</td></tr></table>>]
+/// cause: Response
+/// last_ancestors: {Alice: 60, Bob: 44, Carol: 59, Dave: 5, Eric: 16}
 
-  "C_60" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "C_60" [style=filled, fillcolor=crimson, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">C_60</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 56, Bob: 58, Carol: 60, Dave: 40, Eric: 42}
-
-  "C_61" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_61</td></tr>
-</table>>]
+<tr><td colspan="6">[DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0))]</td></tr></table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 57, Bob: 58, Carol: 61, Dave: 40, Eric: 42}
-
-  "C_62" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_62</td></tr>
-</table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 57, Bob: 58, Carol: 62, Dave: 40, Eric: 42}
-
-  "C_63" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_63</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 59, Bob: 58, Carol: 63, Dave: 40, Eric: 42}
-
-  "C_64" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_64</td></tr>
-</table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 59, Bob: 58, Carol: 64, Dave: 40, Eric: 42}
-
-  "C_65" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_65</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 60, Bob: 58, Carol: 65, Dave: 40, Eric: 42}
-
-  "C_66" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_66</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 60, Bob: 61, Carol: 66, Dave: 40, Eric: 43}
-
-  "C_67" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_67</td></tr>
-</table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 60, Bob: 61, Carol: 67, Dave: 40, Eric: 43}
-
-  "C_68" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_68</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 62, Bob: 61, Carol: 68, Dave: 40, Eric: 43}
-
-  "C_69" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_69</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 62, Bob: 61, Carol: 69, Dave: 44, Eric: 48}
-
-  "C_70" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_70</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 62, Bob: 61, Carol: 70, Dave: 44, Eric: 48}
-
-  "C_71" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_71</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 67, Bob: 67, Carol: 71, Dave: 58, Eric: 58}
-
-  "C_72" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_72</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 67, Bob: 67, Carol: 72, Dave: 58, Eric: 58}
-
-  "C_73" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_73</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 69, Bob: 69, Carol: 73, Dave: 58, Eric: 60}
-
-  "C_74" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_74</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 69, Bob: 70, Carol: 74, Dave: 62, Eric: 63}
-
-  "C_75" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_75</td></tr>
-</table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 69, Bob: 70, Carol: 75, Dave: 62, Eric: 63}
-
-  "C_76" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_76</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 69, Bob: 72, Carol: 76, Dave: 62, Eric: 63}
-
-  "C_77" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_77</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 69, Bob: 73, Carol: 77, Dave: 62, Eric: 63}
-
-  "C_78" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_78</td></tr>
-</table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 69, Bob: 73, Carol: 78, Dave: 62, Eric: 63}
-
-  "C_79" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_79</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 70, Bob: 73, Carol: 79, Dave: 64, Eric: 67}
-
-  "C_80" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_80</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 70, Bob: 74, Carol: 80, Dave: 64, Eric: 67}
-
-  "C_81" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_81</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 70, Bob: 76, Carol: 81, Dave: 64, Eric: 67}
-
-  "C_82" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_82</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 70, Bob: 76, Carol: 82, Dave: 64, Eric: 67}
-
-  "C_83" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_83</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 73, Bob: 76, Carol: 83, Dave: 70, Eric: 68}
-
-  "C_84" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_84</td></tr>
-</table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 73, Bob: 76, Carol: 84, Dave: 70, Eric: 68}
-
-  "C_85" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_85</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 75, Bob: 76, Carol: 85, Dave: 71, Eric: 68}
-
-  "C_86" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_86</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 77, Bob: 85, Carol: 86, Dave: 71, Eric: 72}
-
-  "C_87" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_87</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 78, Bob: 85, Carol: 87, Dave: 71, Eric: 72}
-
-  "C_88" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">C_88</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 78, Bob: 85, Carol: 88, Dave: 73, Eric: 72}
+/// last_ancestors: {Alice: 60, Bob: 44, Carol: 60, Dave: 13, Eric: 25}
 
   "D_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_0</td></tr>
@@ -2450,491 +1589,147 @@ digraph GossipGraph {
 
   "D_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_1</td></tr>
-<tr><td colspan="6">Genesis({Alice, Bob, Carol, Dave, Eric})</td></tr>
+<tr><td colspan="6">DkgMessage(DkgPart(0))</td></tr>
 </table>>]
-/// cause: Observation(Genesis({Alice, Bob, Carol, Dave, Eric}))
+/// cause: Observation(DkgMessage(DkgPart(0)), SerialisedDkgMessage([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 153, 214, 11, 59, 238, 108, 251, 147, 36, 179, 216, 87, 66, 86, 185, 74, 102, 222, 28, 192, 122, 43, 169, 165, 29, 64, 172, 153, 44, 169, 250, 120, 216, 141, 253, 233, 158, 224, 170, 88, 166, 132, 63, 235, 151, 37, 8, 31, 161, 176, 88, 107, 95, 151, 61, 22, 88, 93, 92, 201, 35, 72, 115, 134, 66, 254, 133, 85, 108, 189, 252, 246, 148, 187, 109, 74, 55, 176, 235, 240, 50, 28, 245, 144, 47, 245, 171, 112, 59, 100, 65, 83, 6, 49, 25, 2, 151, 63, 220, 229, 233, 92, 127, 75, 118, 199, 129, 128, 136, 22, 227, 133, 54, 78, 220, 69, 57, 131, 188, 30, 251, 134, 32, 248, 132, 134, 224, 51, 97, 146, 194, 81, 73, 209, 159, 137, 44, 151, 229, 155, 19, 32, 241, 49, 5, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 118, 12, 95, 25, 2, 154, 139, 46, 197, 97, 71, 39, 73, 213, 164, 37, 220, 54, 176, 169, 97, 20, 101, 60, 3, 212, 50, 248, 120, 39, 159, 64, 145, 20, 219, 226, 197, 214, 53, 188, 21, 91, 157, 5, 185, 34, 2, 48, 100, 15, 23, 79, 175, 242, 80, 232, 128, 167, 172, 137, 201, 3, 209, 58, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 181, 35, 136, 113, 97, 156, 132, 104, 160, 82, 162, 101, 238, 190, 31, 66, 15, 4, 203, 255, 179, 25, 117, 247, 77, 65, 54, 36, 210, 18, 16, 19, 226, 17, 141, 109, 45, 171, 114, 62, 81, 105, 225, 204, 201, 183, 203, 239, 143, 121, 113, 62, 4, 8, 88, 226, 110, 100, 184, 189, 230, 116, 67, 47, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 245, 58, 177, 201, 191, 158, 125, 162, 122, 159, 251, 163, 150, 76, 88, 178, 71, 169, 135, 95, 14, 247, 190, 229, 224, 43, 215, 121, 126, 165, 110, 89, 51, 15, 63, 248, 148, 127, 175, 192, 140, 119, 37, 148, 218, 76, 149, 175, 187, 227, 203, 45, 89, 29, 95, 220, 92, 33, 196, 241, 3, 230, 181, 35, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 52, 82, 218, 33, 31, 161, 118, 220, 85, 144, 86, 226, 59, 54, 211, 206, 122, 118, 162, 181, 96, 252, 206, 160, 43, 153, 218, 165, 215, 144, 223, 43, 132, 12, 241, 130, 252, 83, 236, 66, 200, 133, 105, 91, 235, 225, 94, 111, 231, 77, 38, 29, 174, 50, 102, 214, 74, 222, 207, 37, 33, 87, 40, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 116, 105, 3, 122, 125, 163, 111, 22, 48, 221, 175, 32, 228, 195, 11, 63, 179, 27, 95, 21, 187, 217, 24, 143, 190, 131, 123, 251, 131, 35, 62, 114, 213, 9, 163, 13, 100, 40, 41, 197, 3, 148, 173, 34, 252, 118, 40, 47, 19, 184, 128, 12, 3, 72, 109, 208, 56, 155, 219, 89, 62, 200, 154, 12, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218]))
 /// last_ancestors: {Dave: 1}
 
-  "D_2" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "D_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_2</td></tr>
-<tr><td colspan="6">StartDkg({Alice, Bob, Carol, Dave, Eric})</td></tr>
 </table>>]
-/// cause: Observation(StartDkg({Alice, Bob, Carol, Dave, Eric}))
-/// last_ancestors: {Dave: 2}
+/// cause: Request
+/// last_ancestors: {Alice: 26, Bob: 21, Carol: 22, Dave: 2}
 
   "D_3" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_3</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Dave: 3}
+/// cause: Request
+/// last_ancestors: {Alice: 32, Bob: 27, Carol: 25, Dave: 3}
 
   "D_4" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_4</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 4, Bob: 10, Carol: 4, Dave: 4}
+/// cause: Request
+/// last_ancestors: {Alice: 41, Bob: 32, Carol: 34, Dave: 4, Eric: 6}
 
   "D_5" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_5</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 4, Bob: 10, Carol: 6, Dave: 5}
+/// cause: Requesting(Eric)
+/// last_ancestors: {Alice: 41, Bob: 32, Carol: 34, Dave: 5, Eric: 6}
 
   "D_6" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_6</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 5, Bob: 10, Carol: 6, Dave: 6}
-
-  "D_7" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_7</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 5, Bob: 10, Carol: 6, Dave: 7}
-
-  "D_8" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_8</td></tr>
-</table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 5, Bob: 10, Carol: 8, Dave: 8}
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 6, Eric: 14}
 
-  "D_9" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "D_7" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_7</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
+</table>>]
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 38, 78, 62, 136, 63, 81, 101, 63, 33, 242, 248, 202, 46, 185, 133, 2, 87, 168, 227, 151, 205, 236, 160, 82, 66, 167, 81, 218, 125, 0, 244, 35, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 11, 137, 59, 142, 116, 60, 87, 207, 101, 59, 239, 137, 250, 50, 131, 151, 81, 148, 139, 250, 191, 80, 243, 140, 4, 34, 143, 130, 60, 247, 5, 93, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 239, 195, 56, 148, 170, 39, 73, 95, 171, 40, 231, 72, 195, 8, 195, 216, 70, 168, 145, 83, 170, 220, 11, 148, 126, 31, 47, 1, 168, 70, 42, 34, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 212, 254, 53, 154, 223, 18, 59, 239, 239, 113, 221, 7, 143, 130, 192, 109, 65, 148, 57, 182, 156, 64, 94, 206, 64, 154, 108, 169, 102, 61, 60, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 184, 57, 51, 160, 21, 254, 44, 127, 53, 95, 213, 198, 87, 88, 0, 175, 54, 168, 63, 15, 135, 204, 118, 213, 186, 151, 12, 40, 210, 140, 96, 32, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218]))
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 7, Eric: 14}
+
+  "D_8" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+<tr><td colspan="6">D_8</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
+</table>>]
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 124, 20, 4, 193, 203, 228, 155, 82, 85, 5, 133, 40, 63, 211, 108, 255, 255, 128, 156, 109, 110, 58, 90, 124, 87, 254, 67, 118, 8, 47, 57, 59, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 27, 76, 7, 240, 52, 22, 86, 90, 11, 176, 26, 98, 234, 58, 231, 221, 115, 252, 50, 217, 192, 45, 137, 7, 69, 198, 185, 5, 220, 170, 114, 62, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 186, 131, 10, 31, 158, 71, 16, 98, 193, 90, 176, 155, 149, 162, 97, 188, 231, 119, 201, 68, 19, 33, 184, 146, 50, 142, 47, 149, 175, 38, 172, 65, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 89, 187, 13, 78, 7, 121, 202, 105, 119, 5, 70, 213, 64, 10, 220, 154, 91, 243, 95, 176, 101, 20, 231, 29, 32, 86, 165, 36, 131, 162, 229, 68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 248, 242, 16, 125, 112, 170, 132, 113, 45, 176, 219, 14, 236, 113, 86, 121, 207, 110, 246, 27, 184, 7, 22, 169, 13, 30, 27, 180, 86, 30, 31, 72, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218]))
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 8, Eric: 14}
+
+  "D_9" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_9</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 13, Bob: 13, Carol: 11, Dave: 9, Eric: 5}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 91, 239, 169, 61, 159, 1, 53, 226, 127, 251, 182, 239, 147, 91, 200, 40, 0, 193, 209, 108, 170, 196, 157, 71, 201, 114, 245, 85, 105, 124, 149, 2, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 126, 68, 90, 104, 139, 42, 108, 92, 168, 125, 113, 78, 26, 72, 157, 253, 76, 95, 193, 185, 94, 31, 115, 165, 91, 104, 62, 237, 68, 212, 183, 71, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 160, 153, 10, 147, 120, 83, 163, 214, 209, 163, 45, 173, 157, 144, 180, 126, 148, 37, 15, 253, 10, 162, 14, 208, 165, 224, 233, 90, 205, 132, 236, 24, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 195, 238, 186, 189, 100, 124, 218, 80, 250, 37, 232, 11, 36, 125, 137, 83, 225, 195, 254, 73, 191, 252, 227, 45, 56, 214, 50, 242, 168, 220, 14, 94, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 229, 67, 107, 232, 81, 165, 17, 203, 35, 76, 164, 106, 167, 197, 160, 212, 40, 138, 76, 141, 107, 127, 127, 88, 130, 78, 222, 95, 49, 141, 67, 47, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218]))
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 9, Eric: 14}
 
-  "D_10" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "D_10" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_10</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 13, Bob: 13, Carol: 11, Dave: 10, Eric: 5}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 184, 94, 203, 164, 27, 245, 98, 31, 30, 22, 192, 61, 39, 24, 50, 62, 98, 196, 200, 210, 14, 47, 53, 119, 118, 119, 170, 203, 248, 231, 7, 68, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 60, 107, 188, 39, 24, 73, 79, 98, 230, 155, 41, 153, 18, 250, 144, 173, 73, 18, 239, 239, 188, 97, 155, 77, 193, 85, 122, 241, 25, 63, 48, 92, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 191, 119, 173, 170, 21, 157, 59, 165, 175, 197, 148, 244, 250, 55, 50, 201, 43, 136, 115, 3, 99, 188, 199, 240, 195, 182, 172, 237, 231, 238, 106, 0, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 67, 132, 158, 45, 18, 241, 39, 232, 119, 75, 254, 79, 230, 25, 145, 56, 19, 214, 153, 32, 17, 239, 45, 199, 14, 149, 124, 19, 9, 70, 147, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 199, 144, 143, 176, 14, 69, 20, 43, 64, 209, 103, 171, 209, 251, 239, 167, 250, 35, 192, 61, 191, 33, 148, 157, 89, 115, 76, 57, 42, 157, 187, 48, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218]))
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 10, Eric: 14}
 
   "D_11" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_11</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 13, Bob: 13, Carol: 11, Dave: 11, Eric: 6}
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 49, Dave: 11, Eric: 23}
 
   "D_12" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_12</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 13, Bob: 13, Carol: 11, Dave: 12, Eric: 6}
+/// cause: Request
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 49, Dave: 12, Eric: 25}
 
   "D_13" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_13</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 15, Bob: 13, Carol: 11, Dave: 13, Eric: 6}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 49, Dave: 13, Eric: 25}
 
   "D_14" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_14</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 15, Bob: 13, Carol: 11, Dave: 14, Eric: 6}
+/// cause: Requesting(Alice)
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 49, Dave: 14, Eric: 25}
 
-  "D_15" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "D_15" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_15</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 16, Bob: 13, Carol: 11, Dave: 15, Eric: 6}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 170, 216, 37, 136, 90, 89, 129, 15, 15, 245, 38, 119, 97, 207, 174, 64, 125, 102, 103, 175, 211, 0, 58, 60, 18, 91, 105, 118, 108, 183, 27, 58, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 208, 162, 8, 245, 129, 88, 225, 156, 66, 57, 77, 111, 237, 211, 91, 110, 111, 129, 74, 135, 5, 191, 149, 32, 251, 64, 225, 48, 124, 195, 217, 18, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 247, 108, 235, 97, 168, 87, 65, 42, 117, 217, 113, 103, 124, 124, 198, 239, 102, 116, 207, 104, 63, 85, 43, 56, 44, 164, 246, 20, 223, 118, 133, 95, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 29, 55, 206, 206, 207, 86, 161, 183, 168, 29, 152, 95, 8, 129, 115, 29, 89, 143, 178, 64, 113, 19, 135, 28, 21, 138, 110, 207, 238, 130, 67, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 67, 1, 177, 59, 247, 85, 1, 69, 220, 97, 190, 87, 148, 133, 32, 75, 75, 170, 149, 24, 163, 209, 226, 0, 254, 111, 230, 137, 254, 142, 1, 17, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218]))
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 49, Dave: 15, Eric: 25}
 
   "D_16" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_16</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 16, Bob: 16, Carol: 11, Dave: 16, Eric: 6}
+/// last_ancestors: {Alice: 60, Bob: 44, Carol: 60, Dave: 16, Eric: 25}
 
   "D_17" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_17</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 17, Bob: 16, Carol: 15, Dave: 17, Eric: 6}
+/// cause: Response
+/// last_ancestors: {Alice: 61, Bob: 44, Carol: 60, Dave: 17, Eric: 25}
 
   "D_18" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_18</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 24, Bob: 20, Carol: 20, Dave: 18, Eric: 8}
+/// last_ancestors: {Alice: 62, Bob: 44, Carol: 60, Dave: 18, Eric: 25}
 
   "D_19" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_19</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 24, Bob: 20, Carol: 20, Dave: 19, Eric: 8}
+/// cause: Request
+/// last_ancestors: {Alice: 62, Bob: 49, Carol: 60, Dave: 19, Eric: 32}
 
   "D_20" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_20</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 25, Bob: 27, Carol: 24, Dave: 20, Eric: 11}
+/// cause: Requesting(Eric)
+/// last_ancestors: {Alice: 62, Bob: 49, Carol: 60, Dave: 20, Eric: 32}
 
   "D_21" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_21</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 28, Bob: 27, Carol: 24, Dave: 21, Eric: 11}
+/// last_ancestors: {Alice: 62, Bob: 51, Carol: 60, Dave: 21, Eric: 36}
 
   "D_22" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_22</td></tr>
 </table>>]
 /// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 28, Bob: 27, Carol: 24, Dave: 22, Eric: 11}
+/// last_ancestors: {Alice: 62, Bob: 51, Carol: 60, Dave: 22, Eric: 36}
 
-  "D_23" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "D_23" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">D_23</td></tr>
-<tr><td colspan="6">DkgMessage(DkgPart(0))</td></tr>
-</table>>]
-/// cause: Observation(DkgMessage(DkgPart(0)), SerialisedDkgMessage([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 128, 149, 181, 112, 251, 146, 66, 236, 25, 81, 132, 140, 50, 226, 157, 80, 39, 17, 221, 214, 4, 245, 113, 12, 78, 219, 9, 183, 179, 231, 110, 242, 149, 20, 248, 25, 12, 107, 238, 124, 8, 129, 52, 227, 168, 77, 59, 251, 164, 144, 176, 199, 56, 32, 90, 218, 187, 24, 41, 240, 161, 202, 163, 183, 213, 5, 71, 103, 214, 242, 199, 250, 189, 148, 230, 33, 32, 71, 10, 102, 9, 28, 0, 196, 172, 232, 253, 92, 83, 238, 205, 18, 139, 26, 52, 193, 137, 218, 60, 24, 95, 56, 228, 106, 98, 1, 138, 7, 73, 15, 59, 34, 194, 80, 238, 68, 22, 60, 30, 62, 174, 155, 5, 244, 182, 224, 67, 73, 46, 128, 14, 78, 140, 220, 140, 157, 43, 209, 130, 205, 87, 235, 114, 227, 5, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 114, 96, 229, 130, 96, 54, 221, 39, 5, 178, 50, 188, 8, 218, 175, 245, 249, 215, 99, 151, 224, 244, 255, 175, 104, 12, 149, 47, 221, 196, 208, 26, 8, 107, 56, 210, 215, 147, 194, 120, 176, 127, 217, 190, 26, 153, 121, 154, 129, 149, 187, 228, 101, 178, 125, 194, 65, 103, 54, 65, 91, 66, 190, 97, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 193, 207, 164, 47, 188, 143, 5, 139, 202, 166, 8, 234, 61, 136, 21, 230, 218, 221, 250, 219, 120, 7, 97, 247, 81, 40, 87, 228, 104, 206, 239, 7, 192, 102, 177, 247, 84, 206, 92, 142, 156, 174, 222, 79, 253, 223, 207, 240, 28, 77, 62, 123, 43, 122, 96, 10, 82, 53, 13, 164, 215, 211, 111, 98, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 17, 63, 100, 220, 22, 233, 45, 238, 142, 247, 220, 23, 118, 218, 56, 42, 193, 187, 51, 42, 25, 242, 251, 113, 131, 193, 182, 194, 71, 127, 252, 104, 120, 98, 42, 29, 210, 8, 247, 163, 136, 221, 227, 224, 223, 38, 38, 71, 184, 4, 193, 17, 241, 65, 67, 82, 98, 3, 228, 6, 84, 101, 33, 99, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 96, 174, 35, 137, 114, 66, 86, 81, 84, 236, 178, 69, 171, 136, 158, 26, 162, 193, 202, 110, 177, 4, 93, 185, 108, 221, 120, 119, 211, 136, 27, 86, 48, 94, 163, 66, 79, 67, 145, 185, 116, 12, 233, 113, 194, 109, 124, 157, 83, 188, 67, 168, 182, 9, 38, 154, 114, 209, 186, 105, 208, 246, 210, 99, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 175, 29, 227, 53, 206, 155, 126, 180, 25, 225, 136, 115, 224, 54, 4, 11, 131, 199, 97, 179, 73, 23, 190, 0, 86, 249, 58, 44, 95, 146, 58, 67, 232, 89, 28, 104, 204, 125, 43, 207, 96, 59, 238, 2, 165, 180, 210, 243, 238, 115, 198, 62, 124, 209, 8, 226, 130, 159, 145, 204, 76, 136, 132, 100, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218]))
-/// last_ancestors: {Alice: 28, Bob: 27, Carol: 24, Dave: 23, Eric: 11}
-
-  "D_24" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_24</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 32, Bob: 27, Carol: 26, Dave: 24, Eric: 13}
-
-  "D_25" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_25</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 32, Bob: 27, Carol: 26, Dave: 25, Eric: 13}
-
-  "D_26" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_26</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 32, Bob: 27, Carol: 26, Dave: 26, Eric: 16}
-
-  "D_27" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_27</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 32, Bob: 27, Carol: 26, Dave: 27, Eric: 16}
-
-  "D_28" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_28</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 32, Bob: 31, Carol: 31, Dave: 28, Eric: 19}
-
-  "D_29" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_29</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 32, Bob: 31, Carol: 31, Dave: 29, Eric: 19}
-
-  "D_30" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_30</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 33, Bob: 34, Carol: 34, Dave: 30, Eric: 19}
-
-  "D_31" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_31</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 33, Bob: 34, Carol: 34, Dave: 31, Eric: 19}
-
-  "D_32" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_32</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 33, Bob: 34, Carol: 35, Dave: 32, Eric: 19}
-
-  "D_33" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_33</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 35, Bob: 43, Carol: 36, Dave: 33, Eric: 21}
-
-  "D_34" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_34</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
-</table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 29, 60, 83, 1, 72, 70, 80, 198, 103, 113, 57, 206, 51, 63, 197, 215, 116, 57, 20, 254, 149, 52, 18, 214, 48, 212, 54, 5, 2, 122, 161, 27, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 120, 248, 92, 249, 40, 147, 221, 65, 241, 172, 162, 141, 198, 120, 225, 212, 253, 130, 219, 105, 228, 155, 85, 51, 69, 121, 59, 66, 91, 173, 243, 7, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 212, 180, 102, 241, 8, 224, 106, 189, 121, 68, 10, 77, 92, 86, 187, 37, 140, 164, 68, 223, 58, 219, 210, 195, 161, 155, 221, 168, 7, 136, 51, 104, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 47, 113, 112, 233, 233, 44, 248, 56, 3, 128, 115, 12, 239, 143, 215, 34, 21, 238, 11, 75, 137, 66, 22, 33, 182, 64, 226, 229, 96, 187, 133, 84, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 138, 45, 122, 225, 202, 121, 133, 180, 140, 187, 220, 203, 129, 201, 243, 31, 158, 55, 211, 182, 215, 169, 89, 126, 202, 229, 230, 34, 186, 238, 215, 64, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218]))
-/// last_ancestors: {Alice: 35, Bob: 43, Carol: 36, Dave: 34, Eric: 21}
-
-  "D_35" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_35</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
-</table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 83, 243, 210, 81, 109, 132, 162, 52, 126, 92, 209, 97, 17, 236, 21, 134, 3, 118, 63, 131, 239, 201, 64, 24, 187, 121, 93, 191, 214, 36, 221, 53, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 99, 8, 32, 172, 63, 163, 220, 77, 131, 140, 174, 215, 186, 188, 91, 5, 0, 3, 67, 88, 81, 191, 166, 139, 143, 17, 104, 87, 179, 96, 140, 11, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 116, 29, 109, 6, 17, 194, 22, 103, 135, 24, 138, 77, 103, 49, 95, 216, 1, 104, 232, 54, 187, 140, 70, 50, 172, 38, 16, 25, 227, 67, 41, 85, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 132, 50, 186, 96, 227, 224, 80, 128, 140, 72, 103, 195, 16, 2, 165, 87, 254, 244, 235, 11, 29, 130, 172, 165, 128, 190, 26, 177, 191, 127, 216, 42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 148, 71, 7, 187, 181, 255, 138, 153, 145, 120, 68, 57, 186, 210, 234, 214, 250, 129, 239, 224, 126, 119, 18, 25, 85, 86, 37, 73, 156, 187, 135, 0, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218]))
-/// last_ancestors: {Alice: 35, Bob: 43, Carol: 36, Dave: 35, Eric: 21}
-
-  "D_36" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_36</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
-</table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 143, 12, 199, 203, 194, 133, 231, 10, 202, 156, 157, 183, 106, 82, 93, 100, 240, 165, 108, 13, 96, 54, 73, 32, 151, 49, 150, 183, 80, 216, 0, 70, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 190, 106, 106, 14, 19, 201, 120, 196, 63, 77, 136, 41, 42, 28, 28, 174, 62, 138, 14, 172, 14, 104, 53, 135, 193, 133, 179, 247, 205, 39, 230, 53, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 237, 200, 13, 81, 99, 12, 10, 126, 181, 253, 114, 155, 233, 229, 218, 247, 140, 110, 176, 74, 189, 153, 33, 238, 235, 217, 208, 55, 75, 119, 203, 37, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 28, 39, 177, 147, 179, 79, 155, 55, 43, 174, 93, 13, 169, 175, 153, 65, 219, 82, 82, 233, 107, 203, 13, 85, 22, 46, 238, 119, 200, 198, 176, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 75, 133, 84, 214, 3, 147, 44, 241, 160, 94, 72, 127, 104, 121, 88, 139, 41, 55, 244, 135, 26, 253, 249, 187, 64, 130, 11, 184, 69, 22, 150, 5, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218]))
-/// last_ancestors: {Alice: 35, Bob: 43, Carol: 36, Dave: 36, Eric: 21}
-
-  "D_37" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_37</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
-</table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 208, 202, 32, 164, 70, 110, 9, 227, 53, 8, 165, 29, 185, 194, 78, 217, 192, 63, 52, 8, 172, 58, 207, 78, 151, 26, 35, 32, 34, 41, 107, 27, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 119, 46, 20, 255, 42, 163, 152, 53, 111, 217, 225, 57, 134, 186, 89, 52, 95, 251, 42, 144, 223, 68, 120, 251, 14, 53, 118, 201, 194, 253, 220, 22, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 30, 146, 7, 90, 15, 216, 39, 136, 168, 170, 30, 86, 83, 178, 100, 143, 253, 182, 33, 24, 19, 79, 33, 168, 134, 79, 201, 114, 99, 210, 78, 18, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 197, 245, 250, 180, 243, 12, 183, 218, 225, 123, 91, 114, 32, 170, 111, 234, 155, 114, 24, 160, 70, 89, 202, 84, 254, 105, 28, 28, 4, 167, 192, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 108, 89, 238, 15, 216, 65, 70, 45, 27, 77, 152, 142, 237, 161, 122, 69, 58, 46, 15, 40, 122, 99, 115, 1, 118, 132, 111, 197, 164, 123, 50, 9, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218]))
-/// last_ancestors: {Alice: 35, Bob: 43, Carol: 36, Dave: 37, Eric: 21}
-
-  "D_38" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_38</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
-</table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 135, 240, 118, 134, 85, 70, 12, 199, 219, 55, 200, 126, 127, 137, 217, 62, 225, 91, 111, 70, 56, 204, 55, 59, 75, 136, 169, 91, 244, 195, 91, 1, 64, 166, 31, 111, 80, 243, 237, 218, 128, 99, 235, 161, 18, 51, 51, 204, 36, 139, 54, 91, 248, 119, 68, 247, 194, 139, 63, 119, 46, 98, 167, 250, 64, 0, 0, 0, 0, 0, 0, 0, 159, 45, 144, 5, 45, 249, 108, 229, 247, 220, 203, 241, 237, 149, 240, 89, 137, 136, 170, 110, 33, 182, 221, 93, 24, 253, 3, 71, 244, 54, 110, 90, 185, 215, 26, 148, 113, 196, 242, 221, 252, 43, 163, 75, 23, 134, 212, 160, 21, 254, 113, 11, 70, 219, 7, 234, 233, 143, 123, 178, 188, 242, 249, 239, 64, 0, 0, 0, 0, 0, 0, 0, 182, 106, 169, 132, 5, 172, 205, 3, 21, 38, 209, 100, 89, 254, 73, 33, 44, 221, 67, 141, 2, 200, 73, 77, 157, 244, 192, 8, 161, 2, 147, 63, 77, 199, 194, 0, 174, 165, 114, 109, 193, 115, 203, 163, 124, 146, 166, 15, 7, 147, 73, 16, 42, 223, 73, 73, 181, 133, 121, 19, 153, 94, 49, 176, 64, 0, 0, 0, 0, 0, 0, 0, 205, 167, 194, 3, 222, 94, 46, 34, 50, 111, 214, 215, 196, 102, 163, 232, 206, 49, 221, 171, 227, 217, 181, 60, 34, 236, 125, 202, 77, 206, 183, 36, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 228, 228, 219, 130, 182, 17, 143, 64, 79, 184, 219, 74, 48, 207, 252, 175, 113, 134, 118, 202, 196, 235, 33, 44, 167, 227, 58, 140, 250, 153, 220, 9, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218]))
-/// last_ancestors: {Alice: 35, Bob: 43, Carol: 36, Dave: 38, Eric: 21}
-
-  "D_39" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_39</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 48, Bob: 53, Carol: 43, Dave: 39, Eric: 33}
-
-  "D_40" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_40</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 48, Bob: 53, Carol: 43, Dave: 40, Eric: 33}
-
-  "D_41" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_41</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 48, Bob: 55, Carol: 51, Dave: 41, Eric: 41}
-
-  "D_42" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_42</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 55, Bob: 60, Carol: 59, Dave: 42, Eric: 46}
-
-  "D_43" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_43</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 55, Bob: 60, Carol: 59, Dave: 43, Eric: 48}
-
-  "D_44" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_44</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 55, Bob: 60, Carol: 59, Dave: 44, Eric: 48}
-
-  "D_45" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_45</td></tr>
 </table>>]
 /// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 55, Bob: 60, Carol: 59, Dave: 45, Eric: 48}
-
-  "D_46" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_46</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 62, Bob: 61, Carol: 69, Dave: 46, Eric: 48}
-
-  "D_47" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_47</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 63, Bob: 61, Carol: 69, Dave: 47, Eric: 48}
-
-  "D_48" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_48</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 64, Bob: 61, Carol: 69, Dave: 48, Eric: 48}
-
-  "D_49" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_49</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 64, Bob: 65, Carol: 69, Dave: 49, Eric: 54}
-
-  "D_50" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_50</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 64, Bob: 65, Carol: 69, Dave: 50, Eric: 54}
-
-  "D_51" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_51</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 64, Bob: 67, Carol: 69, Dave: 51, Eric: 58}
-
-  "D_52" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_52</td></tr>
-</table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 64, Bob: 67, Carol: 69, Dave: 52, Eric: 58}
-
-  "D_53" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_53</td></tr>
-</table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 64, Bob: 67, Carol: 69, Dave: 53, Eric: 58}
-
-  "D_54" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_54</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 64, Bob: 67, Carol: 69, Dave: 54, Eric: 58}
-
-  "D_55" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_55</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 64, Bob: 67, Carol: 69, Dave: 55, Eric: 58}
-
-  "D_56" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_56</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 67, Bob: 67, Carol: 69, Dave: 56, Eric: 58}
-
-  "D_57" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_57</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 67, Bob: 67, Carol: 69, Dave: 57, Eric: 58}
-
-  "D_58" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_58</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 67, Bob: 67, Carol: 70, Dave: 58, Eric: 58}
-
-  "D_59" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_59</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 67, Bob: 69, Carol: 70, Dave: 59, Eric: 61}
-
-  "D_60" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_60</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 68, Bob: 69, Carol: 70, Dave: 60, Eric: 63}
-
-  "D_61" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_61</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 68, Bob: 70, Carol: 70, Dave: 61, Eric: 63}
-
-  "D_62" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_62</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 68, Bob: 70, Carol: 72, Dave: 62, Eric: 63}
-
-  "D_63" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_63</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 68, Bob: 70, Carol: 72, Dave: 63, Eric: 63}
-
-  "D_64" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_64</td></tr>
-</table>>]
-/// cause: Requesting(Eric)
-/// last_ancestors: {Alice: 68, Bob: 70, Carol: 72, Dave: 64, Eric: 63}
-
-  "D_65" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_65</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 70, Bob: 70, Carol: 72, Dave: 65, Eric: 65}
-
-  "D_66" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_66</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 70, Bob: 70, Carol: 72, Dave: 66, Eric: 66}
-
-  "D_67" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_67</td></tr>
-</table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 70, Bob: 70, Carol: 72, Dave: 67, Eric: 66}
-
-  "D_68" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_68</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 70, Bob: 70, Carol: 72, Dave: 68, Eric: 68}
-
-  "D_69" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_69</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 73, Bob: 70, Carol: 73, Dave: 69, Eric: 68}
-
-  "D_70" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_70</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 73, Bob: 76, Carol: 82, Dave: 70, Eric: 68}
-
-  "D_71" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_71</td></tr>
-</table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 73, Bob: 76, Carol: 82, Dave: 71, Eric: 68}
-
-  "D_72" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_72</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 74, Bob: 76, Carol: 82, Dave: 72, Eric: 68}
-
-  "D_73" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_73</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 74, Bob: 76, Carol: 82, Dave: 73, Eric: 68}
-
-  "D_74" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_74</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 78, Bob: 85, Carol: 88, Dave: 74, Eric: 72}
-
-  "D_75" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_75</td></tr>
-</table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 78, Bob: 85, Carol: 88, Dave: 75, Eric: 72}
-
-  "D_76" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_76</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 78, Bob: 93, Carol: 88, Dave: 76, Eric: 77}
-
-  "D_77" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_77</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 80, Bob: 93, Carol: 88, Dave: 77, Eric: 77}
-
-  "D_78" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_78</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 80, Bob: 94, Carol: 88, Dave: 78, Eric: 77}
-
-  "D_79" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_79</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 80, Bob: 95, Carol: 88, Dave: 79, Eric: 77}
-
-  "D_80" [fillcolor=white, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">D_80</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 82, Bob: 95, Carol: 88, Dave: 80, Eric: 77}
+/// last_ancestors: {Alice: 62, Bob: 51, Carol: 60, Dave: 23, Eric: 36}
 
   "E_0" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_0</td></tr>
@@ -2944,566 +1739,388 @@ digraph GossipGraph {
 
   "E_1" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_1</td></tr>
-<tr><td colspan="6">Genesis({Alice, Bob, Carol, Dave, Eric})</td></tr>
+<tr><td colspan="6">DkgMessage(DkgPart(0))</td></tr>
 </table>>]
-/// cause: Observation(Genesis({Alice, Bob, Carol, Dave, Eric}))
+/// cause: Observation(DkgMessage(DkgPart(0)), SerialisedDkgMessage([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 136, 217, 247, 127, 224, 233, 179, 208, 7, 15, 195, 123, 160, 0, 213, 170, 4, 204, 169, 113, 41, 176, 63, 235, 108, 150, 215, 97, 157, 230, 226, 26, 6, 118, 100, 241, 62, 26, 241, 206, 173, 7, 54, 30, 179, 238, 239, 218, 169, 204, 166, 224, 188, 143, 14, 85, 16, 82, 88, 154, 5, 178, 41, 126, 246, 36, 2, 19, 27, 161, 36, 154, 254, 135, 82, 82, 38, 238, 231, 250, 178, 46, 126, 42, 216, 206, 199, 14, 113, 85, 148, 122, 203, 212, 212, 177, 169, 192, 161, 170, 152, 200, 55, 137, 29, 26, 79, 143, 135, 195, 68, 125, 59, 245, 9, 62, 62, 34, 180, 174, 164, 3, 103, 32, 55, 229, 81, 236, 158, 237, 182, 164, 134, 52, 192, 222, 187, 226, 196, 180, 185, 247, 150, 203, 5, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 100, 102, 91, 1, 206, 147, 169, 245, 113, 144, 37, 173, 41, 133, 0, 201, 63, 242, 36, 187, 149, 72, 38, 26, 39, 127, 58, 206, 169, 32, 237, 76, 146, 156, 178, 161, 98, 241, 117, 198, 38, 135, 127, 114, 143, 100, 202, 7, 18, 137, 225, 129, 19, 218, 33, 226, 158, 117, 218, 62, 90, 121, 66, 53, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 25, 73, 83, 95, 69, 43, 124, 36, 64, 39, 111, 72, 183, 101, 108, 112, 172, 114, 185, 22, 151, 254, 250, 114, 186, 252, 66, 186, 201, 193, 24, 45, 110, 86, 109, 229, 78, 75, 25, 94, 128, 27, 183, 73, 142, 68, 107, 20, 178, 185, 140, 158, 29, 38, 53, 56, 98, 240, 14, 104, 65, 170, 107, 22, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 206, 43, 75, 189, 188, 194, 78, 83, 14, 190, 184, 227, 68, 70, 216, 23, 25, 243, 77, 114, 152, 180, 207, 203, 77, 122, 75, 166, 233, 98, 68, 13, 75, 16, 40, 41, 58, 165, 188, 245, 216, 11, 237, 32, 144, 200, 201, 116, 87, 194, 217, 196, 47, 74, 130, 193, 109, 232, 224, 186, 123, 130, 130, 107, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 132, 14, 67, 27, 51, 90, 33, 130, 219, 176, 0, 127, 213, 202, 1, 19, 139, 75, 132, 215, 161, 66, 222, 87, 41, 117, 241, 187, 92, 171, 93, 97, 39, 202, 226, 108, 38, 255, 95, 141, 50, 160, 36, 248, 142, 168, 106, 129, 247, 242, 132, 225, 57, 150, 149, 23, 49, 99, 21, 228, 98, 179, 171, 76, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 57, 241, 58, 121, 170, 241, 243, 176, 169, 71, 74, 26, 99, 171, 109, 186, 247, 203, 24, 51, 163, 248, 178, 176, 188, 242, 249, 167, 124, 76, 137, 65, 3, 132, 157, 176, 18, 89, 3, 37, 140, 52, 92, 207, 141, 136, 11, 142, 151, 35, 48, 254, 67, 226, 168, 109, 244, 221, 73, 13, 74, 228, 212, 45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
 /// last_ancestors: {Eric: 1}
 
-  "E_2" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "E_2" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_2</td></tr>
-<tr><td colspan="6">StartDkg({Alice, Bob, Carol, Dave, Eric})</td></tr>
 </table>>]
-/// cause: Observation(StartDkg({Alice, Bob, Carol, Dave, Eric}))
-/// last_ancestors: {Eric: 2}
+/// cause: Request
+/// last_ancestors: {Alice: 27, Bob: 21, Carol: 27, Eric: 2}
 
   "E_3" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_3</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Eric: 3}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 27, Bob: 21, Carol: 27, Eric: 3}
 
   "E_4" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_4</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 6, Bob: 6, Carol: 3, Eric: 4}
+/// cause: Request
+/// last_ancestors: {Alice: 35, Bob: 25, Carol: 29, Dave: 2, Eric: 4}
 
   "E_5" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_5</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 9, Bob: 11, Carol: 6, Dave: 6, Eric: 5}
+/// cause: Response
+/// last_ancestors: {Alice: 35, Bob: 25, Carol: 30, Dave: 2, Eric: 5}
 
   "E_6" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_6</td></tr>
 </table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 9, Bob: 11, Carol: 6, Dave: 6, Eric: 6}
+/// cause: Request
+/// last_ancestors: {Alice: 36, Bob: 25, Carol: 30, Dave: 2, Eric: 6}
 
   "E_7" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_7</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 13, Bob: 13, Carol: 11, Dave: 11, Eric: 7}
+/// cause: Request
+/// last_ancestors: {Alice: 36, Bob: 25, Carol: 32, Dave: 2, Eric: 7}
 
   "E_8" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_8</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 13, Bob: 13, Carol: 11, Dave: 11, Eric: 8}
+/// cause: Request
+/// last_ancestors: {Alice: 38, Bob: 25, Carol: 32, Dave: 2, Eric: 8}
 
   "E_9" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_9</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 20, Bob: 14, Carol: 14, Dave: 12, Eric: 9}
+/// cause: Request
+/// last_ancestors: {Alice: 40, Bob: 25, Carol: 32, Dave: 2, Eric: 9}
 
   "E_10" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_10</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 20, Bob: 19, Carol: 16, Dave: 14, Eric: 10}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 40, Bob: 25, Carol: 32, Dave: 2, Eric: 10}
 
   "E_11" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_11</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 20, Bob: 19, Carol: 16, Dave: 14, Eric: 11}
+/// cause: Response
+/// last_ancestors: {Alice: 40, Bob: 28, Carol: 37, Dave: 2, Eric: 11}
 
   "E_12" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_12</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 22, Bob: 21, Carol: 23, Dave: 17, Eric: 12}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 40, Bob: 28, Carol: 37, Dave: 2, Eric: 12}
 
   "E_13" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_13</td></tr>
 </table>>]
-/// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 22, Bob: 21, Carol: 23, Dave: 17, Eric: 13}
+/// cause: Response
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 4, Eric: 13}
 
-  "E_14" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "E_14" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_14</td></tr>
-<tr><td colspan="6">DkgMessage(DkgPart(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgPart(0)), SerialisedDkgMessage([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 146, 55, 35, 29, 36, 20, 58, 236, 255, 168, 21, 248, 158, 44, 198, 97, 133, 45, 44, 235, 184, 123, 48, 111, 224, 194, 213, 143, 210, 126, 192, 37, 28, 103, 213, 75, 149, 190, 129, 43, 35, 21, 228, 109, 218, 200, 114, 1, 131, 53, 217, 20, 228, 75, 255, 233, 50, 195, 236, 159, 1, 13, 211, 68, 131, 243, 67, 85, 164, 204, 10, 171, 60, 216, 3, 212, 111, 251, 255, 18, 128, 176, 227, 139, 172, 212, 96, 124, 191, 101, 211, 193, 51, 223, 208, 113, 143, 97, 166, 167, 184, 92, 51, 253, 202, 188, 127, 0, 32, 68, 85, 205, 208, 239, 109, 18, 106, 55, 136, 7, 47, 43, 114, 138, 225, 60, 210, 248, 175, 184, 70, 242, 158, 165, 195, 152, 196, 183, 182, 122, 108, 134, 190, 225, 5, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 180, 244, 71, 126, 71, 119, 222, 58, 113, 202, 4, 167, 239, 153, 246, 89, 18, 69, 62, 165, 211, 157, 214, 211, 62, 213, 103, 81, 62, 81, 96, 86, 168, 191, 226, 52, 73, 3, 113, 254, 130, 187, 178, 46, 137, 61, 247, 159, 61, 194, 232, 249, 8, 1, 233, 29, 113, 200, 228, 229, 186, 158, 218, 20, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 57, 237, 177, 166, 184, 198, 97, 48, 201, 149, 84, 19, 109, 26, 63, 62, 185, 123, 61, 168, 17, 176, 130, 25, 204, 46, 182, 152, 39, 217, 164, 89, 203, 134, 91, 65, 33, 183, 94, 7, 174, 171, 21, 241, 148, 250, 165, 91, 212, 77, 210, 240, 211, 239, 37, 246, 84, 55, 123, 132, 140, 181, 112, 38, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 190, 229, 27, 207, 41, 22, 229, 37, 33, 97, 164, 127, 234, 154, 135, 34, 96, 178, 60, 171, 79, 194, 46, 95, 89, 136, 4, 224, 16, 97, 233, 92, 238, 77, 212, 77, 249, 106, 76, 16, 217, 155, 120, 179, 160, 183, 84, 23, 107, 217, 187, 231, 158, 222, 98, 206, 56, 166, 17, 35, 94, 204, 6, 56, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 67, 222, 133, 247, 154, 101, 104, 27, 121, 44, 244, 235, 103, 27, 208, 6, 7, 233, 59, 174, 141, 212, 218, 164, 230, 225, 82, 39, 250, 232, 45, 96, 17, 21, 77, 90, 209, 30, 58, 25, 4, 140, 219, 117, 172, 116, 3, 211, 1, 101, 165, 222, 105, 205, 159, 166, 28, 21, 168, 193, 47, 227, 156, 73, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218, 104, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 200, 214, 239, 31, 12, 181, 235, 16, 209, 247, 67, 88, 229, 155, 24, 235, 173, 31, 59, 177, 203, 230, 134, 234, 115, 59, 161, 110, 227, 112, 114, 99, 52, 220, 197, 102, 169, 210, 39, 34, 47, 124, 62, 56, 184, 49, 178, 142, 152, 240, 142, 213, 52, 188, 220, 126, 0, 132, 62, 96, 1, 250, 50, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
-/// last_ancestors: {Alice: 22, Bob: 21, Carol: 23, Dave: 17, Eric: 14}
+/// cause: Request
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 5, Eric: 14}
 
   "E_15" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_15</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 29, Bob: 26, Carol: 24, Dave: 19, Eric: 15}
+/// cause: Requesting(Carol)
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 5, Eric: 15}
 
   "E_16" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_16</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 32, Bob: 27, Carol: 26, Dave: 25, Eric: 16}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 5, Eric: 16}
 
-  "E_17" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "E_17" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_17</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 32, Bob: 27, Carol: 26, Dave: 25, Eric: 17}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 6, 244, 190, 110, 69, 89, 34, 145, 60, 65, 3, 212, 1, 230, 245, 116, 62, 100, 147, 108, 150, 228, 201, 134, 194, 226, 244, 61, 51, 58, 27, 105, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32, 64, 0, 0, 0, 0, 0, 0, 0, 150, 96, 144, 212, 224, 58, 123, 224, 58, 99, 74, 122, 28, 244, 122, 80, 56, 64, 182, 241, 139, 76, 50, 212, 143, 203, 147, 197, 48, 230, 147, 3, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53, 64, 0, 0, 0, 0, 0, 0, 0, 39, 205, 97, 58, 123, 28, 212, 47, 56, 225, 143, 32, 58, 166, 189, 127, 55, 244, 122, 128, 137, 140, 212, 84, 165, 49, 208, 118, 129, 57, 250, 17, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106, 64, 0, 0, 0, 0, 0, 0, 0, 184, 57, 51, 160, 21, 254, 44, 127, 53, 95, 213, 198, 87, 88, 0, 175, 54, 168, 63, 15, 135, 204, 118, 213, 186, 151, 12, 40, 210, 140, 96, 32, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218, 64, 0, 0, 0, 0, 0, 0, 0, 73, 166, 4, 6, 176, 223, 133, 206, 50, 221, 26, 109, 117, 10, 67, 222, 53, 92, 4, 158, 132, 12, 25, 86, 208, 253, 72, 217, 34, 224, 198, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 5, Eric: 17}
 
-  "E_18" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "E_18" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_18</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 32, Bob: 31, Carol: 31, Dave: 25, Eric: 18}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 119, 213, 26, 226, 18, 58, 0, 240, 226, 244, 188, 129, 83, 223, 148, 251, 40, 107, 174, 55, 132, 15, 52, 54, 120, 247, 240, 243, 109, 120, 50, 30, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32, 64, 0, 0, 0, 0, 0, 0, 0, 77, 223, 108, 192, 49, 10, 215, 197, 80, 167, 198, 176, 220, 70, 191, 150, 183, 9, 167, 49, 152, 255, 231, 194, 108, 131, 51, 151, 44, 146, 208, 82, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53, 64, 0, 0, 0, 0, 0, 0, 0, 34, 233, 190, 158, 81, 218, 173, 155, 191, 253, 209, 223, 98, 10, 44, 222, 64, 208, 253, 33, 164, 23, 98, 28, 25, 146, 216, 16, 152, 4, 129, 19, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106, 64, 0, 0, 0, 0, 0, 0, 0, 248, 242, 16, 125, 112, 170, 132, 113, 45, 176, 219, 14, 236, 113, 86, 121, 207, 110, 246, 27, 184, 7, 22, 169, 13, 30, 27, 180, 86, 30, 31, 72, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218, 64, 0, 0, 0, 0, 0, 0, 0, 205, 252, 98, 91, 144, 122, 91, 71, 156, 6, 231, 61, 114, 53, 195, 192, 88, 53, 77, 12, 196, 31, 144, 2, 186, 44, 192, 45, 194, 144, 207, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 5, Eric: 18}
 
-  "E_19" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "E_19" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_19</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 32, Bob: 31, Carol: 31, Dave: 27, Eric: 19}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 152, 228, 201, 34, 134, 246, 164, 231, 174, 21, 114, 17, 60, 111, 37, 154, 105, 229, 162, 23, 105, 116, 78, 107, 177, 48, 40, 77, 195, 29, 65, 79, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32, 64, 0, 0, 0, 0, 0, 0, 0, 92, 4, 85, 15, 117, 219, 115, 51, 214, 179, 216, 217, 94, 85, 15, 231, 252, 126, 165, 59, 103, 133, 75, 169, 137, 187, 133, 69, 204, 181, 242, 29, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53, 64, 0, 0, 0, 0, 0, 0, 0, 33, 36, 224, 251, 98, 192, 66, 127, 252, 173, 61, 162, 132, 223, 182, 135, 149, 240, 73, 105, 109, 110, 130, 26, 170, 195, 128, 103, 40, 245, 145, 96, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106, 64, 0, 0, 0, 0, 0, 0, 0, 229, 67, 107, 232, 81, 165, 17, 203, 35, 76, 164, 106, 167, 197, 160, 212, 40, 138, 76, 141, 107, 127, 127, 88, 130, 78, 222, 95, 49, 141, 67, 47, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218, 64, 0, 0, 0, 0, 0, 0, 0, 170, 99, 246, 212, 63, 138, 224, 22, 74, 70, 9, 51, 205, 79, 72, 117, 193, 251, 240, 186, 113, 104, 182, 201, 162, 86, 217, 129, 141, 204, 226, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 5, Eric: 19}
 
-  "E_20" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "E_20" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_20</td></tr>
+<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 33, Bob: 35, Carol: 32, Dave: 27, Eric: 20}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 72, 115, 166, 135, 226, 203, 152, 219, 52, 21, 95, 67, 221, 150, 118, 26, 193, 251, 61, 24, 182, 73, 76, 44, 175, 161, 185, 43, 111, 68, 235, 10, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32, 64, 0, 0, 0, 0, 0, 0, 0, 29, 125, 73, 149, 70, 244, 193, 160, 56, 169, 12, 102, 217, 13, 159, 73, 212, 179, 190, 36, 185, 145, 185, 252, 231, 60, 149, 133, 173, 12, 134, 23, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53, 64, 0, 0, 0, 0, 0, 0, 0, 242, 134, 236, 162, 170, 28, 235, 101, 60, 61, 186, 136, 213, 132, 199, 120, 231, 107, 63, 49, 188, 217, 38, 205, 32, 216, 112, 223, 235, 212, 32, 36, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106, 64, 0, 0, 0, 0, 0, 0, 0, 199, 144, 143, 176, 14, 69, 20, 43, 64, 209, 103, 171, 209, 251, 239, 167, 250, 35, 192, 61, 191, 33, 148, 157, 89, 115, 76, 57, 42, 157, 187, 48, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218, 64, 0, 0, 0, 0, 0, 0, 0, 156, 154, 50, 190, 114, 109, 61, 240, 67, 101, 21, 206, 205, 114, 24, 215, 13, 220, 64, 74, 194, 105, 1, 110, 146, 14, 40, 147, 104, 101, 86, 61, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
+/// last_ancestors: {Alice: 41, Bob: 34, Carol: 37, Dave: 5, Eric: 20}
 
   "E_21" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_21</td></tr>
 </table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 33, Bob: 35, Carol: 32, Dave: 27, Eric: 21}
+/// cause: Response
+/// last_ancestors: {Alice: 46, Bob: 40, Carol: 49, Dave: 5, Eric: 21}
 
   "E_22" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_22</td></tr>
 </table>>]
 /// cause: Response
-/// last_ancestors: {Alice: 34, Bob: 39, Carol: 32, Dave: 27, Eric: 22}
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 49, Dave: 5, Eric: 22}
 
   "E_23" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_23</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 34, Bob: 39, Carol: 32, Dave: 27, Eric: 23}
+/// cause: Requesting(Dave)
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 49, Dave: 5, Eric: 23}
 
   "E_24" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_24</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 34, Bob: 39, Carol: 32, Dave: 27, Eric: 24}
+/// cause: Response
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 49, Dave: 11, Eric: 24}
 
   "E_25" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_25</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 37, Bob: 41, Carol: 39, Dave: 31, Eric: 25}
+/// cause: Requesting(Dave)
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 49, Dave: 11, Eric: 25}
 
-  "E_26" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "E_26" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_26</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 138, 153, 35, 248, 153, 216, 184, 122, 106, 134, 80, 113, 45, 223, 172, 55, 123, 22, 241, 115, 42, 74, 119, 230, 125, 37, 65, 46, 73, 205, 232, 77, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32, 64, 0, 0, 0, 0, 0, 0, 0, 223, 202, 149, 240, 255, 184, 167, 56, 118, 121, 42, 58, 243, 75, 133, 190, 47, 132, 6, 135, 97, 119, 175, 178, 212, 59, 153, 28, 83, 75, 233, 34, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53, 64, 0, 0, 0, 0, 0, 0, 0, 53, 252, 7, 233, 100, 153, 150, 246, 128, 200, 2, 3, 188, 92, 27, 153, 233, 201, 189, 163, 160, 124, 33, 178, 115, 207, 142, 52, 176, 112, 215, 107, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106, 64, 0, 0, 0, 0, 0, 0, 0, 138, 45, 122, 225, 202, 121, 133, 180, 140, 187, 220, 203, 129, 201, 243, 31, 158, 55, 211, 182, 215, 169, 89, 126, 202, 229, 230, 34, 186, 238, 215, 64, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218, 64, 0, 0, 0, 0, 0, 0, 0, 223, 94, 236, 217, 48, 90, 116, 114, 152, 174, 182, 148, 71, 54, 204, 166, 82, 165, 232, 201, 14, 215, 145, 74, 33, 252, 62, 17, 196, 108, 216, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
-/// last_ancestors: {Alice: 37, Bob: 41, Carol: 39, Dave: 31, Eric: 26}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 49, Dave: 11, Eric: 26}
 
-  "E_27" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "E_27" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_27</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 251, 178, 181, 134, 182, 135, 19, 51, 1, 24, 132, 144, 154, 41, 13, 38, 65, 56, 40, 125, 248, 202, 41, 54, 44, 66, 66, 165, 145, 195, 183, 74, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32, 64, 0, 0, 0, 0, 0, 0, 0, 46, 143, 123, 237, 96, 90, 59, 85, 49, 56, 196, 200, 79, 183, 1, 97, 212, 80, 21, 73, 37, 175, 204, 129, 228, 72, 227, 219, 63, 22, 253, 49, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53, 64, 0, 0, 0, 0, 0, 0, 0, 97, 107, 65, 84, 11, 45, 99, 119, 97, 88, 4, 1, 5, 69, 246, 155, 103, 105, 2, 21, 82, 147, 111, 205, 156, 79, 132, 18, 238, 104, 66, 25, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106, 64, 0, 0, 0, 0, 0, 0, 0, 148, 71, 7, 187, 181, 255, 138, 153, 145, 120, 68, 57, 186, 210, 234, 214, 250, 129, 239, 224, 126, 119, 18, 25, 85, 86, 37, 73, 156, 187, 135, 0, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218, 64, 0, 0, 0, 0, 0, 0, 0, 200, 35, 205, 33, 95, 210, 178, 187, 192, 244, 130, 113, 114, 4, 157, 101, 147, 114, 126, 182, 179, 51, 239, 151, 85, 218, 99, 169, 157, 181, 186, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
-/// last_ancestors: {Alice: 37, Bob: 41, Carol: 39, Dave: 31, Eric: 27}
+/// cause: Response
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 49, Dave: 12, Eric: 27}
 
   "E_28" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_28</td></tr>
 <tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 150, 119, 255, 157, 155, 25, 170, 131, 123, 192, 120, 118, 130, 71, 25, 171, 108, 99, 134, 232, 189, 16, 141, 175, 144, 27, 47, 207, 88, 115, 209, 51, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32, 64, 0, 0, 0, 0, 0, 0, 0, 125, 209, 27, 6, 105, 151, 213, 82, 221, 159, 104, 121, 36, 88, 46, 75, 86, 255, 170, 29, 50, 10, 92, 94, 203, 61, 35, 114, 82, 84, 104, 36, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53, 64, 0, 0, 0, 0, 0, 0, 0, 100, 43, 56, 110, 54, 21, 1, 34, 63, 127, 88, 124, 198, 104, 67, 235, 63, 155, 207, 82, 166, 3, 43, 13, 6, 96, 23, 21, 76, 53, 255, 20, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106, 64, 0, 0, 0, 0, 0, 0, 0, 75, 133, 84, 214, 3, 147, 44, 241, 160, 94, 72, 127, 104, 121, 88, 139, 41, 55, 244, 135, 26, 253, 249, 187, 64, 130, 11, 184, 69, 22, 150, 5, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218, 64, 0, 0, 0, 0, 0, 0, 0, 51, 223, 112, 62, 208, 16, 88, 192, 1, 154, 54, 130, 13, 46, 43, 127, 24, 171, 186, 198, 150, 206, 2, 158, 195, 33, 157, 132, 146, 158, 26, 106, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
-/// last_ancestors: {Alice: 37, Bob: 41, Carol: 39, Dave: 31, Eric: 28}
+/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 60, 117, 216, 41, 189, 74, 247, 213, 53, 124, 166, 233, 240, 51, 121, 72, 143, 239, 72, 49, 231, 218, 91, 30, 177, 208, 67, 181, 198, 48, 94, 111, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32, 64, 0, 0, 0, 0, 0, 0, 0, 62, 249, 117, 218, 208, 163, 250, 250, 194, 84, 4, 185, 123, 24, 199, 130, 33, 59, 215, 37, 35, 229, 202, 88, 93, 49, 240, 152, 189, 109, 69, 41, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53, 64, 0, 0, 0, 0, 0, 0, 0, 65, 125, 19, 139, 227, 252, 253, 31, 79, 137, 96, 136, 9, 161, 210, 16, 185, 94, 7, 36, 103, 199, 115, 198, 81, 15, 58, 166, 7, 82, 26, 87, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106, 64, 0, 0, 0, 0, 0, 0, 0, 67, 1, 177, 59, 247, 85, 1, 69, 220, 97, 190, 87, 148, 133, 32, 75, 75, 170, 149, 24, 163, 209, 226, 0, 254, 111, 230, 137, 254, 142, 1, 17, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218, 64, 0, 0, 0, 0, 0, 0, 0, 70, 133, 78, 236, 9, 175, 4, 106, 104, 150, 26, 39, 34, 14, 44, 217, 226, 205, 197, 22, 231, 179, 139, 110, 242, 77, 48, 151, 72, 115, 214, 62, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
+/// last_ancestors: {Alice: 52, Bob: 43, Carol: 49, Dave: 12, Eric: 28}
 
-  "E_29" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "E_29" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_29</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 178, 222, 100, 110, 203, 248, 113, 230, 83, 115, 111, 220, 154, 51, 173, 228, 51, 152, 73, 197, 39, 133, 111, 197, 5, 62, 37, 109, 156, 164, 89, 99, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32, 64, 0, 0, 0, 0, 0, 0, 0, 69, 178, 146, 249, 207, 187, 184, 168, 150, 242, 210, 23, 96, 204, 7, 233, 222, 44, 0, 227, 149, 220, 178, 29, 19, 129, 9, 210, 216, 9, 168, 30, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53, 64, 0, 0, 0, 0, 0, 0, 0, 217, 133, 192, 132, 211, 126, 255, 106, 216, 205, 52, 83, 40, 9, 32, 65, 143, 153, 88, 10, 12, 12, 48, 169, 104, 65, 139, 96, 104, 22, 228, 77, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106, 64, 0, 0, 0, 0, 0, 0, 0, 108, 89, 238, 15, 216, 65, 70, 45, 27, 77, 152, 142, 237, 161, 122, 69, 58, 46, 15, 40, 122, 99, 115, 1, 118, 132, 111, 197, 164, 123, 50, 9, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218, 64, 0, 0, 0, 0, 0, 0, 0, 0, 45, 28, 155, 219, 4, 141, 239, 92, 40, 250, 201, 181, 222, 146, 157, 234, 154, 103, 79, 240, 146, 240, 140, 203, 68, 241, 83, 52, 136, 110, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
-/// last_ancestors: {Alice: 37, Bob: 41, Carol: 39, Dave: 31, Eric: 29}
+/// cause: Response
+/// last_ancestors: {Alice: 56, Bob: 46, Carol: 54, Dave: 12, Eric: 29}
 
-  "E_30" [style=filled, fillcolor=cyan, shape=rectangle, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
+  "E_30" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_30</td></tr>
-<tr><td colspan="6">DkgMessage(DkgAck(0))</td></tr>
 </table>>]
-/// cause: Observation(DkgMessage(DkgAck(0)), SerialisedDkgMessage([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 27, 242, 146, 84, 169, 87, 170, 231, 57, 63, 109, 105, 142, 142, 165, 148, 153, 79, 87, 225, 120, 107, 93, 253, 78, 189, 16, 201, 82, 155, 179, 94, 149, 24, 16, 4, 247, 29, 115, 11, 211, 174, 28, 90, 55, 159, 254, 106, 184, 240, 255, 107, 31, 207, 137, 148, 222, 126, 115, 77, 56, 205, 134, 32, 64, 0, 0, 0, 0, 0, 0, 0, 179, 237, 85, 185, 88, 64, 161, 90, 65, 158, 146, 180, 24, 24, 46, 215, 223, 25, 129, 214, 228, 248, 224, 251, 254, 74, 234, 166, 25, 99, 199, 27, 108, 105, 21, 255, 214, 42, 108, 12, 175, 230, 84, 176, 50, 42, 25, 6, 137, 133, 184, 59, 161, 99, 202, 137, 245, 122, 55, 136, 170, 93, 216, 53, 64, 0, 0, 0, 0, 0, 0, 0, 76, 233, 24, 30, 7, 41, 152, 205, 71, 89, 182, 255, 165, 69, 116, 109, 43, 188, 76, 213, 88, 94, 158, 45, 247, 85, 97, 174, 51, 210, 200, 76, 152, 121, 205, 107, 9, 75, 236, 188, 146, 190, 60, 88, 89, 62, 107, 169, 155, 232, 128, 32, 205, 103, 132, 42, 169, 112, 53, 41, 143, 241, 16, 106, 64, 0, 0, 0, 0, 0, 0, 0, 228, 228, 219, 130, 182, 17, 143, 64, 79, 184, 219, 74, 48, 207, 252, 175, 113, 134, 118, 202, 196, 235, 33, 44, 167, 227, 58, 140, 250, 153, 220, 9, 213, 190, 15, 107, 167, 238, 158, 209, 83, 205, 247, 251, 37, 172, 205, 166, 156, 123, 201, 48, 231, 184, 205, 99, 28, 245, 76, 58, 22, 175, 33, 218, 64, 0, 0, 0, 0, 0, 0, 0, 125, 224, 158, 231, 100, 250, 133, 179, 85, 115, 255, 149, 189, 252, 66, 70, 189, 40, 66, 201, 56, 81, 223, 93, 159, 238, 177, 147, 20, 9, 222, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
-/// last_ancestors: {Alice: 37, Bob: 41, Carol: 39, Dave: 31, Eric: 30}
+/// cause: Request
+/// last_ancestors: {Alice: 56, Bob: 47, Carol: 54, Dave: 12, Eric: 30}
 
   "E_31" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_31</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 37, Bob: 41, Carol: 40, Dave: 31, Eric: 31}
+/// cause: Request
+/// last_ancestors: {Alice: 56, Bob: 49, Carol: 54, Dave: 12, Eric: 31}
 
   "E_32" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_32</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 37, Bob: 41, Carol: 40, Dave: 31, Eric: 32}
+/// cause: Requesting(Dave)
+/// last_ancestors: {Alice: 56, Bob: 49, Carol: 54, Dave: 12, Eric: 32}
 
   "E_33" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_33</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 38, Bob: 41, Carol: 40, Dave: 31, Eric: 33}
+/// last_ancestors: {Alice: 56, Bob: 51, Carol: 54, Dave: 12, Eric: 33}
 
   "E_34" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_34</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 38, Bob: 41, Carol: 41, Dave: 31, Eric: 34}
+/// cause: Response
+/// last_ancestors: {Alice: 62, Bob: 51, Carol: 60, Dave: 19, Eric: 34}
 
   "E_35" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_35</td></tr>
 </table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 45, Bob: 41, Carol: 41, Dave: 31, Eric: 35}
+/// cause: Requesting(Bob)
+/// last_ancestors: {Alice: 62, Bob: 51, Carol: 60, Dave: 19, Eric: 35}
 
   "E_36" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_36</td></tr>
 </table>>]
 /// cause: Request
-/// last_ancestors: {Alice: 47, Bob: 41, Carol: 41, Dave: 31, Eric: 36}
+/// last_ancestors: {Alice: 62, Bob: 51, Carol: 60, Dave: 20, Eric: 36}
 
   "E_37" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_37</td></tr>
 </table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 47, Bob: 41, Carol: 41, Dave: 31, Eric: 37}
+/// cause: Response
+/// last_ancestors: {Alice: 62, Bob: 53, Carol: 60, Dave: 20, Eric: 37}
 
   "E_38" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
 <tr><td colspan="6">E_38</td></tr>
 </table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 47, Bob: 44, Carol: 51, Dave: 31, Eric: 38}
-
-  "E_39" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_39</td></tr>
-</table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 47, Bob: 44, Carol: 51, Dave: 31, Eric: 39}
-
-  "E_40" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_40</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 48, Bob: 55, Carol: 51, Dave: 39, Eric: 40}
-
-  "E_41" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_41</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 48, Bob: 55, Carol: 51, Dave: 40, Eric: 41}
-
-  "E_42" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_42</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 48, Bob: 55, Carol: 51, Dave: 40, Eric: 42}
-
-  "E_43" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_43</td></tr>
-</table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 48, Bob: 55, Carol: 51, Dave: 40, Eric: 43}
-
-  "E_44" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_44</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 53, Bob: 57, Carol: 59, Dave: 40, Eric: 44}
-
-  "E_45" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_45</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 55, Bob: 60, Carol: 59, Dave: 40, Eric: 45}
-
-  "E_46" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_46</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 55, Bob: 60, Carol: 59, Dave: 40, Eric: 46}
-
-  "E_47" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_47</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 55, Bob: 60, Carol: 59, Dave: 42, Eric: 47}
-
-  "E_48" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_48</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 55, Bob: 60, Carol: 59, Dave: 42, Eric: 48}
-
-  "E_49" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_49</td></tr>
-</table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 55, Bob: 60, Carol: 59, Dave: 42, Eric: 49}
-
-  "E_50" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_50</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 55, Bob: 60, Carol: 59, Dave: 43, Eric: 50}
-
-  "E_51" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_51</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 59, Bob: 62, Carol: 64, Dave: 43, Eric: 51}
-
-  "E_52" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_52</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 59, Bob: 63, Carol: 64, Dave: 43, Eric: 52}
-
-  "E_53" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_53</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 59, Bob: 65, Carol: 64, Dave: 43, Eric: 53}
-
-  "E_54" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_54</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 59, Bob: 65, Carol: 64, Dave: 43, Eric: 54}
-
-  "E_55" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_55</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 59, Bob: 67, Carol: 64, Dave: 43, Eric: 55}
-
-  "E_56" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_56</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 64, Bob: 67, Carol: 69, Dave: 49, Eric: 56}
-
-  "E_57" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_57</td></tr>
-</table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 64, Bob: 67, Carol: 69, Dave: 49, Eric: 57}
-
-  "E_58" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_58</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 64, Bob: 67, Carol: 69, Dave: 50, Eric: 58}
-
-  "E_59" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_59</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 64, Bob: 69, Carol: 69, Dave: 50, Eric: 59}
-
-  "E_60" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_60</td></tr>
-</table>>]
 /// cause: Requesting(Alice)
-/// last_ancestors: {Alice: 64, Bob: 69, Carol: 69, Dave: 50, Eric: 60}
-
-  "E_61" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_61</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 64, Bob: 69, Carol: 69, Dave: 54, Eric: 61}
-
-  "E_62" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_62</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 68, Bob: 69, Carol: 69, Dave: 54, Eric: 62}
-
-  "E_63" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_63</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 68, Bob: 69, Carol: 69, Dave: 55, Eric: 63}
-
-  "E_64" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_64</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 70, Bob: 69, Carol: 69, Dave: 55, Eric: 64}
-
-  "E_65" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_65</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 70, Bob: 70, Carol: 72, Dave: 63, Eric: 65}
-
-  "E_66" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_66</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 70, Bob: 70, Carol: 72, Dave: 64, Eric: 66}
-
-  "E_67" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_67</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 70, Bob: 70, Carol: 72, Dave: 64, Eric: 67}
-
-  "E_68" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_68</td></tr>
-</table>>]
-/// cause: Requesting(Dave)
-/// last_ancestors: {Alice: 70, Bob: 70, Carol: 72, Dave: 64, Eric: 68}
-
-  "E_69" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_69</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 70, Bob: 70, Carol: 72, Dave: 68, Eric: 69}
-
-  "E_70" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_70</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 70, Bob: 73, Carol: 79, Dave: 68, Eric: 70}
-
-  "E_71" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_71</td></tr>
-</table>>]
-/// cause: Requesting(Bob)
-/// last_ancestors: {Alice: 70, Bob: 73, Carol: 79, Dave: 68, Eric: 71}
-
-  "E_72" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_72</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 70, Bob: 78, Carol: 80, Dave: 68, Eric: 72}
-
-  "E_73" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_73</td></tr>
-</table>>]
-/// cause: Response
-/// last_ancestors: {Alice: 70, Bob: 79, Carol: 80, Dave: 68, Eric: 73}
-
-  "E_74" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_74</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 77, Bob: 87, Carol: 86, Dave: 71, Eric: 74}
-
-  "E_75" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_75</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 77, Bob: 88, Carol: 86, Dave: 71, Eric: 75}
-
-  "E_76" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_76</td></tr>
-</table>>]
-/// cause: Requesting(Carol)
-/// last_ancestors: {Alice: 77, Bob: 88, Carol: 86, Dave: 71, Eric: 76}
-
-  "E_77" [fillcolor=white, label=<<table border="0" cellborder="0" cellpadding="0" cellspacing="0">
-<tr><td colspan="6">E_77</td></tr>
-</table>>]
-/// cause: Request
-/// last_ancestors: {Alice: 77, Bob: 91, Carol: 86, Dave: 71, Eric: 77}
+/// last_ancestors: {Alice: 62, Bob: 53, Carol: 60, Dave: 20, Eric: 38}
 
 }
 
 /// ===== meta-elections =====
 /// consensus_history:
-/// ea47a3b8d596df9dce6c2658e06eac7fd94f060ba92c695cb5b9923b0702e219
+/// ce0294d6ca768e2f98cec710e3ce71aa34f73c7e23b861de6766cae2d09fac85
 /// 8a1489034a48bd6202b99050822a67e0fc109b9478109d75a8cfe66c4233912b
-/// 37af3643a25292963841c28ef26a43951df93c6bc5f9229c124bb20704b5d1d6
-/// 7c14e4fdff94f1632e39e11342a6ac6c1e023f244a75cded465c05fb6d740f8f
-/// 89862abbf4b32ae5bc3a58cfd978ab85addbfee65ba237f6f08075a6ee9d45ff
-/// 943bdbd8c4df9373bde28ec4275d02a19ab25e2ca9b7a502c8a765a757c83452
-/// f6c56e14bf038ffe07cd7c8e179160366cd15b90190e8b0ceada12675b3eda90
-/// 2ca9f846e056f80853af4b105acf1503d4ff13471c229be80d585b83304054ac
-/// 3edfb40ce4d6e4c99204964bafa4df6aad9750a1ac58318f3b21417571fb42fb
-/// 50f54db460a0f9f0e5a21cc8cf649338494e88a67b1669cac7027d3dff82bdbc
-/// 98d18826bd9712b4bfb15c2cbc88383489f53efb77e50a63d4785b5f1806e26c
-/// af91b5e40d269c60a32b9f211db8193533adcaff2c0c28f2b60730ba0de07719
-/// 37bc389a55a6f1764319d2446ddb872126633b935d8a2474f687570a2153796a
-/// 7a07dade075a08cc7f5592385ed18c60edde56773804f15dc0d7053868f83ea7
-/// aa89548d6904c9f51c296c224dbfa813aee86dff7d0257a0cd677ddd440ac9d5
-/// ae1f6d8fdb496ca5abe6f7fbe1aab5ec750edfcf620f22fbbb8fe087e8eb42c0
-/// f82919a8e8ea0f5bb41e116c346d4bd1bf62f04052d44b8ef907422a3b036af7
-/// 1146a3d8854878703249a47d1754484eceac5d4a2354ed8993119b2b7ec679e0
-/// 4b5fcd300614bffa87014bd4055a7eabfd8df0ae14c556907b5ba692f9ddea0e
-/// 4f27c06a73441e2292f9f64cb21f8cdf528a4fd445f3d03a6d577ec98a364945
-/// a6df423ebca5901c0bdfc7bcc71511d0e847120970665a7ebabffb08229038a9
-/// b1161bdd833b581ed48f280fa75e9a49b70789bb57c188666b63136d625148be
-/// 129e1aefc908d0c5605a489a710b401e48cfa456ee076d0b6346359acbbe3ca3
-/// 3de79832ece875ec2d4e766d9fd0f6f2dd52e6cd9510c23816c36b8ae65edd28
-/// 3dff07475d7d06bf38f8fa961ac426a1984b85aa3dc19b05260eaa2fa8e6cae3
-/// 78f0a2c02b89bb1bb85d77509e6896ea083b5559f831119d2d4de24fda4b32d7
-/// 816b31666ea7804992740072e4071b118adb9c064aef782db34e9ea3d9958d6a
-/// 4d9dae47feed87d6974ed2963ec39dd7eb1f0781a1d0fa2940a95cc925d7a96c
-/// 51c0a0d9dac04ab3c11232b6ba7e1e63384d8ac4426c640e25c0f49b8b50b55b
-/// acc1c915df983d86374f5773ef628972e0b8140f3d3c5a9e57079abd2d9e2709
-/// afbd36ddbc1873fcfd836a57778f9f81bc6898d99fd1793efcf7d46e68866ae6
-/// c5f65a06b24dcea4234da432663421fb1f94055ad582e0a43c0edf95862ae488
+/// 6306ff8058cfe51049894634803f76a3a5feef7c99f83d04a772003c239eddf2
+/// b06f5f3ffd6d214052248792ca9ea8a3be285ab74062de5f33c051cb9fcaf211
+/// f00b25fe0a70a3d30e8391668c6ea1d585fba7c12f29301d601ac751fb641952
+/// 78a0db7021819ef81af689aed6b21445d93f566af4144f8a5cc34e64ea29c300
+/// bd33f6fb8979fc3b372250fe6ef9fa04f8f4d9065b5be4e5a9922bf2643cc5f6
+/// 3f73733827db57d63ce69be5a51ddb9cbe303216f0f045fe8c10d7d387e52919
+/// 5b66cda5925726f427918120fe650c0cdf195ebabceaebcf266109268d8af299
+/// f637c84064c99c837f99ca522932ce791a0563dc0a73e87f8f1c7f21724fcd2e
+/// 14c12494447b68301248da9264f7dbd74c2b1fe147a5cad04fbbe5aca28c73fc
+/// 2a803d0adf28084530d69a612c0447975818fe80de141e962e4087d89454eddd
+/// d23b7bc0e2823f300461c67657886e489db3f4c279ed4ab35ecd21f707cc63a9
+/// 1a2d4059556864cda151f0b2a8b3837ab4ea90563a9edd6a6326686fdac6e207
+/// 2060bc3605e5b7b31288013b08b7285bb265e9b051fa1f5d25536769b4eee27f
+/// 66bd83d60c24da119e404a386c13f780d4afabefb3bfb2f03a8cb0d77b628933
+/// 4ecb846605e829fce9e5825c326cfd33910ad0184af82e4ff893da0d28b81be2
+/// 50f0796aadfc18ff44efb93a1ea56b08739cd91e4dc35cf2f2c373d1ef14c566
+/// ef8a1ceca19fb213f183e3d9b7cc988e191d18bfed32e93f2398f11d7bd7da16
 
 /// interesting_events: {
+///   Alice -> ["A_60", "A_61", "A_63", "A_64"]
+///   Bob -> ["B_46", "B_48", "B_53"]
+///   Carol -> ["C_57", "C_59", "C_60"]
 /// }
-/// all_voters: {Alice, Bob, Carol, Dave, Eric}
-/// unconsensused_events: {}
+/// all_voters: {Alice, Bob, Carol}
+/// unconsensused_events: {"A_59", "B_45", "C_56", "D_10", "D_15", "D_7", "D_8", "D_9", "E_17", "E_18", "E_19", "E_20", "E_28"}
 /// meta_events: {
-///   A_83 -> {
+///   A_60 -> {
+///     observees: {}
+///     interesting_content: [DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0))]
+///   }
+///   A_61 -> {
+///     observees: {}
+///     interesting_content: [DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0))]
+///   }
+///   A_62 -> {
 ///     observees: {}
 ///     interesting_content: []
 ///   }
-///   A_84 -> {
+///   A_63 -> {
+///     observees: {}
+///     interesting_content: [DkgMessage(DkgAck(0))]
+///   }
+///   A_64 -> {
+///     observees: {Alice, Bob, Carol}
+///     interesting_content: [DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0))]
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///     }
+///   }
+///   A_65 -> {
+///     observees: {}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///     }
+///   }
+///   A_66 -> {
+///     observees: {}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///     }
+///   }
+///   A_67 -> {
+///     observees: {}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///     }
+///   }
+///   A_68 -> {
+///     observees: {}
+///     interesting_content: []
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///     }
+///   }
+///   B_46 -> {
+///     observees: {}
+///     interesting_content: [DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0))]
+///   }
+///   B_47 -> {
 ///     observees: {}
 ///     interesting_content: []
 ///   }
-///   A_85 -> {
+///   B_48 -> {
+///     observees: {}
+///     interesting_content: [DkgMessage(DkgAck(0))]
+///   }
+///   B_49 -> {
 ///     observees: {}
 ///     interesting_content: []
 ///   }
-///   A_86 -> {
+///   B_50 -> {
 ///     observees: {}
 ///     interesting_content: []
 ///   }
-///   B_96 -> {
+///   B_51 -> {
 ///     observees: {}
 ///     interesting_content: []
 ///   }
-///   B_97 -> {
+///   B_52 -> {
 ///     observees: {}
 ///     interesting_content: []
 ///   }
-///   B_98 -> {
+///   B_53 -> {
+///     observees: {Alice, Bob, Carol}
+///     interesting_content: [DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0))]
+///     meta_votes: {
+///         stage est bin aux dec
+///       A: 0/0   t   -   -   - 
+///       B: 0/0   t   -   -   - 
+///       C: 0/0   t   -   -   - 
+///     }
+///   }
+///   C_57 -> {
+///     observees: {}
+///     interesting_content: [DkgMessage(DkgAck(0))]
+///   }
+///   C_58 -> {
 ///     observees: {}
 ///     interesting_content: []
 ///   }
-///   B_99 -> {
+///   C_59 -> {
 ///     observees: {}
-///     interesting_content: []
+///     interesting_content: [DkgMessage(DkgAck(0))]
 ///   }
-///   B_100 -> {
+///   C_60 -> {
 ///     observees: {}
-///     interesting_content: []
-///   }
-///   B_101 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   D_78 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   D_79 -> {
-///     observees: {}
-///     interesting_content: []
-///   }
-///   D_80 -> {
-///     observees: {}
-///     interesting_content: []
+///     interesting_content: [DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0)), DkgMessage(DkgAck(0))]
 ///   }
 /// }

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -190,6 +190,7 @@ fn parse_single_state() -> Parser<u8, PeerState> {
     seq(b"VOTE").map(|_| PeerState::VOTE)
         | seq(b"SEND").map(|_| PeerState::SEND)
         | seq(b"RECV").map(|_| PeerState::RECV)
+        | seq(b"DKG").map(|_| PeerState::DKG)
 }
 
 fn parse_peers() -> Parser<u8, BTreeSet<PeerId>> {

--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -122,14 +122,15 @@ impl Network {
         self.consensus_mode
     }
 
-    fn active_peers(&self) -> impl Iterator<Item = &Peer> {
+    fn running_non_ignoring_peers(&self) -> impl Iterator<Item = &Peer> {
         self.peers
             .values()
-            .filter(|peer| peer.status() == PeerStatus::Active && !peer.ignore_process_events())
+            .filter(|peer| peer.is_running() && !peer.ignore_process_events())
     }
 
-    pub fn active_non_malicious_peers(&self) -> impl Iterator<Item = &Peer> {
-        self.active_peers().filter(|peer| !peer.is_malicious())
+    pub fn running_non_malicious_peers(&self) -> impl Iterator<Item = &Peer> {
+        self.running_non_ignoring_peers()
+            .filter(|peer| !peer.is_malicious())
     }
 
     /// Returns the IDs of peers which consider themselves to be still running correctly, i.e. those
@@ -157,10 +158,10 @@ impl Network {
 
     /// Returns true if all peers hold the same sequence of stable blocks.
     fn check_blocks_all_in_sequence(&self) -> Result<(), ConsensusError> {
-        let first_peer = unwrap!(self.active_non_malicious_peers().next());
+        let first_peer = unwrap!(self.running_non_malicious_peers().next());
         let payloads = first_peer.blocks_payloads();
         if let Some(peer) = self
-            .active_non_malicious_peers()
+            .running_non_malicious_peers()
             .find(|peer| peer.blocks_payloads() != payloads)
         {
             Err(ConsensusError::DifferingBlocksOrder(DifferingBlocksOrder {
@@ -289,7 +290,7 @@ impl Network {
 
     fn check_consensus_broken(&self) -> Result<(), ConsensusError> {
         let mut block_order = BTreeMap::new();
-        for peer in self.active_non_malicious_peers() {
+        for peer in self.running_non_malicious_peers() {
             for (index, block) in peer.blocks().enumerate() {
                 let key = self.block_key(block);
 
@@ -352,7 +353,7 @@ impl Network {
     ) -> Result<(), ConsensusError> {
         // Check the number of consensused blocks.
         let (got_min, got_max) = unwrap!(self
-            .active_non_malicious_peers()
+            .running_non_malicious_peers()
             .map(|peer| peer.blocks_payloads().len())
             .minmax()
             .into_option());
@@ -421,7 +422,7 @@ impl Network {
 
     /// Checks if the blocks are only signed by valid voters.
     fn check_blocks_signatories(&self) -> Result<(), ConsensusError> {
-        let block_groups = unwrap!(self.active_non_malicious_peers().next()).grouped_blocks();
+        let block_groups = unwrap!(self.running_non_malicious_peers().next()).grouped_blocks();
         let mut valid_voters = BTreeSet::new();
 
         for block_group in block_groups {
@@ -584,7 +585,10 @@ impl Network {
                 if add_type == AddPeerType::Voter && !self.allow_addition_of_peer() {
                     return Ok(false);
                 }
-                let current_peers = self.active_peers().map(|peer| peer.id().clone()).collect();
+                let current_peers = self
+                    .running_non_ignoring_peers()
+                    .map(|peer| peer.id().clone())
+                    .collect();
                 let _ = self.peers.insert(
                     peer_id.clone(),
                     Peer::from_existing(

--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -9,7 +9,7 @@
 use super::{
     new_rng,
     peer::{NetworkView, Peer, PeerStatus},
-    schedule::{Schedule, ScheduleEvent, ScheduleOptions},
+    schedule::{AddPeerType, Schedule, ScheduleEvent, ScheduleOptions},
     Observation,
 };
 use crate::{
@@ -580,8 +580,8 @@ impl Network {
                 // Do a full reset while we're at it.
                 self.msg_queue.clear();
             }
-            ScheduleEvent::AddPeer(peer_id) => {
-                if !self.allow_addition_of_peer() {
+            ScheduleEvent::AddPeer(peer_id, add_type) => {
+                if add_type == AddPeerType::Voter && !self.allow_addition_of_peer() {
                     return Ok(false);
                 }
                 let current_peers = self.active_peers().map(|peer| peer.id().clone()).collect();

--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -658,13 +658,6 @@ impl Network {
 
                 self.peer_mut(&voting_peer_id).vote_for(&observation);
             }
-            ScheduleEvent::StartDkg(peers) => {
-                // All valid peers should vote for new DKG.
-                for peer_id in self.running_peers_ids() {
-                    self.peer_mut(&peer_id)
-                        .vote_for(&ParsecObservation::StartDkg(peers.clone()));
-                }
-            }
         }
         Ok(true)
     }

--- a/src/dev_utils/peer.rs
+++ b/src/dev_utils/peer.rs
@@ -511,10 +511,6 @@ impl Peer {
             })
     }
 
-    pub fn is_active_and_has_block(&self, payload: &Observation) -> bool {
-        self.status == PeerStatus::Active && self.blocks().any(|block| block.payload() == payload)
-    }
-
     pub fn is_malicious(&self) -> bool {
         match self.parsec {
             WrappedParsec::Good(..) => false,

--- a/src/dev_utils/peer_statuses.rs
+++ b/src/dev_utils/peer_statuses.rs
@@ -85,6 +85,11 @@ impl PeerStatuses {
         let _ = self.statuses.insert(p, PeerStatus::Active);
     }
 
+    /// Adds a Dkg peer with Pending status.
+    pub fn add_dkg_peer(&mut self, p: PeerId) {
+        let _ = self.statuses.entry(p).or_insert(PeerStatus::Pending);
+    }
+
     /// Randomly chooses a peer to remove.
     pub fn remove_random_peer<R: Rng>(&mut self, rng: &mut R, min_active: usize) -> Option<PeerId> {
         let name = self.choose_name_to_remove(rng);

--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -917,7 +917,7 @@ mod handle_malice {
         let request_msg = unwrap!(alice.create_gossip(bob.our_pub_id()));
         let a_1 = nth_event(alice.graph(), 1);
         assert!(
-            !a_1.is_requesting()
+            !a_1.is_requesting(),
             "A_1 should not be a 'Requesting(Bob)' event to ensure a 'Request' using this as its \
              other-parent is invalid.",
         );
@@ -1070,7 +1070,7 @@ mod handle_malice {
         // event as an other-parent for her Response event, as it is not a Request event.)
         let b_1 = nth_event(bob.graph(), 1);
         assert!(
-            !b_1.is_request()
+            !b_1.is_request(),
             "B_1 should not be a Request event to ensure a 'Response' using this as its \
              other-parent is invalid.",
         );

--- a/src/functional_tests.rs
+++ b/src/functional_tests.rs
@@ -314,7 +314,7 @@ fn remove_peer() {
     assert_eq!(
         alice.create_gossip(&eric_id),
         Err(Error::InvalidPeerState {
-            required: PeerState::VOTE | PeerState::RECV,
+            required: PeerState::DKG | PeerState::RECV,
             actual: PeerState::inactive()
         })
     );

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -60,6 +60,10 @@ impl PeerId {
             .unwrap_or_else(|| PeerId::new_with_keypair(id))
     }
 
+    pub fn named_peer_ids() -> &'static [PeerId] {
+        &PEERS
+    }
+
     pub fn new_with_random_keypair(id: &str) -> Self {
         let (pub_sign, sec_sign) = gen_sign_keypair();
         Self {

--- a/src/peer_list/mod.rs
+++ b/src/peer_list/mod.rs
@@ -129,7 +129,7 @@ impl<S: SecretId> PeerList<S> {
             let iter = self
                 .iter()
                 .skip(1)
-                .filter(|(_, peer)| peer.state().can_vote() && peer.state().can_recv());
+                .filter(|(_, peer)| peer.state().can_dkg() && peer.state().can_recv());
             Some(iter)
         } else {
             None

--- a/src/peer_list/peer_state.rs
+++ b/src/peer_list/peer_state.rs
@@ -25,11 +25,14 @@ pub struct PeerState(u8);
 
 impl PeerState {
     /// The peer is counted towards supermajority.
-    pub const VOTE: Self = PeerState(0b0000_0001);
+    /// Automatically DKG as well
+    pub const VOTE: Self = PeerState(0b0000_1001);
     /// The peer can send gossips.
     pub const SEND: Self = PeerState(0b0000_0010);
     /// The peer can receive gossips.
     pub const RECV: Self = PeerState(0b0000_0100);
+    /// The peer can participate in DKG.
+    pub const DKG: Self = PeerState(0b0000_1000);
 
     pub fn inactive() -> Self {
         PeerState(0)
@@ -45,6 +48,10 @@ impl PeerState {
 
     pub fn can_vote(self) -> bool {
         self.contains(Self::VOTE)
+    }
+
+    pub fn can_dkg(self) -> bool {
+        self.contains(Self::DKG)
     }
 
     pub fn can_send(self) -> bool {
@@ -93,7 +100,15 @@ impl Debug for PeerState {
             if separator {
                 write!(f, "|")?;
             }
+            separator = true;
             write!(f, "RECV")?;
+        }
+
+        if self.contains(Self::DKG) {
+            if separator {
+                write!(f, "|")?;
+            }
+            write!(f, "DKG")?;
         }
 
         write!(f, ")")

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -304,6 +304,43 @@ fn run_non_member_dkg() {
     run_dkgs(&mut env, &peer_ids, &all_peer_ids, &dkgs);
 }
 
+#[test]
+fn run_non_member_single_add_remove_dkg() {
+    let mut env = Environment::new(SEED);
+
+    let mut names = NAMES.iter();
+    let all_peer_ids: BTreeSet<_> = names.by_ref().take(5).cloned().map(PeerId::new).collect();
+
+    let peer_ids: BTreeSet<_> = all_peer_ids.iter().take(4).cloned().collect();
+    let non_members: BTreeSet<_> = all_peer_ids.iter().skip(1).take(4).cloned().collect();
+
+    let dkgs = [(non_members, "single_add_remove".to_string())]
+        .iter()
+        .cloned()
+        .collect();
+
+    run_dkgs(&mut env, &peer_ids, &all_peer_ids, &dkgs);
+}
+
+#[test]
+fn run_non_member_split_dkg() {
+    let mut env = Environment::new(SEED);
+
+    let mut names = NAMES.iter();
+    let all_peer_ids: BTreeSet<_> = names.by_ref().take(8).cloned().map(PeerId::new).collect();
+
+    let genesis: BTreeSet<_> = all_peer_ids.iter().skip(2).take(4).cloned().collect();
+    let left: BTreeSet<_> = all_peer_ids.iter().take(4).cloned().collect();
+    let right: BTreeSet<_> = all_peer_ids.iter().skip(4).take(4).cloned().collect();
+
+    let dkgs = [(left, "left".to_string()), (right, "right".to_string())]
+        .iter()
+        .cloned()
+        .collect();
+
+    run_dkgs(&mut env, &genesis, &all_peer_ids, &dkgs);
+}
+
 fn run_dkgs(
     env: &mut Environment,
     peer_ids: &BTreeSet<PeerId>,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -254,103 +254,91 @@ fn add_few_peers_and_vote() {
     unwrap!(env.network.execute_schedule(&mut env.rng, schedule));
 }
 
+// Run DKG with the 4 voters in genesis
 #[test]
 fn run_dkg() {
     let mut env = Environment::new(SEED);
+    let named_peer_ids = PeerId::named_peer_ids();
 
-    let mut names = NAMES.iter();
-    let peer_ids: BTreeSet<_> = names.by_ref().take(4).cloned().map(PeerId::new).collect();
-    let dkgs = [(peer_ids.clone(), "dkg".to_string())]
-        .iter()
-        .cloned()
-        .collect();
+    let genesis: BTreeSet<_> = named_peer_ids[0..4].iter().cloned().collect();
 
-    run_dkgs(&mut env, &peer_ids, &peer_ids, &dkgs);
+    let dkgs = vec![(genesis.clone(), "dkg".to_string())];
+
+    run_dkgs(&mut env, &genesis, &genesis, dkgs);
 }
 
+// Run 2 DKGs with disjoint sets of 4 peers from the 8 voters in genesis
 #[test]
 fn run_split_dkg() {
     let mut env = Environment::new(SEED);
+    let named_peer_ids = PeerId::named_peer_ids();
 
-    let mut names = NAMES.iter();
-    let peer_ids: BTreeSet<_> = names.by_ref().take(8).cloned().map(PeerId::new).collect();
+    let genesis: BTreeSet<_> = named_peer_ids[0..8].iter().cloned().collect();
+    let left: BTreeSet<_> = named_peer_ids[0..4].iter().cloned().collect();
+    let right: BTreeSet<_> = named_peer_ids[4..8].iter().cloned().collect();
 
-    let left: BTreeSet<_> = peer_ids.iter().take(4).cloned().collect();
-    let right: BTreeSet<_> = peer_ids.iter().skip(4).take(4).cloned().collect();
+    let dkgs = vec![(left, "left".to_string()), (right, "right".to_string())];
 
-    let dkgs = [(left, "left".to_string()), (right, "right".to_string())]
-        .iter()
-        .cloned()
-        .collect();
-
-    run_dkgs(&mut env, &peer_ids, &peer_ids, &dkgs);
+    run_dkgs(&mut env, &genesis, &genesis, dkgs);
 }
 
+// Run a DKG with 4 peers not in the 4 voters in genesis
 #[test]
-fn run_non_member_dkg() {
+fn run_non_voters_dkg() {
     let mut env = Environment::new(SEED);
+    let named_peer_ids = PeerId::named_peer_ids();
 
-    let mut names = NAMES.iter();
-    let all_peer_ids: BTreeSet<_> = names.by_ref().take(8).cloned().map(PeerId::new).collect();
+    let all_peer_ids: BTreeSet<_> = named_peer_ids[0..8].iter().cloned().collect();
+    let genesis: BTreeSet<_> = named_peer_ids[0..4].iter().cloned().collect();
+    let non_voters: BTreeSet<_> = named_peer_ids[4..8].iter().cloned().collect();
 
-    let peer_ids: BTreeSet<_> = all_peer_ids.iter().take(4).cloned().collect();
-    let non_members: BTreeSet<_> = all_peer_ids.iter().skip(4).take(4).cloned().collect();
+    let dkgs = vec![(non_voters, "non_voters".to_string())];
 
-    let dkgs = [(non_members, "non_members".to_string())]
-        .iter()
-        .cloned()
-        .collect();
-
-    run_dkgs(&mut env, &peer_ids, &all_peer_ids, &dkgs);
+    run_dkgs(&mut env, &genesis, &all_peer_ids, dkgs);
 }
 
+// Run a DKG with 4 peers with one of them not in the 4 voters in genesis
 #[test]
 fn run_non_member_single_add_remove_dkg() {
     let mut env = Environment::new(SEED);
+    let named_peer_ids = PeerId::named_peer_ids();
 
-    let mut names = NAMES.iter();
-    let all_peer_ids: BTreeSet<_> = names.by_ref().take(5).cloned().map(PeerId::new).collect();
+    let all_peer_ids: BTreeSet<_> = named_peer_ids[0..5].iter().cloned().collect();
+    let genesis: BTreeSet<_> = named_peer_ids[0..4].iter().cloned().collect();
+    let single_add_remove: BTreeSet<_> = named_peer_ids[1..5].iter().cloned().collect();
 
-    let peer_ids: BTreeSet<_> = all_peer_ids.iter().take(4).cloned().collect();
-    let non_members: BTreeSet<_> = all_peer_ids.iter().skip(1).take(4).cloned().collect();
+    let dkgs = vec![(single_add_remove, "single_add_remove".to_string())];
 
-    let dkgs = [(non_members, "single_add_remove".to_string())]
-        .iter()
-        .cloned()
-        .collect();
-
-    run_dkgs(&mut env, &peer_ids, &all_peer_ids, &dkgs);
+    run_dkgs(&mut env, &genesis, &all_peer_ids, dkgs);
 }
 
+// Run 2 DKGs with disjoint sets of 4 peers, each with 2 of the 4 voters in genesis
 #[test]
 fn run_non_member_split_dkg() {
     let mut env = Environment::new(SEED);
+    let named_peer_ids = PeerId::named_peer_ids();
 
-    let mut names = NAMES.iter();
-    let all_peer_ids: BTreeSet<_> = names.by_ref().take(8).cloned().map(PeerId::new).collect();
+    let all_peer_ids: BTreeSet<_> = named_peer_ids[0..8].iter().cloned().collect();
+    let genesis: BTreeSet<_> = named_peer_ids[2..6].iter().cloned().collect();
+    let left: BTreeSet<_> = named_peer_ids[0..4].iter().cloned().collect();
+    let right: BTreeSet<_> = named_peer_ids[4..8].iter().cloned().collect();
 
-    let genesis: BTreeSet<_> = all_peer_ids.iter().skip(2).take(4).cloned().collect();
-    let left: BTreeSet<_> = all_peer_ids.iter().take(4).cloned().collect();
-    let right: BTreeSet<_> = all_peer_ids.iter().skip(4).take(4).cloned().collect();
+    let dkgs = vec![(left, "left".to_string()), (right, "right".to_string())];
 
-    let dkgs = [(left, "left".to_string()), (right, "right".to_string())]
-        .iter()
-        .cloned()
-        .collect();
-
-    run_dkgs(&mut env, &genesis, &all_peer_ids, &dkgs);
+    run_dkgs(&mut env, &genesis, &all_peer_ids, dkgs);
 }
 
 fn run_dkgs(
     env: &mut Environment,
     peer_ids: &BTreeSet<PeerId>,
     all_peer_ids: &BTreeSet<PeerId>,
-    dkgs: &BTreeMap<BTreeSet<PeerId>, String>,
+    dkgs: Vec<(BTreeSet<PeerId>, String)>,
 ) {
     //
     // Arrange
     //
     use parsec::dev_utils::ObservationEvent;
+    let dkgs: BTreeMap<_, _> = dkgs.into_iter().collect();
     let obs_schedule = ObservationSchedule {
         genesis: Genesis::new(peer_ids.iter().cloned().collect()),
         schedule: dkgs

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -265,7 +265,7 @@ fn run_dkg() {
         .cloned()
         .collect();
 
-    run_dkgs(&mut env, peer_ids, dkgs);
+    run_dkgs(&mut env, &peer_ids, &peer_ids, &dkgs);
 }
 
 #[test]
@@ -283,7 +283,7 @@ fn run_split_dkg() {
         .cloned()
         .collect();
 
-    run_dkgs(&mut env, peer_ids, dkgs);
+    run_dkgs(&mut env, &peer_ids, &peer_ids, &dkgs);
 }
 
 #[test]
@@ -301,13 +301,14 @@ fn run_non_member_dkg() {
         .cloned()
         .collect();
 
-    run_dkgs(&mut env, peer_ids, dkgs);
+    run_dkgs(&mut env, &peer_ids, &all_peer_ids, &dkgs);
 }
 
 fn run_dkgs(
     env: &mut Environment,
-    peer_ids: BTreeSet<PeerId>,
-    dkgs: BTreeMap<BTreeSet<PeerId>, String>,
+    peer_ids: &BTreeSet<PeerId>,
+    all_peer_ids: &BTreeSet<PeerId>,
+    dkgs: &BTreeMap<BTreeSet<PeerId>, String>,
 ) {
     //
     // Arrange
@@ -342,7 +343,7 @@ fn run_dkgs(
 
     let actual: BTreeSet<_> = env
         .network
-        .active_non_malicious_peers()
+        .running_non_malicious_peers()
         .flat_map(|peer| {
             let id = peer.id().clone();
             peer.blocks().map(move |block| (id.clone(), block))
@@ -363,8 +364,7 @@ fn run_dkgs(
     let expected: BTreeSet<_> = dkgs
         .iter()
         .flat_map(|(participants, dkg_name)| {
-            // TODO: need to validate the participants when they are not voters
-            peer_ids
+            all_peer_ids
                 .iter()
                 .map(move |id| (id.clone(), dkg_name.clone(), participants.contains(&id)))
         })

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -286,6 +286,24 @@ fn run_split_dkg() {
     run_dkgs(&mut env, peer_ids, dkgs);
 }
 
+#[test]
+fn run_non_member_dkg() {
+    let mut env = Environment::new(SEED);
+
+    let mut names = NAMES.iter();
+    let all_peer_ids: BTreeSet<_> = names.by_ref().take(8).cloned().map(PeerId::new).collect();
+
+    let peer_ids: BTreeSet<_> = all_peer_ids.iter().take(4).cloned().collect();
+    let non_members: BTreeSet<_> = all_peer_ids.iter().skip(4).take(4).cloned().collect();
+
+    let dkgs = [(non_members, "non_members".to_string())]
+        .iter()
+        .cloned()
+        .collect();
+
+    run_dkgs(&mut env, peer_ids, dkgs);
+}
+
 fn run_dkgs(
     env: &mut Environment,
     peer_ids: BTreeSet<PeerId>,
@@ -345,6 +363,7 @@ fn run_dkgs(
     let expected: BTreeSet<_> = dkgs
         .iter()
         .flat_map(|(participants, dkg_name)| {
+            // TODO: need to validate the participants when they are not voters
             peer_ids
                 .iter()
                 .map(move |id| (id.clone(), dkg_name.clone(), participants.contains(&id)))


### PR DESCRIPTION
The bulk of the feature is in `feat/parsec: support non voters DKG`
Preceding commits and follow up refactor and extend testing. 

To support adding a new elder in routing we will likely need to run the
DKG before adding the node to the Parsec Voters.

Moreover, to support split in the context of node ageing, we will need
to support DKGs with non voters.

In order to support this flow, the gossip will contain non voters
gossip. (This could also happen when a voter is removed)

More details in the commit comments.