### PR TITLE
fix/parsec: handle DKG with a single voter

### DIFF
--- a/src/dev_utils/schedule.rs
+++ b/src/dev_utils/schedule.rs
@@ -753,7 +753,8 @@ impl Schedule {
 
         // Gossip should theoretically complete in O(log N) steps
         // The constant (adjustment_coeff) is for making the number big enough.
-        let n = peers.present_peers().count() as f64;
+        let non_zero_ln = 2;
+        let n = std::cmp::max(peers.present_peers().count(), non_zero_ln) as f64;
         let adjustment_coeff = 250.0 / options.prob_gossip;
         let additional_steps = (adjustment_coeff * n.ln()) as usize;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -267,6 +267,22 @@ fn run_dkg() {
     run_dkgs(&mut env, &genesis, &genesis, dkgs, vec![]);
 }
 
+// Run a DKG with 2 peers and only 1 voter in genesis (like routing adding first node).
+#[test]
+fn run_one_voter_two_participants_dkg() {
+    let _ = maidsafe_utilities::log::init(false);
+    let mut env = Environment::with_consensus_mode(SEED, ConsensusMode::Single);
+    let named_peer_ids = PeerId::named_peer_ids();
+
+    let final_peer_ids: BTreeSet<_> = named_peer_ids[0..2].iter().cloned().collect();
+    let genesis: BTreeSet<_> = named_peer_ids[0..1].iter().cloned().collect();
+    let participants: BTreeSet<_> = named_peer_ids[0..2].iter().cloned().collect();
+
+    let dkgs = vec![(participants, "one_voter_two_participants".to_string())];
+
+    run_dkgs(&mut env, &genesis, &final_peer_ids, dkgs, vec![]);
+}
+
 // Run 2 DKGs with disjoint sets of 4 peers from the 8 voters in genesis
 #[test]
 fn run_split_dkg() {


### PR DESCRIPTION
Routing start its test with a single voter, then we start DKG with
the two node forming the next Elder group.

This test was not working as the special handling of single voters
was making the DkgPart beeing consensused again and again.
 => Use same process to find consensus vote when there is a single
    voter.
 => Ensure there are sync event so consensus can be found with a
    single voter and no one else to gossip

Update scheduler so additional events are added even for a single
voter.

Note:
- Single voter now also require create_gossip to be called on
  themselves to progress.

Test:
Clippy + tests.