### PR TITLE
Fix warnings introduced in rustc 1.38

### DIFF
--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -935,9 +935,12 @@ mod detail {
             attr.label = format!("{}</table>", attr.label);
             attr
         }
+    }
 
-        fn to_string(&self) -> String {
-            format!(
+    impl fmt::Display for EventAttributes {
+        fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+            write!(
+                f,
                 "[{}, {}label=<{}>]",
                 self.fillcolor,
                 if self.is_rectangle {

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -379,6 +379,11 @@ impl<P: PublicId> Event<P> {
         }
     }
 
+    #[cfg(any(
+        feature = "testing",
+        feature = "malice-detection",
+        all(test, feature = "mock")
+    ))]
     pub fn is_requesting(&self) -> bool {
         if let Cause::Requesting { .. } = self.content.cause {
             true
@@ -396,6 +401,11 @@ impl<P: PublicId> Event<P> {
         }
     }
 
+    #[cfg(any(
+        feature = "testing",
+        feature = "malice-detection",
+        all(test, feature = "mock")
+    ))]
     pub fn is_request(&self) -> bool {
         if let Cause::Request { .. } = self.content.cause {
             true
@@ -404,6 +414,7 @@ impl<P: PublicId> Event<P> {
         }
     }
 
+    #[cfg(any(test, feature = "testing", feature = "malice-detection"))]
     pub fn is_response(&self) -> bool {
         if let Cause::Response { .. } = self.content.cause {
             true

--- a/src/gossip/graph/mod.rs
+++ b/src/gossip/graph/mod.rs
@@ -102,6 +102,7 @@ impl<P: PublicId> Graph<P> {
     }
 
     /// Gets `Event` by the given `hash`, if it exists.
+    #[cfg(any(feature = "malice-detection", feature = "dump-graphs"))]
     pub fn get_by_hash<'a>(&'a self, hash: &EventHash) -> Option<IndexedEventRef<'a, P>> {
         self.get_index(hash).and_then(|index| self.get(index))
     }
@@ -130,6 +131,7 @@ impl<P: PublicId> Graph<P> {
     }
 
     /// Returns self-parent of the given event, if any.
+    #[cfg(feature = "malice-detection")]
     pub fn self_parent<E: AsRef<Event<P>>>(&self, event: E) -> Option<IndexedEventRef<P>> {
         event
             .as_ref()
@@ -138,6 +140,7 @@ impl<P: PublicId> Graph<P> {
     }
 
     /// Returns other-parent of the given event, if any.
+    #[cfg(feature = "malice-detection")]
     pub fn other_parent<E: AsRef<Event<P>>>(&self, event: E) -> Option<IndexedEventRef<P>> {
         event
             .as_ref()
@@ -158,6 +161,7 @@ impl<P: PublicId> Graph<P> {
     }
 
     /// Returns `event` if it's a sync event, or else `self_sync_parent()` of it otherwise.
+    #[cfg(feature = "malice-detection")]
     pub fn self_sync_ancestor<'a>(
         &'a self,
         event: IndexedEventRef<'a, P>,
@@ -259,6 +263,7 @@ impl<P: PublicId> Graph<P> {
 #[cfg(any(all(test, feature = "mock"), feature = "testing"))]
 impl<P: PublicId> Graph<P> {
     /// Remove the topologically last event.
+    #[cfg(test)]
     pub fn remove_last(&mut self) -> Option<(EventIndex, Event<P>)> {
         let index = EventIndex(self.events.len() - 1);
         #[cfg(feature = "malice-detection")]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -15,6 +15,7 @@ pub const HASH_LEN: usize = 32;
 pub struct Hash([u8; HASH_LEN]);
 
 impl Hash {
+    #[cfg(any(test, feature = "testing"))]
     pub const ZERO: Self = Hash([0; HASH_LEN]);
 
     #[cfg(any(test, feature = "testing"))]

--- a/src/meta_voting/meta_event.rs
+++ b/src/meta_voting/meta_event.rs
@@ -184,5 +184,4 @@ pub(crate) mod snapshot {
             }
         }
     }
-
 }

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -281,10 +281,6 @@ impl<'a> Visitor<'a> for UnprovableMaliceVisitor {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub(crate) struct ObservationHash(pub(crate) Hash);
 
-impl ObservationHash {
-    pub const ZERO: Self = ObservationHash(Hash::ZERO);
-}
-
 impl<'a, T: NetworkEvent, P: PublicId> From<&'a Observation<T, P>> for ObservationHash {
     fn from(observation: &'a Observation<T, P>) -> Self {
         ObservationHash(Hash::from(serialise(observation).as_slice()))
@@ -340,15 +336,6 @@ impl ObservationKey {
         match *self {
             ObservationKey::Single(ref hash, _) => hash,
             ObservationKey::Supermajority(ref hash) => hash,
-        }
-    }
-
-    pub fn matches(&self, other_hash: &ObservationHash, other_creator: PeerIndex) -> bool {
-        match *self {
-            ObservationKey::Single(ref hash, creator) => {
-                other_hash == hash && other_creator == creator
-            }
-            ObservationKey::Supermajority(ref hash) => other_hash == hash,
         }
     }
 

--- a/src/peer_list/mod.rs
+++ b/src/peer_list/mod.rs
@@ -117,6 +117,7 @@ impl<S: SecretId> PeerList<S> {
     }
 
     /// Returns an iterator of peers that can vote.
+    #[cfg(feature = "malice-detection")]
     pub fn voters(&self) -> impl Iterator<Item = (PeerIndex, &Peer<S::PublicId>)> {
         self.iter().filter(|(_, peer)| peer.state().can_vote())
     }
@@ -139,6 +140,7 @@ impl<S: SecretId> PeerList<S> {
     }
 
     /// Return public ids of all peers.
+    #[cfg(all(test, any(feature = "testing", feature = "mock")))]
     pub fn all_ids(&self) -> impl Iterator<Item = (PeerIndex, &S::PublicId)> {
         self.iter().map(|(index, peer)| (index, peer.id()))
     }
@@ -260,7 +262,7 @@ impl<S: SecretId> PeerList<S> {
     }
 
     /// Removes last event from its creator.
-    #[cfg(any(all(test, feature = "mock"), feature = "testing"))]
+    #[cfg(all(test, feature = "mock"))]
     pub fn remove_last_event(&mut self, creator: PeerIndex) -> Option<EventIndex> {
         if let Some(peer) = self.get_known_mut(creator) {
             peer.remove_last_event()

--- a/src/peer_list/peer.rs
+++ b/src/peer_list/peer.rs
@@ -88,7 +88,7 @@ impl<P: PublicId> Peer<P> {
         self.events.add(index_by_creator, event_index);
     }
 
-    #[cfg(any(all(test, feature = "mock"), feature = "testing"))]
+    #[cfg(all(test, feature = "mock"))]
     pub(super) fn remove_last_event(&mut self) -> Option<EventIndex> {
         self.events.remove_last()
     }
@@ -122,7 +122,7 @@ impl Events {
         self.0.push(Slot::new(event_index))
     }
 
-    #[cfg(any(all(test, feature = "mock"), feature = "testing"))]
+    #[cfg(all(test, feature = "mock"))]
     fn remove_last(&mut self) -> Option<EventIndex> {
         if let Some(slot) = self.0.last_mut() {
             if let Some(index) = slot.rest.pop() {

--- a/src/peer_list/peer_index.rs
+++ b/src/peer_list/peer_index.rs
@@ -19,7 +19,7 @@ impl PeerIndex {
     /// `PeerIndex` of ourselves.
     pub const OUR: Self = PeerIndex(0);
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     pub fn new_test_peer_index(index: usize) -> Self {
         Self(index)
     }
@@ -38,10 +38,6 @@ impl<T> PeerIndexMap<T> {
         self.0.get(key.0).and_then(Option::as_ref)
     }
 
-    pub fn get_mut(&mut self, key: PeerIndex) -> Option<&mut T> {
-        self.0.get_mut(key.0).and_then(Option::as_mut)
-    }
-
     pub fn contains_key(&self, key: PeerIndex) -> bool {
         self.0.get(key.0).map(Option::is_some).unwrap_or(false)
     }
@@ -55,14 +51,6 @@ impl<T> PeerIndexMap<T> {
             map: self,
             current: 0,
         }
-    }
-
-    pub fn keys<'a>(&'a self) -> impl Iterator<Item = PeerIndex> + 'a {
-        self.0
-            .iter()
-            .enumerate()
-            .filter(|(_, value)| value.is_some())
-            .map(|(index, _)| PeerIndex(index))
     }
 
     pub fn insert(&mut self, key: PeerIndex, value: T) -> Option<T> {
@@ -160,13 +148,6 @@ pub(crate) enum Entry<'a, T> {
 }
 
 impl<'a, T> Entry<'a, T> {
-    pub fn or_insert(self, default: T) -> &'a mut T {
-        match self {
-            Entry::Occupied(entry) => entry.into_mut(),
-            Entry::Vacant(entry) => entry.insert(default),
-        }
-    }
-
     pub fn or_insert_with<F: FnOnce() -> T>(self, default: F) -> &'a mut T {
         match self {
             Entry::Occupied(entry) => entry.into_mut(),
@@ -211,6 +192,7 @@ impl PeerIndexSet {
         self.0.get(key.0).cloned().unwrap_or(false)
     }
 
+    #[cfg(any(test, feature = "testing"))]
     pub fn is_empty(&self) -> bool {
         self.0.iter().all(|value| !*value)
     }
@@ -242,10 +224,6 @@ impl PeerIndexSet {
         } else {
             false
         }
-    }
-
-    pub fn clear(&mut self) {
-        self.0.clear()
     }
 }
 


### PR DESCRIPTION
As part of testing I ran the following combinations of feature flags (seems manual, probably should automate...)

```
cargo test $@ --release

cargo test $@ --release --features=testing
cargo test $@ --release --features=malice-detection
cargo test $@ --release --features=mock
cargo test $@ --release --features=dump-graphs dot_parser

cargo test $@ --release --features=testing,malice-detection
cargo test $@ --release --features=testing,mock
cargo test $@ --release --features=testing,dump-graphs dot_parser

cargo test $@ --release --features=malice-detection,mock
cargo test $@ --release --features=malice-detection,dump-graphs dot_parser

cargo test $@ --release --features=mock,dump-graphs dot_parser

cargo test $@ --release --features=testing,malice-detection,mock
cargo test $@ --release --features=testing,malice-detection,dump-graphs dot_parser
cargo test $@ --release --features=testing,mock,dump-graphs dot_parser
cargo test $@ --release --features=malice-detection,mock,dump-graphs dot_parser

cargo test $@ --release --features=testing,malice-detection,mock,dump-graphs dot_parser
```