### PR TITLE
unresponsive node handling

### DIFF
--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -364,8 +364,13 @@ impl Network {
         &self,
         expected_peers: &BTreeMap<PeerId, PeerStatus>,
         min_expected_observations: usize,
-        max_expected_observations: usize,
+        mut max_expected_observations: usize,
     ) -> Result<(), ConsensusError> {
+        // Failed peers may incur extra observations due to the unresponsive node handling.
+        max_expected_observations += expected_peers
+            .values()
+            .filter(|peer_status| peer_status == &&PeerStatus::Failed)
+            .count();
         // Check the number of consensused blocks.
         let (got_min, got_max) = unwrap!(self
             .running_non_malicious_peers()

--- a/src/dev_utils/schedule.rs
+++ b/src/dev_utils/schedule.rs
@@ -282,6 +282,8 @@ pub struct ScheduleOptions {
     pub genesis_restrict_consensus_to: Option<BTreeSet<PeerId>>,
     /// Allows for voting for the same OpaquePayload. This applies only when `ConsensusMode::Single`
     pub vote_for_same: bool,
+    /// Extra votes for the Left
+    pub observation_left: usize,
 }
 
 impl ScheduleOptions {
@@ -340,6 +342,7 @@ impl Default for ScheduleOptions {
             intermediate_consistency_checks: true,
             genesis_restrict_consensus_to: None,
             vote_for_same: false,
+            observation_left: 0,
         }
     }
 }
@@ -586,6 +589,7 @@ impl Schedule {
         // the +1 below is to account for genesis
         let max_observations = obs_schedule.count_observations() * observation_multiplier
             + obs_schedule.count_expected_accusations()
+            + options.observation_left
             + 1;
 
         let mut peers = PeerStatuses::new(&obs_schedule.genesis.all_ids());

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -1023,6 +1023,7 @@ mod detail {
                 Observation::Remove { peer_id, .. } => {
                     format!("Remove({:?})", sanitise_peer_id(peer_id))
                 }
+                Observation::Left(peer_id) => format!("Left({:?})", sanitise_peer_id(peer_id)),
                 Observation::Accusation { offender, malice } => format!(
                     "Accusation {{ {:?}, {} }}",
                     sanitise_peer_id(offender),

--- a/src/gossip/event.rs
+++ b/src/gossip/event.rs
@@ -379,6 +379,13 @@ impl<P: PublicId> Event<P> {
         }
     }
 
+    pub fn is_observation(&self) -> bool {
+        match self.content.cause {
+            Cause::Observation { .. } => true,
+            _ => false,
+        }
+    }
+
     #[cfg(any(
         feature = "testing",
         feature = "malice-detection",

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -78,6 +78,8 @@ pub enum Observation<T: NetworkEvent, P: PublicId> {
     /// Vote for the next message (Part or Ack) to be handled for the Distributed Key Generation
     /// algorithm used by our common coin.
     DkgMessage(DkgMessage),
+    /// Vote to remove the indicated peer from the network, due to unresponsive.
+    Left(P),
 }
 
 impl<T: NetworkEvent, P: PublicId> Observation<T, P> {
@@ -121,6 +123,7 @@ impl<T: NetworkEvent, P: PublicId> Debug for Observation<T, P> {
             Observation::Genesis { group, .. } => write!(formatter, "Genesis({:?})", group),
             Observation::Add { peer_id, .. } => write!(formatter, "Add({:?})", peer_id),
             Observation::Remove { peer_id, .. } => write!(formatter, "Remove({:?})", peer_id),
+            Observation::Left(offender) => write!(formatter, "Left({:?})", offender),
             Observation::Accusation { offender, malice } => {
                 write!(formatter, "Accusation {{ {:?}, {:?} }}", offender, malice)
             }

--- a/src/peer_list/mod.rs
+++ b/src/peer_list/mod.rs
@@ -117,7 +117,6 @@ impl<S: SecretId> PeerList<S> {
     }
 
     /// Returns an iterator of peers that can vote.
-    #[cfg(feature = "malice-detection")]
     pub fn voters(&self) -> impl Iterator<Item = (PeerIndex, &Peer<S::PublicId>)> {
         self.iter().filter(|(_, peer)| peer.state().can_vote())
     }


### PR DESCRIPTION
This PR contains the work of detecting un-responsive node, then voted for remove it following the normal node removal flow. Correspondent integration tests are also included.
The `un-responsive` is defined as a node does not appear as a voter during certain amount of consensused observations.