### PR TITLE
feat/parsec: adding gossip peers by force

### DIFF
--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -978,6 +978,17 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
         Some(())
     }
 
+    /// Add a gossip peer by force
+    pub fn add_force_gossip_peer(&mut self, peer_id: &S::PublicId) {
+        debug!(
+            "{:?}: adding a new gossip_peer {:?} by force.",
+            self.peer_list.our_pub_id(),
+            peer_id
+        );
+        let state = PeerState::DKG | PeerState::SEND | PeerState::RECV;
+        let _ = self.add_gossip_peer(peer_id, state);
+    }
+
     // This function must be called on consensus on a `StartDkg` observation.
     fn handle_dkg_start_consensus(&mut self, peers: &BTreeSet<S::PublicId>) -> Option<()> {
         let state = if self.new_peer_can_recv(self.our_pub_id()) {

--- a/src/peer_list/peer.rs
+++ b/src/peer_list/peer.rs
@@ -17,7 +17,12 @@ use std::{
     iter::{self, FromIterator},
 };
 
-#[derive(Debug)]
+impl<P: PublicId> Debug for Peer<P> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.id())
+    }
+}
+
 pub(crate) struct Peer<P: PublicId> {
     id: P,
     presence: Presence,


### PR DESCRIPTION
This feature is required by the routing work of replace parsec::DKG with BLS-DKG crate.